### PR TITLE
Add authenticated venue follow endpoints

### DIFF
--- a/prisma/migrations/20260904161500_venue_follow/migration.sql
+++ b/prisma/migrations/20260904161500_venue_follow/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "VenueFollow" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "venueCmsId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "VenueFollow_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "VenueFollow_userId_idx" ON "VenueFollow"("userId");
+
+-- CreateIndex
+CREATE INDEX "VenueFollow_venueCmsId_idx" ON "VenueFollow"("venueCmsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VenueFollow_userId_venueCmsId_key" ON "VenueFollow"("userId", "venueCmsId");
+
+-- AddForeignKey
+ALTER TABLE "VenueFollow" ADD CONSTRAINT "VenueFollow_venueCmsId_fkey" FOREIGN KEY ("venueCmsId") REFERENCES "Venue"("cmsId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,11 +48,25 @@ model Profile {
 }
 
 model Venue {
-  id      String  @id @default(uuid())
-  cmsId   String  @unique
+  id      String        @id @default(uuid())
+  cmsId   String        @unique
   name    String
   slug    String
   matches Match[]
+  follows VenueFollow[]
+}
+
+model VenueFollow {
+  id         String   @id @default(uuid())
+  userId     String
+  venueCmsId String
+  createdAt  DateTime @default(now())
+
+  venue Venue @relation(fields: [venueCmsId], references: [cmsId], onDelete: Cascade)
+
+  @@unique([userId, venueCmsId])
+  @@index([userId])
+  @@index([venueCmsId])
 }
 
 enum MatchRuleset {

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import {
 
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
+  venueFollowRepository?: import("./modules/venue").VenueFollowRepository;
   matchRepository?: MatchRepository;
 };
 
@@ -46,7 +47,10 @@ export async function createApp(
   const venue = createVenueModule({
     prisma,
     venueRepository: dependencies.venueRepository,
+    venueFollowRepository: dependencies.venueFollowRepository,
     hasAuthenticatedCaller: identity.hasAuthenticatedCaller,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
   });
   const match = createMatchModule({
     prisma,

--- a/src/modules/venue/controllers/venue.controller.ts
+++ b/src/modules/venue/controllers/venue.controller.ts
@@ -2,7 +2,11 @@ import { Request, Response } from "express";
 import { z } from "zod";
 
 import { EnsureVenueFromCms } from "../services/ensure-venue-from-cms.service";
+import { FollowVenue, VenueNotFoundForFollowError } from "../services/follow-venue.service";
 import { GetVenueByCmsId } from "../services/get-venue-by-cms-id.service";
+import { GetVenueFollowStatus } from "../services/get-venue-follow-status.service";
+import { ListFollowedVenues } from "../services/list-followed-venues.service";
+import { UnfollowVenue } from "../services/unfollow-venue.service";
 import { DomainError } from "../../../lib/domain-error";
 import { VenuePersistenceError } from "../repositories/venue-persistence-error";
 
@@ -19,7 +23,12 @@ const ensureVenueBodySchema = z.object({
 export function createVenueController(deps: {
   getVenueByCmsId: GetVenueByCmsId;
   ensureVenueFromCms: EnsureVenueFromCms;
+  followVenue: FollowVenue;
+  unfollowVenue: UnfollowVenue;
+  getVenueFollowStatus: GetVenueFollowStatus;
+  listFollowedVenues: ListFollowedVenues;
   hasAuthenticatedCaller: (req: Request) => boolean;
+  tryGetSessionUserId: (req: Request) => string | null;
 }) {
   return {
     async getByCmsId(req: Request, res: Response) {
@@ -60,10 +69,76 @@ export function createVenueController(deps: {
         return sendVenueError(res, error);
       }
     },
+
+    async follow(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { cmsId } = z.parse(cmsIdParamSchema, req.params);
+        const result = await deps.followVenue.execute({ userId, cmsId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendVenueError(res, error);
+      }
+    },
+
+    async unfollow(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { cmsId } = z.parse(cmsIdParamSchema, req.params);
+        const result = await deps.unfollowVenue.execute({ userId, cmsId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendVenueError(res, error);
+      }
+    },
+
+    async followStatus(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { cmsId } = z.parse(cmsIdParamSchema, req.params);
+        const result = await deps.getVenueFollowStatus.execute({
+          userId,
+          cmsId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendVenueError(res, error);
+      }
+    },
+
+    async listFollowed(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const result = await deps.listFollowedVenues.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendVenueError(res, error);
+      }
+    },
   };
 }
 
 function sendVenueError(res: Response, error: unknown) {
+  if (error instanceof VenueNotFoundForFollowError) {
+    return res.status(404).json({ error: error.message });
+  }
+
   if (error instanceof DomainError) {
     return res.status(400).json({ error: error.message });
   }

--- a/src/modules/venue/controllers/venues.http.test.ts
+++ b/src/modules/venue/controllers/venues.http.test.ts
@@ -199,4 +199,84 @@ describe("venues HTTP", () => {
     expect(response.status).toBe(503);
     expect(await response.json()).toEqual({ error: "Unable to save venue" });
   });
+
+  test("follow endpoints require auth and persist for the session user", async () => {
+    await fetch(`${server.url}/api/venues/sanity-1`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Grand Prix Arena",
+        slug: "grand-prix-arena",
+      }),
+    });
+
+    const unauth = await fetch(`${server.url}/api/venues/sanity-1/follow`, {
+      method: "POST",
+    });
+    expect(unauth.status).toBe(401);
+
+    const token = jwt.sign({ userId: "user-1" }, config.JWT_SECRET);
+    const cookie = `token=${token}`;
+
+    const followed = await fetch(`${server.url}/api/venues/sanity-1/follow`, {
+      method: "POST",
+      headers: { Cookie: cookie },
+    });
+    const followedBody = (await followed.json()) as {
+      following: boolean;
+      venueCmsId: string;
+      venue: { slug: string };
+    };
+    expect(followed.status).toBe(200);
+    expect(followedBody.following).toBe(true);
+    expect(followedBody.venueCmsId).toBe("sanity-1");
+    expect(followedBody.venue.slug).toBe("grand-prix-arena");
+
+    const status = await fetch(`${server.url}/api/venues/sanity-1/follow`, {
+      headers: { Cookie: cookie },
+    });
+    expect(status.status).toBe(200);
+    expect(await status.json()).toEqual({
+      following: true,
+      venueCmsId: "sanity-1",
+    });
+
+    const listed = await fetch(`${server.url}/api/me/followed-venues`, {
+      headers: { Cookie: cookie },
+    });
+    const listedBody = (await listed.json()) as {
+      venues: Array<{ cmsId: string; slug: string }>;
+    };
+    expect(listed.status).toBe(200);
+    expect(listedBody.venues).toHaveLength(1);
+    expect(listedBody.venues[0]).toMatchObject({
+      cmsId: "sanity-1",
+      slug: "grand-prix-arena",
+    });
+
+    const unfollowed = await fetch(`${server.url}/api/venues/sanity-1/follow`, {
+      method: "DELETE",
+      headers: { Cookie: cookie },
+    });
+    expect(unfollowed.status).toBe(200);
+    expect(await unfollowed.json()).toEqual({
+      following: false,
+      venueCmsId: "sanity-1",
+    });
+
+    const empty = await fetch(`${server.url}/api/me/followed-venues`, {
+      headers: { Cookie: cookie },
+    });
+    expect(await empty.json()).toEqual({ venues: [] });
+  });
+
+  test("follow returns 404 when the venue row is missing", async () => {
+    const token = jwt.sign({ userId: "user-1" }, config.JWT_SECRET);
+    const response = await fetch(`${server.url}/api/venues/missing/follow`, {
+      method: "POST",
+      headers: { Cookie: `token=${token}` },
+    });
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Venue not found" });
+  });
 });

--- a/src/modules/venue/index.ts
+++ b/src/modules/venue/index.ts
@@ -1,41 +1,77 @@
-import { Request, Router } from "express";
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
 
 import { PrismaClient } from "../../generated/prisma/client";
 import { createVenueController } from "./controllers/venue.controller";
+import { InMemoryVenueFollowRepository } from "./repositories/in-memory-venue-follow.repository";
+import { PrismaVenueFollowRepository } from "./repositories/prisma-venue-follow.repository";
 import { PrismaVenueRepository } from "./repositories/prisma-venue.repository";
+import { VenueFollowRepository } from "./repositories/venue-follow.repository";
 import { VenueRepository } from "./repositories/venue.repository";
 import { createVenueRoutes } from "./routes/venue.routes";
 import { EnsureVenueFromCms } from "./services/ensure-venue-from-cms.service";
+import { FollowVenue } from "./services/follow-venue.service";
 import { GetVenueByCmsId } from "./services/get-venue-by-cms-id.service";
+import { GetVenueFollowStatus } from "./services/get-venue-follow-status.service";
+import { ListFollowedVenues } from "./services/list-followed-venues.service";
+import { UnfollowVenue } from "./services/unfollow-venue.service";
 
 export type CreateVenueModuleParams = {
   prisma: PrismaClient;
   venueRepository?: VenueRepository;
+  venueFollowRepository?: VenueFollowRepository;
   hasAuthenticatedCaller: (req: Request) => boolean;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
 };
 
 export type VenueModule = {
   router: Router;
   venueRepository: VenueRepository;
+  venueFollowRepository: VenueFollowRepository;
 };
 
 export function createVenueModule({
   prisma,
   venueRepository: venueRepositoryOverride,
+  venueFollowRepository: venueFollowRepositoryOverride,
   hasAuthenticatedCaller,
+  tryGetSessionUserId,
+  requireAuth,
 }: CreateVenueModuleParams): VenueModule {
   const venueRepository =
     venueRepositoryOverride ?? new PrismaVenueRepository(prisma);
 
+  const venueFollowRepository =
+    venueFollowRepositoryOverride ??
+    (venueRepositoryOverride
+      ? new InMemoryVenueFollowRepository((cmsId) =>
+          venueRepository.findByCmsId(cmsId),
+        )
+      : new PrismaVenueFollowRepository(prisma));
+
   const controller = createVenueController({
     getVenueByCmsId: new GetVenueByCmsId(venueRepository),
     ensureVenueFromCms: new EnsureVenueFromCms(venueRepository),
+    followVenue: new FollowVenue(venueRepository, venueFollowRepository),
+    unfollowVenue: new UnfollowVenue(venueRepository, venueFollowRepository),
+    getVenueFollowStatus: new GetVenueFollowStatus(
+      venueRepository,
+      venueFollowRepository,
+    ),
+    listFollowedVenues: new ListFollowedVenues(venueFollowRepository),
     hasAuthenticatedCaller,
+    tryGetSessionUserId,
   });
 
   return {
-    router: createVenueRoutes(controller),
+    router: createVenueRoutes(controller, { requireAuth }),
     venueRepository,
+    venueFollowRepository,
   };
 }
 
@@ -44,9 +80,16 @@ export { CmsId } from "./entities/cms-id";
 export { Slug } from "./entities/slug";
 export { Venue } from "./entities/venue";
 export { VenueName } from "./entities/venue-name";
+export { InMemoryVenueFollowRepository } from "./repositories/in-memory-venue-follow.repository";
 export { InMemoryVenueRepository } from "./repositories/in-memory-venue.repository";
+export { PrismaVenueFollowRepository } from "./repositories/prisma-venue-follow.repository";
 export { PrismaVenueRepository } from "./repositories/prisma-venue.repository";
 export { VenuePersistenceError } from "./repositories/venue-persistence-error";
+export type { VenueFollowRepository } from "./repositories/venue-follow.repository";
 export type { VenueRepository } from "./repositories/venue.repository";
 export { EnsureVenueFromCms } from "./services/ensure-venue-from-cms.service";
+export { FollowVenue } from "./services/follow-venue.service";
 export { GetVenueByCmsId } from "./services/get-venue-by-cms-id.service";
+export { GetVenueFollowStatus } from "./services/get-venue-follow-status.service";
+export { ListFollowedVenues } from "./services/list-followed-venues.service";
+export { UnfollowVenue } from "./services/unfollow-venue.service";

--- a/src/modules/venue/repositories/in-memory-venue-follow.repository.ts
+++ b/src/modules/venue/repositories/in-memory-venue-follow.repository.ts
@@ -1,0 +1,67 @@
+import { CmsId } from "../entities/cms-id";
+import { Venue } from "../entities/venue";
+import {
+  FollowedVenue,
+  VenueFollowRecord,
+  VenueFollowRepository,
+} from "./venue-follow.repository";
+
+type StoredFollow = {
+  userId: string;
+  venueCmsId: string;
+  createdAt: Date;
+};
+
+/**
+ * In-memory follows keyed by userId + cmsId.
+ * Requires a venue lookup callback so list results include venue snapshots.
+ */
+export class InMemoryVenueFollowRepository implements VenueFollowRepository {
+  private readonly follows = new Map<string, StoredFollow>();
+
+  constructor(
+    private readonly findVenueByCmsId: (cmsId: CmsId) => Promise<Venue | null>,
+  ) {}
+
+  async isFollowing(userId: string, venueCmsId: CmsId): Promise<boolean> {
+    return this.follows.has(key(userId, venueCmsId.value));
+  }
+
+  async follow(userId: string, venueCmsId: CmsId): Promise<VenueFollowRecord> {
+    const existing = this.follows.get(key(userId, venueCmsId.value));
+    if (existing) {
+      return { ...existing };
+    }
+
+    const record: StoredFollow = {
+      userId,
+      venueCmsId: venueCmsId.value,
+      createdAt: new Date(),
+    };
+    this.follows.set(key(userId, venueCmsId.value), record);
+    return { ...record };
+  }
+
+  async unfollow(userId: string, venueCmsId: CmsId): Promise<boolean> {
+    return this.follows.delete(key(userId, venueCmsId.value));
+  }
+
+  async listFollowedByUser(userId: string): Promise<FollowedVenue[]> {
+    const rows = [...this.follows.values()]
+      .filter((row) => row.userId === userId)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+    const result: FollowedVenue[] = [];
+    for (const row of rows) {
+      const venue = await this.findVenueByCmsId(CmsId.from(row.venueCmsId));
+      if (venue) {
+        result.push({ venue, followedAt: row.createdAt });
+      }
+    }
+    return result;
+  }
+}
+
+function key(userId: string, venueCmsId: string): string {
+  return `${userId}::${venueCmsId}`;
+}

--- a/src/modules/venue/repositories/prisma-venue-follow.repository.ts
+++ b/src/modules/venue/repositories/prisma-venue-follow.repository.ts
@@ -1,0 +1,102 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { CmsId } from "../entities/cms-id";
+import { Slug } from "../entities/slug";
+import { Venue } from "../entities/venue";
+import { VenueName } from "../entities/venue-name";
+import { VenuePersistenceError } from "./venue-persistence-error";
+import {
+  FollowedVenue,
+  VenueFollowRecord,
+  VenueFollowRepository,
+} from "./venue-follow.repository";
+
+export class PrismaVenueFollowRepository implements VenueFollowRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async isFollowing(userId: string, venueCmsId: CmsId): Promise<boolean> {
+    try {
+      const row = await this.prisma.venueFollow.findUnique({
+        where: {
+          userId_venueCmsId: {
+            userId,
+            venueCmsId: venueCmsId.value,
+          },
+        },
+        select: { id: true },
+      });
+      return row !== null;
+    } catch (error) {
+      throw new VenuePersistenceError("Failed to check venue follow", {
+        cause: error,
+      });
+    }
+  }
+
+  async follow(userId: string, venueCmsId: CmsId): Promise<VenueFollowRecord> {
+    try {
+      const row = await this.prisma.venueFollow.upsert({
+        where: {
+          userId_venueCmsId: {
+            userId,
+            venueCmsId: venueCmsId.value,
+          },
+        },
+        create: {
+          userId,
+          venueCmsId: venueCmsId.value,
+        },
+        update: {},
+      });
+
+      return {
+        userId: row.userId,
+        venueCmsId: row.venueCmsId,
+        createdAt: row.createdAt,
+      };
+    } catch (error) {
+      throw new VenuePersistenceError("Failed to follow venue", {
+        cause: error,
+      });
+    }
+  }
+
+  async unfollow(userId: string, venueCmsId: CmsId): Promise<boolean> {
+    try {
+      const result = await this.prisma.venueFollow.deleteMany({
+        where: {
+          userId,
+          venueCmsId: venueCmsId.value,
+        },
+      });
+      return result.count > 0;
+    } catch (error) {
+      throw new VenuePersistenceError("Failed to unfollow venue", {
+        cause: error,
+      });
+    }
+  }
+
+  async listFollowedByUser(userId: string): Promise<FollowedVenue[]> {
+    try {
+      const rows = await this.prisma.venueFollow.findMany({
+        where: { userId },
+        orderBy: { createdAt: "desc" },
+        include: { venue: true },
+      });
+
+      return rows.map((row) => ({
+        followedAt: row.createdAt,
+        venue: Venue.rehydrate({
+          id: row.venue.id,
+          cmsId: CmsId.from(row.venue.cmsId),
+          name: VenueName.from(row.venue.name),
+          slug: Slug.from(row.venue.slug),
+        }),
+      }));
+    } catch (error) {
+      throw new VenuePersistenceError("Failed to list followed venues", {
+        cause: error,
+      });
+    }
+  }
+}

--- a/src/modules/venue/repositories/venue-follow.repository.ts
+++ b/src/modules/venue/repositories/venue-follow.repository.ts
@@ -1,0 +1,20 @@
+import { CmsId } from "../entities/cms-id";
+import { Venue } from "../entities/venue";
+
+export type VenueFollowRecord = {
+  userId: string;
+  venueCmsId: string;
+  createdAt: Date;
+};
+
+export type FollowedVenue = {
+  venue: Venue;
+  followedAt: Date;
+};
+
+export interface VenueFollowRepository {
+  isFollowing(userId: string, venueCmsId: CmsId): Promise<boolean>;
+  follow(userId: string, venueCmsId: CmsId): Promise<VenueFollowRecord>;
+  unfollow(userId: string, venueCmsId: CmsId): Promise<boolean>;
+  listFollowedByUser(userId: string): Promise<FollowedVenue[]>;
+}

--- a/src/modules/venue/routes/venue.routes.ts
+++ b/src/modules/venue/routes/venue.routes.ts
@@ -4,8 +4,19 @@ import { createVenueController } from "../controllers/venue.controller";
 
 export function createVenueRoutes(
   controller: ReturnType<typeof createVenueController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
 ): Router {
   const router = Router();
+
+  router.get("/api/me/followed-venues", options.requireAuth, (req, res) => {
+    void controller.listFollowed(req, res);
+  });
 
   router.get("/api/venues/:cmsId", (req, res) => {
     void controller.getByCmsId(req, res);
@@ -14,6 +25,30 @@ export function createVenueRoutes(
   router.put("/api/venues/:cmsId", (req, res) => {
     void controller.ensureFromCms(req, res);
   });
+
+  router.get(
+    "/api/venues/:cmsId/follow",
+    options.requireAuth,
+    (req, res) => {
+      void controller.followStatus(req, res);
+    },
+  );
+
+  router.post(
+    "/api/venues/:cmsId/follow",
+    options.requireAuth,
+    (req, res) => {
+      void controller.follow(req, res);
+    },
+  );
+
+  router.delete(
+    "/api/venues/:cmsId/follow",
+    options.requireAuth,
+    (req, res) => {
+      void controller.unfollow(req, res);
+    },
+  );
 
   return router;
 }

--- a/src/modules/venue/services/follow-venue.service.test.ts
+++ b/src/modules/venue/services/follow-venue.service.test.ts
@@ -1,0 +1,73 @@
+import { DomainError } from "../../../lib/domain-error";
+import { CmsId } from "../entities/cms-id";
+import { VenueFollowRepository } from "../repositories/venue-follow.repository";
+import { VenueRepository } from "../repositories/venue.repository";
+import {
+  FollowVenue,
+  VenueNotFoundForFollowError,
+} from "./follow-venue.service";
+
+describe("FollowVenue", () => {
+  const venues = {
+    findByCmsId: jest.fn(),
+  } as unknown as VenueRepository;
+  const follows = {
+    follow: jest.fn(),
+  } as unknown as VenueFollowRepository;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("follows an existing venue", async () => {
+    const venue = {
+      toSnapshot: () => ({
+        id: "v1",
+        cmsId: "cms-1",
+        name: "Arena",
+        slug: "arena",
+      }),
+    };
+    (venues.findByCmsId as jest.Mock).mockResolvedValue(venue);
+    (follows.follow as jest.Mock).mockResolvedValue({
+      userId: "user-1",
+      venueCmsId: "cms-1",
+      createdAt: new Date("2026-09-04T12:00:00.000Z"),
+    });
+
+    const result = await new FollowVenue(venues, follows).execute({
+      userId: "user-1",
+      cmsId: "cms-1",
+    });
+
+    expect(venues.findByCmsId).toHaveBeenCalledWith(CmsId.from("cms-1"));
+    expect(follows.follow).toHaveBeenCalledWith("user-1", CmsId.from("cms-1"));
+    expect(result).toEqual({
+      following: true,
+      venueCmsId: "cms-1",
+      followedAt: "2026-09-04T12:00:00.000Z",
+      venue: {
+        id: "v1",
+        cmsId: "cms-1",
+        name: "Arena",
+        slug: "arena",
+      },
+    });
+  });
+
+  test("rejects blank userId", async () => {
+    await expect(
+      new FollowVenue(venues, follows).execute({ userId: "  ", cmsId: "cms-1" }),
+    ).rejects.toBeInstanceOf(DomainError);
+  });
+
+  test("rejects missing venue", async () => {
+    (venues.findByCmsId as jest.Mock).mockResolvedValue(null);
+    await expect(
+      new FollowVenue(venues, follows).execute({
+        userId: "user-1",
+        cmsId: "cms-1",
+      }),
+    ).rejects.toBeInstanceOf(VenueNotFoundForFollowError);
+  });
+});

--- a/src/modules/venue/services/follow-venue.service.ts
+++ b/src/modules/venue/services/follow-venue.service.ts
@@ -1,0 +1,39 @@
+import { DomainError } from "../../../lib/domain-error";
+import { CmsId } from "../entities/cms-id";
+import { VenueFollowRepository } from "../repositories/venue-follow.repository";
+import { VenueRepository } from "../repositories/venue.repository";
+
+export class FollowVenue {
+  constructor(
+    private readonly venues: VenueRepository,
+    private readonly follows: VenueFollowRepository,
+  ) {}
+
+  async execute(input: { userId: string; cmsId: string }) {
+    const userId = input.userId.trim();
+    if (!userId) {
+      throw new DomainError("userId is required");
+    }
+
+    const cmsId = CmsId.from(input.cmsId);
+    const venue = await this.venues.findByCmsId(cmsId);
+    if (!venue) {
+      throw new VenueNotFoundForFollowError();
+    }
+
+    const follow = await this.follows.follow(userId, cmsId);
+    return {
+      following: true as const,
+      venueCmsId: follow.venueCmsId,
+      followedAt: follow.createdAt.toISOString(),
+      venue: venue.toSnapshot(),
+    };
+  }
+}
+
+export class VenueNotFoundForFollowError extends Error {
+  constructor() {
+    super("Venue not found");
+    this.name = "VenueNotFoundForFollowError";
+  }
+}

--- a/src/modules/venue/services/get-venue-follow-status.service.ts
+++ b/src/modules/venue/services/get-venue-follow-status.service.ts
@@ -1,0 +1,31 @@
+import { DomainError } from "../../../lib/domain-error";
+import { CmsId } from "../entities/cms-id";
+import { VenueFollowRepository } from "../repositories/venue-follow.repository";
+import { VenueRepository } from "../repositories/venue.repository";
+import { VenueNotFoundForFollowError } from "./follow-venue.service";
+
+export class GetVenueFollowStatus {
+  constructor(
+    private readonly venues: VenueRepository,
+    private readonly follows: VenueFollowRepository,
+  ) {}
+
+  async execute(input: { userId: string; cmsId: string }) {
+    const userId = input.userId.trim();
+    if (!userId) {
+      throw new DomainError("userId is required");
+    }
+
+    const cmsId = CmsId.from(input.cmsId);
+    const venue = await this.venues.findByCmsId(cmsId);
+    if (!venue) {
+      throw new VenueNotFoundForFollowError();
+    }
+
+    const following = await this.follows.isFollowing(userId, cmsId);
+    return {
+      following,
+      venueCmsId: cmsId.value,
+    };
+  }
+}

--- a/src/modules/venue/services/list-followed-venues.service.ts
+++ b/src/modules/venue/services/list-followed-venues.service.ts
@@ -1,0 +1,21 @@
+import { DomainError } from "../../../lib/domain-error";
+import { VenueFollowRepository } from "../repositories/venue-follow.repository";
+
+export class ListFollowedVenues {
+  constructor(private readonly follows: VenueFollowRepository) {}
+
+  async execute(input: { userId: string }) {
+    const userId = input.userId.trim();
+    if (!userId) {
+      throw new DomainError("userId is required");
+    }
+
+    const rows = await this.follows.listFollowedByUser(userId);
+    return {
+      venues: rows.map((row) => ({
+        ...row.venue.toSnapshot(),
+        followedAt: row.followedAt.toISOString(),
+      })),
+    };
+  }
+}

--- a/src/modules/venue/services/unfollow-venue.service.ts
+++ b/src/modules/venue/services/unfollow-venue.service.ts
@@ -1,0 +1,31 @@
+import { DomainError } from "../../../lib/domain-error";
+import { CmsId } from "../entities/cms-id";
+import { VenueFollowRepository } from "../repositories/venue-follow.repository";
+import { VenueRepository } from "../repositories/venue.repository";
+import { VenueNotFoundForFollowError } from "./follow-venue.service";
+
+export class UnfollowVenue {
+  constructor(
+    private readonly venues: VenueRepository,
+    private readonly follows: VenueFollowRepository,
+  ) {}
+
+  async execute(input: { userId: string; cmsId: string }) {
+    const userId = input.userId.trim();
+    if (!userId) {
+      throw new DomainError("userId is required");
+    }
+
+    const cmsId = CmsId.from(input.cmsId);
+    const venue = await this.venues.findByCmsId(cmsId);
+    if (!venue) {
+      throw new VenueNotFoundForFollowError();
+    }
+
+    await this.follows.unfollow(userId, cmsId);
+    return {
+      following: false as const,
+      venueCmsId: cmsId.value,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Adds authenticated venue follow support on top of the existing VenueFollow schema/migration.

### Model
- `VenueFollow` links a user to a venue by `userId` + `venueCmsId` (with migration already on this branch).

### Endpoints (auth required)
- `GET /api/venues/:cmsId/follow` — follow status for the current user
- `POST /api/venues/:cmsId/follow` — follow a venue
- `DELETE /api/venues/:cmsId/follow` — unfollow a venue
- `GET /api/me/followed-venues` — list venues the current user follows

### Included
- Controllers, routes, and services (follow / unfollow / status / list)
- Prisma + in-memory venue-follow repositories
- App/module wiring for `venueFollowRepository` and auth middleware
- Unit and HTTP tests
- Migration for the VenueFollow model