### PR TITLE
Phase 1: auth/me profile + session userId on match create

### DIFF
--- a/prisma/migrations/20260904071000_profile_handle_avatar/migration.sql
+++ b/prisma/migrations/20260904071000_profile_handle_avatar/migration.sql
@@ -1,0 +1,20 @@
+-- AlterTable
+ALTER TABLE "Profile" ADD COLUMN "handle" TEXT;
+ALTER TABLE "Profile" ADD COLUMN "avatarUrl" TEXT;
+
+-- Backfill unique handles for existing profiles
+UPDATE "Profile"
+SET "handle" = 'user_' || substr(replace("userId", '-', ''), 1, 12)
+WHERE "handle" IS NULL;
+
+-- Ensure uniqueness if collision (extremely unlikely with userId prefix)
+UPDATE "Profile" AS p
+SET "handle" = p."handle" || '_' || substr(p."id", 1, 4)
+WHERE EXISTS (
+  SELECT 1 FROM "Profile" AS other
+  WHERE other."handle" = p."handle" AND other."id" <> p."id"
+);
+
+ALTER TABLE "Profile" ALTER COLUMN "handle" SET NOT NULL;
+
+CREATE UNIQUE INDEX "Profile_handle_key" ON "Profile"("handle");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,11 +36,13 @@ model Account {
 }
 
 model Profile {
-  id        String @id @default(uuid())
-  userId    String @unique
+  id        String  @id @default(uuid())
+  userId    String  @unique
   firstName String
   lastName  String
-  email     String @unique @default("")
+  email     String  @unique @default("")
+  handle    String  @unique
+  avatarUrl String?
 
   user User @relation(fields: [userId], references: [id])
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -52,6 +52,7 @@ export async function createApp(
     prisma,
     venueRepository: venue.venueRepository,
     matchRepository: dependencies.matchRepository,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
   });
 
   app.use(identity.router);

--- a/src/modules/identity/controllers/identity.controller.ts
+++ b/src/modules/identity/controllers/identity.controller.ts
@@ -45,14 +45,14 @@ export class IdentityController {
 
   async me(req: Request, res: Response): Promise<void> {
     const { userId } = this.parseAuthenticationToken(req.cookies.token);
-    const player = await this.authService.getPlayerById(userId);
+    const user = await this.authService.getMeUser(userId);
 
-    if (!player) {
+    if (!user) {
       res.status(401).json({ error: "Unauthorized" });
       return;
     }
 
-    res.status(204).send();
+    res.status(200).json(user);
   }
 
   async logout(_req: Request, res: Response): Promise<void> {

--- a/src/modules/identity/index.ts
+++ b/src/modules/identity/index.ts
@@ -8,7 +8,10 @@ import {
 import { IdentityConfig } from "./config";
 import { IdentityController } from "./controllers/identity.controller";
 import { makeAuthorizationMiddleware } from "./middleware/authorization.middleware";
-import { makeOptionalAuthentication } from "./middleware/optional-auth.middleware";
+import {
+  makeOptionalAuthentication,
+  makeTryGetSessionUserId,
+} from "./middleware/optional-auth.middleware";
 import { AccountRepository } from "./repositories/account.repository";
 import { PlayerRepository } from "./repositories/player.repository";
 import { ProfileRepository } from "./repositories/profile.repository";
@@ -24,6 +27,7 @@ export type IdentityModule = {
   router: Router;
   authorizationMiddleware: ReturnType<typeof makeAuthorizationMiddleware>;
   hasAuthenticatedCaller: (req: Request) => boolean;
+  tryGetSessionUserId: (req: Request) => string | null;
 };
 
 export function createIdentityModule({
@@ -54,6 +58,7 @@ export function createIdentityModule({
     router,
     authorizationMiddleware: makeAuthorizationMiddleware(config),
     hasAuthenticatedCaller: makeOptionalAuthentication(config),
+    tryGetSessionUserId: makeTryGetSessionUserId(config),
   };
 }
 

--- a/src/modules/identity/middleware/optional-auth.middleware.ts
+++ b/src/modules/identity/middleware/optional-auth.middleware.ts
@@ -2,6 +2,7 @@ import { Request } from "express";
 import jwt from "jsonwebtoken";
 
 import { IdentityConfig } from "../config";
+import { makeAuthenticationTokenParser } from "../utils/jwt";
 
 export function makeOptionalAuthentication(config: IdentityConfig) {
   return (req: Request): boolean => {
@@ -15,6 +16,23 @@ export function makeOptionalAuthentication(config: IdentityConfig) {
       return true;
     } catch {
       return false;
+    }
+  };
+}
+
+export function makeTryGetSessionUserId(config: IdentityConfig) {
+  const parse = makeAuthenticationTokenParser(config);
+
+  return (req: Request): string | null => {
+    const token = req.cookies?.token;
+    if (typeof token !== "string" || token.length === 0) {
+      return null;
+    }
+
+    try {
+      return parse(token).userId;
+    } catch {
+      return null;
     }
   };
 }

--- a/src/modules/identity/repositories/player.repository.ts
+++ b/src/modules/identity/repositories/player.repository.ts
@@ -16,6 +16,7 @@ export class PlayerRepository {
   async getPlayerById(id: string) {
     return this.prisma.user.findUnique({
       where: { id },
+      include: { profile: true },
     });
   }
 }

--- a/src/modules/identity/repositories/profile.repository.ts
+++ b/src/modules/identity/repositories/profile.repository.ts
@@ -1,4 +1,14 @@
 import { PrismaClient } from "../../../generated/prisma/client";
+import { handleCandidate, slugifyHandle } from "../utils/handle";
+
+export type CreateProfileInput = {
+  userId: string;
+  firstName: string;
+  lastName: string;
+  email?: string;
+  handle: string;
+  avatarUrl?: string | null;
+};
 
 export class ProfileRepository {
   private readonly prisma: PrismaClient;
@@ -7,9 +17,56 @@ export class ProfileRepository {
     this.prisma = prisma;
   }
 
-  async createProfile(userId: string, firstName: string, lastName: string) {
+  async createProfile(input: CreateProfileInput) {
     return this.prisma.profile.create({
-      data: { userId, firstName, lastName },
+      data: {
+        userId: input.userId,
+        firstName: input.firstName,
+        lastName: input.lastName,
+        email: input.email ?? "",
+        handle: input.handle,
+        avatarUrl: input.avatarUrl ?? null,
+      },
     });
+  }
+
+  async getProfileByUserId(userId: string) {
+    return this.prisma.profile.findUnique({
+      where: { userId },
+    });
+  }
+
+  async updateHandle(userId: string, handle: string) {
+    return this.prisma.profile.update({
+      where: { userId },
+      data: { handle },
+    });
+  }
+
+  async isHandleTaken(handle: string, excludeUserId?: string) {
+    const existing = await this.prisma.profile.findUnique({
+      where: { handle },
+      select: { userId: true },
+    });
+    if (!existing) return false;
+    if (excludeUserId && existing.userId === excludeUserId) return false;
+    return true;
+  }
+
+  /**
+   * Allocates a unique handle from email local-part or display name.
+   */
+  async allocateHandle(seed: string, excludeUserId?: string): Promise<string> {
+    const local = seed.includes("@") ? seed.split("@")[0]! : seed;
+    const base = slugifyHandle(local);
+
+    for (let attempt = 1; attempt <= 50; attempt += 1) {
+      const candidate = handleCandidate(base, attempt);
+      if (!(await this.isHandleTaken(candidate, excludeUserId))) {
+        return candidate;
+      }
+    }
+
+    return `player${Date.now().toString(36)}`;
   }
 }

--- a/src/modules/identity/services/auth.service.test.ts
+++ b/src/modules/identity/services/auth.service.test.ts
@@ -1,0 +1,76 @@
+import { AuthService } from "./auth.service";
+
+describe("AuthService.getMeUser", () => {
+  const config = {
+    JWT_SECRET: "test",
+    FRONTEND_URL: "http://localhost:3001",
+  } as ConstructorParameters<typeof AuthService>[0]["config"];
+
+  function makeService(player: unknown) {
+    const playerRepository = {
+      getPlayerById: jest.fn(async () => player),
+      createPlayer: jest.fn(),
+    };
+    const profileRepository = {
+      createProfile: jest.fn(async (input) => input),
+      allocateHandle: jest.fn(async () => "alexj"),
+      updateHandle: jest.fn(async (_userId: string, handle: string) => ({
+        userId: "user-1",
+        firstName: "Alex",
+        lastName: "Johnson",
+        email: "alex@example.com",
+        handle,
+        avatarUrl: null,
+      })),
+      getProfileByUserId: jest.fn(),
+      isHandleTaken: jest.fn(),
+    };
+
+    const service = new AuthService({
+      config,
+      googleOauthService: {} as never,
+      googleUserService: {} as never,
+      accountRepository: {} as never,
+      playerRepository: playerRepository as never,
+      profileRepository: profileRepository as never,
+    });
+
+    return { service, playerRepository, profileRepository };
+  }
+
+  test("returns profile fields for dashboard identity strip", async () => {
+    const { service } = makeService({
+      id: "user-1",
+      profile: {
+        firstName: "Alex",
+        lastName: "Johnson",
+        email: "alex@example.com",
+        handle: "alexj",
+        avatarUrl: "https://example.com/a.png",
+      },
+    });
+
+    await expect(service.getMeUser("user-1")).resolves.toEqual({
+      id: "user-1",
+      displayName: "Alex Johnson",
+      name: "Alex Johnson",
+      email: "alex@example.com",
+      handle: "alexj",
+      avatarUrl: "https://example.com/a.png",
+    });
+  });
+
+  test("backfills missing profile", async () => {
+    const { service, profileRepository } = makeService({
+      id: "user-1",
+      profile: null,
+    });
+
+    const me = await service.getMeUser("user-1");
+
+    expect(profileRepository.allocateHandle).toHaveBeenCalled();
+    expect(profileRepository.createProfile).toHaveBeenCalled();
+    expect(me?.handle).toBe("alexj");
+    expect(me?.id).toBe("user-1");
+  });
+});

--- a/src/modules/identity/services/auth.service.ts
+++ b/src/modules/identity/services/auth.service.ts
@@ -14,6 +14,24 @@ export type AuthServiceDeps = {
   profileRepository: ProfileRepository;
 };
 
+export type AuthMeUser = {
+  id: string;
+  displayName: string;
+  name: string;
+  email: string;
+  handle: string;
+  avatarUrl: string | null;
+};
+
+type GoogleUserInfo = {
+  id: string;
+  email?: string;
+  name?: string;
+  given_name?: string;
+  family_name?: string;
+  picture?: string;
+};
+
 export class AuthService {
   private readonly config: IdentityConfig;
   private readonly googleOauthService: GoogleOauthService;
@@ -44,9 +62,9 @@ export class AuthService {
         authenticationCode,
       );
 
-    const userInfo = await this.googleUserService.getUserInfo(
+    const userInfo = (await this.googleUserService.getUserInfo(
       tokenData.access_token,
-    );
+    )) as GoogleUserInfo;
 
     let account =
       await this.accountRepository.getAccountByProviderAndProviderId(
@@ -66,11 +84,23 @@ export class AuthService {
         new Date(new Date().getTime() + tokenData.expires_in * 1000),
       );
 
-      await this.profileRepository.createProfile(
-        player.id,
-        userInfo.name,
-        userInfo.family_name,
-      );
+      const firstName =
+        userInfo.given_name?.trim() ||
+        userInfo.name?.trim() ||
+        "Player";
+      const lastName = userInfo.family_name?.trim() || "";
+      const email = userInfo.email?.trim() || "";
+      const handleSeed = email || firstName;
+      const handle = await this.profileRepository.allocateHandle(handleSeed);
+
+      await this.profileRepository.createProfile({
+        userId: player.id,
+        firstName,
+        lastName,
+        email,
+        handle,
+        avatarUrl: userInfo.picture?.trim() || null,
+      });
     }
 
     return {
@@ -83,5 +113,45 @@ export class AuthService {
 
   async getPlayerById(userId: string) {
     return this.playerRepository.getPlayerById(userId);
+  }
+
+  async getMeUser(userId: string): Promise<AuthMeUser | null> {
+    const player = await this.playerRepository.getPlayerById(userId);
+    if (!player) return null;
+
+    let profile = player.profile;
+    if (!profile) {
+      const handle = await this.profileRepository.allocateHandle(
+        `user_${userId}`,
+        userId,
+      );
+      profile = await this.profileRepository.createProfile({
+        userId,
+        firstName: "Player",
+        lastName: "",
+        email: "",
+        handle,
+        avatarUrl: null,
+      });
+    } else if (!profile.handle?.trim()) {
+      const handle = await this.profileRepository.allocateHandle(
+        profile.email || profile.firstName || `user_${userId}`,
+        userId,
+      );
+      profile = await this.profileRepository.updateHandle(userId, handle);
+    }
+
+    const displayName =
+      [profile.firstName, profile.lastName].filter(Boolean).join(" ").trim() ||
+      profile.handle;
+
+    return {
+      id: userId,
+      displayName,
+      name: displayName,
+      email: profile.email || "",
+      handle: profile.handle,
+      avatarUrl: profile.avatarUrl ?? null,
+    };
   }
 }

--- a/src/modules/identity/utils/handle.test.ts
+++ b/src/modules/identity/utils/handle.test.ts
@@ -1,0 +1,21 @@
+import { handleCandidate, slugifyHandle } from "./handle";
+
+describe("slugifyHandle", () => {
+  test("lowercases and strips non-alphanumeric", () => {
+    expect(slugifyHandle("Alex Johnson")).toBe("alexjohnson");
+    expect(slugifyHandle("riley.padel")).toBe("rileypadel");
+  });
+
+  test("falls back when empty", () => {
+    expect(slugifyHandle("!!!")).toBe("player");
+    expect(slugifyHandle("")).toBe("player");
+  });
+});
+
+describe("handleCandidate", () => {
+  test("appends attempt suffix without exceeding length budget", () => {
+    expect(handleCandidate("alex", 1)).toBe("alex");
+    expect(handleCandidate("alex", 2)).toBe("alex2");
+    expect(handleCandidate("a".repeat(20), 12)).toHaveLength(20);
+  });
+});

--- a/src/modules/identity/utils/handle.ts
+++ b/src/modules/identity/utils/handle.ts
@@ -1,0 +1,18 @@
+/** URL-safe handle from a display seed (email local-part, name, etc.). */
+export function slugifyHandle(seed: string): string {
+  const cleaned = seed
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "")
+    .slice(0, 20);
+
+  return cleaned || "player";
+}
+
+export function handleCandidate(base: string, attempt: number): string {
+  if (attempt <= 1) return base;
+  const suffix = String(attempt);
+  const maxBase = Math.max(1, 20 - suffix.length);
+  return `${base.slice(0, maxBase)}${suffix}`;
+}

--- a/src/modules/match/controllers/match.controller.ts
+++ b/src/modules/match/controllers/match.controller.ts
@@ -12,6 +12,7 @@ import { DomainError } from "../../../lib/domain-error";
 import { MatchLockConflictError } from "../entities/match-lock-conflict-error";
 import { MatchVenueNotFoundError } from "../entities/match-venue-not-found-error";
 import { MatchPersistenceError } from "../entities/match-persistence-error";
+import { bindSessionUserIdToPairings } from "../utils/bind-session-user";
 
 const playerSchema = z.object({
   userId: z.string().nullable().optional(),
@@ -70,12 +71,17 @@ export function createMatchController(deps: {
   lockMatch: LockMatch;
   listLockedMatchesByPlayer: ListLockedMatchesByPlayer;
   listLockedMatchesByVenue: ListLockedMatchesByVenue;
+  tryGetSessionUserId: (req: Request) => string | null;
 }) {
   return {
     async create(req: Request, res: Response) {
       try {
         const body = z.parse(createMatchBodySchema, req.body ?? {});
-        const match = await deps.createMatch.execute(body);
+        const sessionUserId = deps.tryGetSessionUserId(req);
+        const pairings = sessionUserId
+          ? bindSessionUserIdToPairings(body.pairings, sessionUserId)
+          : body.pairings;
+        const match = await deps.createMatch.execute({ ...body, pairings });
         return res.status(201).json(match.toSnapshot());
       } catch (error) {
         return sendMatchError(res, error);

--- a/src/modules/match/controllers/matches.http.test.ts
+++ b/src/modules/match/controllers/matches.http.test.ts
@@ -119,6 +119,15 @@ describe("matches HTTP", () => {
           { slot: "A1", displayName: "Alex", isGuest: true, userId: null },
           { slot: "A2", displayName: "Sam", isGuest: true, userId: null },
         ],
+        teamB: [
+          { slot: "B1", displayName: "Jordan", isGuest: true, userId: null },
+          {
+            slot: "B2",
+            displayName: "Riley",
+            isGuest: false,
+            userId: "user-riley",
+          },
+        ],
       },
     });
 

--- a/src/modules/match/controllers/matches.http.test.ts
+++ b/src/modules/match/controllers/matches.http.test.ts
@@ -5,6 +5,7 @@ import type { Express } from "express";
 
 import { createApp } from "../../../app";
 import { Config } from "../../../config";
+import { signAuthenticationToken } from "../../identity/utils/jwt";
 import { CmsId } from "../../venue/entities/cms-id";
 import { Slug } from "../../venue/entities/slug";
 import { Venue } from "../../venue/entities/venue";
@@ -72,6 +73,10 @@ describe("matches HTTP", () => {
   let matches: InMemoryMatchRepository;
   let app: Express;
   let server: { url: string; close: () => Promise<void> };
+
+  function sessionCookie(userId: string) {
+    return `token=${signAuthenticationToken(config, { userId })}`;
+  }
 
   beforeEach(async () => {
     venues = new InMemoryVenueRepository();
@@ -142,6 +147,139 @@ describe("matches HTTP", () => {
     expect(await playerHistory.json()).toEqual([]);
     expect(venueHistory.status).toBe(200);
     expect(await venueHistory.json()).toEqual([]);
+  });
+
+  test("authenticated create binds omitted userId, lock then lists by that player", async () => {
+    const created = await fetch(`${server.url}/api/matches`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        pairings: {
+          teamA: pairings.teamA,
+          teamB: [
+            { displayName: "Jordan", isGuest: true, userId: null },
+            { displayName: "Riley", isGuest: false, userId: null },
+          ],
+        },
+      }),
+    });
+    const createdBody = (await created.json()) as {
+      id: string;
+      pairings: {
+        teamB: { displayName: string; isGuest: boolean; userId: string | null }[];
+      };
+    };
+
+    expect(created.status).toBe(201);
+    expect(createdBody.pairings.teamB[1]).toEqual({
+      slot: "B2",
+      displayName: "Riley",
+      isGuest: false,
+      userId: "user-riley",
+    });
+
+    const locked = await fetch(`${server.url}/api/matches/${createdBody.id}/lock`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score: scoreA, winner: "A" }),
+    });
+    expect(locked.status).toBe(200);
+
+    const history = await fetch(
+      `${server.url}/api/matches?playerUserId=user-riley`,
+    );
+    const items = (await history.json()) as { id: string }[];
+    expect(history.status).toBe(200);
+    expect(items.map((item) => item.id)).toEqual([createdBody.id]);
+  });
+
+  test("invalid or missing token still creates without 401", async () => {
+    const invalid = await fetch(`${server.url}/api/matches`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: "token=not-a-jwt",
+      },
+      body: JSON.stringify(createBody),
+    });
+    const invalidBody = (await invalid.json()) as {
+      pairings: { teamB: { userId: string | null }[] };
+    };
+
+    expect(invalid.status).toBe(201);
+    expect(invalid.status).not.toBe(401);
+    expect(invalidBody.pairings.teamB[1].userId).toBe("user-riley");
+
+    const guestsOnly = {
+      teamA: [
+        { displayName: "Alex", isGuest: true, userId: null },
+        { displayName: "Sam", isGuest: true, userId: null },
+      ],
+      teamB: [
+        { displayName: "Jordan", isGuest: true, userId: null },
+        { displayName: "Riley", isGuest: true, userId: null },
+      ],
+    };
+    const anonymous = await fetch(`${server.url}/api/matches`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...createBody, pairings: guestsOnly }),
+    });
+    const anonymousBody = (await anonymous.json()) as {
+      pairings: {
+        teamA: { isGuest: boolean; userId: string | null }[];
+        teamB: { isGuest: boolean; userId: string | null }[];
+      };
+    };
+
+    expect(anonymous.status).toBe(201);
+    expect(anonymousBody.pairings.teamA.every((player) => player.userId === null)).toBe(
+      true,
+    );
+    expect(anonymousBody.pairings.teamB[1]).toMatchObject({
+      isGuest: true,
+      userId: null,
+    });
+  });
+
+  test("authenticated create does not attach session userId to guest slots", async () => {
+    const created = await fetch(`${server.url}/api/matches`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        pairings: {
+          teamA: [
+            { displayName: "Alex", isGuest: true, userId: null },
+            { displayName: "Sam", isGuest: true, userId: null },
+          ],
+          teamB: [
+            { displayName: "Jordan", isGuest: true, userId: null },
+            { displayName: "Riley", isGuest: true, userId: null },
+          ],
+        },
+      }),
+    });
+    const createdBody = (await created.json()) as {
+      pairings: {
+        teamA: { isGuest: boolean; userId: string | null }[];
+        teamB: { isGuest: boolean; userId: string | null }[];
+      };
+    };
+
+    expect(created.status).toBe(201);
+    expect(
+      [...createdBody.pairings.teamA, ...createdBody.pairings.teamB].every(
+        (player) => player.isGuest && player.userId === null,
+      ),
+    ).toBe(true);
   });
 
   test("GET missing match is 404", async () => {

--- a/src/modules/match/index.ts
+++ b/src/modules/match/index.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import { Request, Router } from "express";
 
 import { PrismaClient } from "../../generated/prisma/client";
 import { VenueRepository } from "../venue/repositories/venue.repository";
@@ -18,6 +18,7 @@ export type CreateMatchModuleParams = {
   prisma: PrismaClient;
   venueRepository: VenueRepository;
   matchRepository?: MatchRepository;
+  tryGetSessionUserId: (req: Request) => string | null;
 };
 
 export type MatchModule = {
@@ -29,6 +30,7 @@ export function createMatchModule({
   prisma,
   venueRepository,
   matchRepository: matchRepositoryOverride,
+  tryGetSessionUserId,
 }: CreateMatchModuleParams): MatchModule {
   const matchRepository =
     matchRepositoryOverride ?? new PrismaMatchRepository(prisma);
@@ -45,6 +47,7 @@ export function createMatchModule({
       matchRepository,
       venueRepository,
     ),
+    tryGetSessionUserId,
   });
 
   return {

--- a/src/modules/match/utils/bind-session-user.test.ts
+++ b/src/modules/match/utils/bind-session-user.test.ts
@@ -1,0 +1,86 @@
+import { bindSessionUserIdToPairings } from "./bind-session-user";
+
+const guest = (displayName: string) => ({
+  displayName,
+  isGuest: true as const,
+  userId: null as string | null,
+});
+
+const named = (
+  displayName: string,
+  userId: string | null,
+  isGuest = false,
+) => ({
+  displayName,
+  isGuest,
+  userId,
+});
+
+describe("bindSessionUserIdToPairings", () => {
+  test("assigns session userId to the first non-guest with a missing userId", () => {
+    const bound = bindSessionUserIdToPairings(
+      {
+        teamA: [guest("Alex"), guest("Sam")],
+        teamB: [guest("Jordan"), named("Riley", null)],
+      },
+      "user-riley",
+    );
+
+    expect(bound.teamB[1]).toEqual({
+      displayName: "Riley",
+      isGuest: false,
+      userId: "user-riley",
+    });
+    expect(bound.teamA[0].userId).toBeNull();
+  });
+
+  test("keeps a matching userId and clears guest on that slot", () => {
+    const bound = bindSessionUserIdToPairings(
+      {
+        teamA: [guest("Alex"), guest("Sam")],
+        teamB: [
+          guest("Jordan"),
+          named("Riley", "user-riley", true),
+        ],
+      },
+      "user-riley",
+    );
+
+    expect(bound.teamB[1]).toEqual({
+      displayName: "Riley",
+      isGuest: false,
+      userId: "user-riley",
+    });
+  });
+
+  test("does not overwrite a different account userId or force a guest slot", () => {
+    const pairings = {
+      teamA: [named("Alex", "user-alex"), guest("Sam")] as [
+        ReturnType<typeof named>,
+        ReturnType<typeof guest>,
+      ],
+      teamB: [guest("Jordan"), named("Riley", "user-other")] as [
+        ReturnType<typeof guest>,
+        ReturnType<typeof named>,
+      ],
+    };
+
+    expect(bindSessionUserIdToPairings(pairings, "user-riley")).toEqual(pairings);
+  });
+
+  test("treats blank userId as missing", () => {
+    const bound = bindSessionUserIdToPairings(
+      {
+        teamA: [guest("Alex"), named("Sam", "  ")],
+        teamB: [guest("Jordan"), guest("Riley")],
+      },
+      "user-sam",
+    );
+
+    expect(bound.teamA[1]).toEqual({
+      displayName: "Sam",
+      isGuest: false,
+      userId: "user-sam",
+    });
+  });
+});

--- a/src/modules/match/utils/bind-session-user.ts
+++ b/src/modules/match/utils/bind-session-user.ts
@@ -1,0 +1,60 @@
+import { MatchPlayerInput } from "../entities/match-player";
+import { PairingsInput } from "../entities/pairings";
+
+function normalizedUserId(userId: unknown): string | null {
+  if (typeof userId !== "string") {
+    return null;
+  }
+
+  const value = userId.trim();
+  return value.length === 0 ? null : value;
+}
+
+function withSessionUser(player: MatchPlayerInput, sessionUserId: string): MatchPlayerInput {
+  return { ...player, userId: sessionUserId, isGuest: false };
+}
+
+export function bindSessionUserIdToPairings(
+  pairings: PairingsInput,
+  sessionUserId: string,
+): PairingsInput {
+  const teamA: [MatchPlayerInput, MatchPlayerInput] = [
+    pairings.teamA[0],
+    pairings.teamA[1],
+  ];
+  const teamB: [MatchPlayerInput, MatchPlayerInput] = [
+    pairings.teamB[0],
+    pairings.teamB[1],
+  ];
+  const ordered: Array<{ team: [MatchPlayerInput, MatchPlayerInput]; index: 0 | 1 }> = [
+    { team: teamA, index: 0 },
+    { team: teamA, index: 1 },
+    { team: teamB, index: 0 },
+    { team: teamB, index: 1 },
+  ];
+
+  let alreadyBound = false;
+  for (const slot of ordered) {
+    const player = slot.team[slot.index];
+    if (normalizedUserId(player.userId) === sessionUserId) {
+      slot.team[slot.index] = withSessionUser(player, sessionUserId);
+      alreadyBound = true;
+    }
+  }
+
+  if (!alreadyBound) {
+    for (const slot of ordered) {
+      const player = slot.team[slot.index];
+      if (player.isGuest === true) {
+        continue;
+      }
+      if (normalizedUserId(player.userId) !== null) {
+        continue;
+      }
+      slot.team[slot.index] = withSessionUser(player, sessionUserId);
+      break;
+    }
+  }
+
+  return { teamA, teamB };
+}


### PR DESCRIPTION
## Summary

Phase 1 identity and match-create changes so the home dashboard can render a signed-in profile and list that user's locked history.

### Identity

- Return `/api/auth/me` as user JSON with `id`, `displayName`/`name`, `email`, `handle`, and `avatarUrl`
- Add `Profile.handle` + `Profile.avatarUrl` (migration + allocation on sign-in / me)

### Match create session binding

- `POST /api/matches` still accepts player `userId` in the body and stores it
- If the request has a valid `token` cookie, bind the session `userId` onto the current-user slot when that slot is a non-guest with missing/null/empty `userId` (or already has the same `userId`)
- Never overwrite a different account's `userId`, and never attach the session to an explicit guest (`isGuest: true`)
- Missing or invalid token is treated as anonymous: create still returns 201 (does not 401)
- Guests still create with `userId: null`
- `GET /api/matches?playerUserId=` still returns only `status=locked` matches, newest first

## Linked issues

- Landing: https://github.com/leaguesports/landing-page/issues/44
- Closes #15
- Closes #16