### PR TITLE
Reject disallowed CORS origins without throwing

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import cookieParser from "cookie-parser";
 import cors from "cors";
 import express from "express";
 
-import { Config } from "./config";
+import { Config, corsReflectOrigin } from "./config";
 import { createPrismaClient } from "./lib/prisma";
 import { createIdentityModule } from "./modules/identity";
 import {
@@ -30,11 +30,10 @@ export async function createApp(
   app.use(
     cors({
       origin: (origin, callback) => {
-        if (!origin || config.CORS_ORIGINS.includes(origin)) {
-          callback(null, origin ?? config.FRONTEND_URL);
-        } else {
-          callback(new Error(`CORS blocked for origin: ${origin}`));
-        }
+        callback(
+          null,
+          corsReflectOrigin(origin, config.CORS_ORIGINS, config.FRONTEND_URL),
+        );
       },
       credentials: true,
     }),

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,6 +1,9 @@
 import {
+  corsReflectOrigin,
   expandOriginVariants,
   getCorsOrigins,
+  isAllowedCorsOrigin,
+  isVercelPreviewOrigin,
   normalizeOrigin,
 } from "./config";
 
@@ -33,5 +36,66 @@ describe(getCorsOrigins, () => {
     expect(origins).toContain("https://leaguesports.co.za");
     expect(origins).toContain("https://www.leaguesports.co.za");
     expect(origins).toContain("http://localhost:3001");
+  });
+});
+
+describe(isVercelPreviewOrigin, () => {
+  test("allows https preview hosts", () => {
+    expect(
+      isVercelPreviewOrigin(
+        "https://landing-page-git-feat-team.vercel.app",
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects the apex, http, and lookalike hosts", () => {
+    expect(isVercelPreviewOrigin("https://vercel.app")).toBe(false);
+    expect(isVercelPreviewOrigin("http://foo.vercel.app")).toBe(false);
+    expect(isVercelPreviewOrigin("https://evil.vercel.app.attacker.com")).toBe(
+      false,
+    );
+  });
+});
+
+describe(isAllowedCorsOrigin, () => {
+  const allowed = ["https://leaguesports.co.za", "http://localhost:3001"];
+
+  test("allows listed origins and Vercel previews", () => {
+    expect(isAllowedCorsOrigin("https://leaguesports.co.za", allowed)).toBe(
+      true,
+    );
+    expect(
+      isAllowedCorsOrigin("https://landing-page-git-feat.vercel.app", allowed),
+    ).toBe(true);
+  });
+
+  test("rejects unknown origins", () => {
+    expect(isAllowedCorsOrigin("https://evil.example", allowed)).toBe(false);
+  });
+});
+
+describe(corsReflectOrigin, () => {
+  const allowed = ["http://localhost:3001"];
+
+  test("reflects no-origin requests with the frontend fallback", () => {
+    expect(corsReflectOrigin(undefined, allowed, "http://localhost:3001")).toBe(
+      "http://localhost:3001",
+    );
+  });
+
+  test("rejects unknown origins with false instead of throwing", () => {
+    expect(
+      corsReflectOrigin("https://evil.example", allowed, "http://localhost:3001"),
+    ).toBe(false);
+  });
+
+  test("reflects a Vercel preview origin", () => {
+    expect(
+      corsReflectOrigin(
+        "https://landing-page-git-feat.vercel.app",
+        allowed,
+        "http://localhost:3001",
+      ),
+    ).toBe("https://landing-page-git-feat.vercel.app");
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,8 +42,44 @@ export function expandOriginVariants(origin: string): string[] {
   return [...variants];
 }
 
+/**
+ * `FRONTEND_URL` (± www) plus comma-separated `CORS_ORIGINS`.
+ * HTTPS `*.vercel.app` preview hosts are allowed separately
+ * (`isVercelPreviewOrigin`) and do not need to be listed here.
+ */
 export function getCorsOrigins(frontendUrl: string, extraOrigins: string[]): string[] {
   return [...new Set([...expandOriginVariants(frontendUrl), ...extraOrigins])];
+}
+
+/** Vercel Preview hostnames only (`https://*.vercel.app`), not `https://vercel.app`. */
+export function isVercelPreviewOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return url.protocol === "https:" && url.hostname.endsWith(".vercel.app");
+  } catch {
+    return false;
+  }
+}
+
+export function isAllowedCorsOrigin(
+  origin: string,
+  allowedOrigins: string[],
+): boolean {
+  return allowedOrigins.includes(origin) || isVercelPreviewOrigin(origin);
+}
+
+/**
+ * Reflect an allowed origin, or `false` to skip CORS headers without throwing.
+ * A thrown error in the cors callback surfaces as a browser network failure.
+ */
+export function corsReflectOrigin(
+  requestOrigin: string | undefined,
+  allowedOrigins: string[],
+  fallbackOrigin: string,
+): string | false {
+  if (!requestOrigin) return fallbackOrigin;
+  if (isAllowedCorsOrigin(requestOrigin, allowedOrigins)) return requestOrigin;
+  return false;
 }
 
 export function getConfig(): Config {

--- a/src/modules/match/controllers/matches.http.test.ts
+++ b/src/modules/match/controllers/matches.http.test.ts
@@ -287,6 +287,36 @@ describe("matches HTTP", () => {
     expect(response.status).toBe(400);
   });
 
+  test("unknown Origin still reaches the handler instead of throwing CORS", async () => {
+    const response = await fetch(`${server.url}/api/matches`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: "https://evil.example",
+      },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(await response.json()).toEqual({ error: "Invalid match payload" });
+  });
+
+  test("Vercel preview Origin is reflected so preview browsers can read the response", async () => {
+    const origin = "https://landing-page-git-feat-team.vercel.app";
+    const response = await fetch(`${server.url}/api/matches`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: origin,
+      },
+      body: "{}",
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("access-control-allow-origin")).toBe(origin);
+  });
+
   test("lock maps persistence failures instead of returning 200", async () => {
     const created = await fetch(`${server.url}/api/matches`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- Disallowed CORS origins now use `callback(null, false)` instead of throwing, so same-origin Next `/api` proxies get a real HTTP status instead of an opaque browser network failure.
- HTTPS `*.vercel.app` preview hosts are allowed so Vercel previews can exercise match create. Extra origins can still be listed in `CORS_ORIGINS`.

Related to leaguesports/landing-page#33

## Test plan
- [ ] `npm test`
- [ ] POST `/api/matches` with `Origin: https://evil.example` returns 400 (not 500) and no `Access-Control-Allow-Origin`
- [ ] POST with `Origin: https://<preview>.vercel.app` returns 400 and reflects that origin
- [ ] Production `https://leaguesports.co.za` Start Match still creates a match (`POST /api/matches` → 201)


Made with [Cursor](https://cursor.com)