### PR TITLE
fix: honor OAuth returnTo after Google sign-in

### DIFF
--- a/src/modules/identity/controllers/identity.controller.ts
+++ b/src/modules/identity/controllers/identity.controller.ts
@@ -7,6 +7,7 @@ import {
   getClearAuthCookieOptions,
 } from "../utils/cookie";
 import { makeAuthenticationTokenParser } from "../utils/jwt";
+import { resolvePostAuthRedirect } from "../utils/post-auth-redirect";
 
 export type IdentityControllerDeps = {
   config: IdentityConfig;
@@ -36,11 +37,14 @@ export class IdentityController {
 
   async googleCallback(req: Request, res: Response): Promise<void> {
     const authenticationCode = req.query.code as string;
+    // Sign-in puts `returnTo` into Google OAuth `state`; Google echoes it here.
+    const returnTo =
+      typeof req.query.state === "string" ? req.query.state : undefined;
     const { token, frontendUrl } =
       await this.authService.signInWithGoogle(authenticationCode);
 
     res.cookie("token", token, getAuthCookieOptions(this.config));
-    res.redirect(frontendUrl);
+    res.redirect(resolvePostAuthRedirect(returnTo, frontendUrl));
   }
 
   async me(req: Request, res: Response): Promise<void> {

--- a/src/modules/identity/utils/post-auth-redirect.test.ts
+++ b/src/modules/identity/utils/post-auth-redirect.test.ts
@@ -1,0 +1,58 @@
+import { resolvePostAuthRedirect } from "./post-auth-redirect";
+
+describe("resolvePostAuthRedirect", () => {
+  const frontend = "https://leaguesports.co.za";
+
+  test("falls back to FRONTEND_URL when returnTo is missing", () => {
+    expect(resolvePostAuthRedirect(undefined, frontend)).toBe(frontend);
+    expect(resolvePostAuthRedirect("  ", frontend)).toBe(frontend);
+  });
+
+  test("allows absolute same-origin returnTo including path", () => {
+    expect(
+      resolvePostAuthRedirect(
+        "https://leaguesports.co.za/venues/the-grid",
+        frontend,
+      ),
+    ).toBe("https://leaguesports.co.za/venues/the-grid");
+  });
+
+  test("allows www ↔ apex variants of FRONTEND_URL", () => {
+    expect(
+      resolvePostAuthRedirect(
+        "https://www.leaguesports.co.za/venues/the-grid",
+        frontend,
+      ),
+    ).toBe("https://www.leaguesports.co.za/venues/the-grid");
+  });
+
+  test("allows relative paths on the frontend origin", () => {
+    expect(resolvePostAuthRedirect("/venues/the-grid", frontend)).toBe(
+      "https://leaguesports.co.za/venues/the-grid",
+    );
+  });
+
+  test("allows Vercel preview origins", () => {
+    expect(
+      resolvePostAuthRedirect(
+        "https://landing-page-git-fix.vercel.app/venues/x",
+        frontend,
+      ),
+    ).toBe("https://landing-page-git-fix.vercel.app/venues/x");
+  });
+
+  test("rejects external origins", () => {
+    expect(
+      resolvePostAuthRedirect("https://evil.example/phish", frontend),
+    ).toBe(frontend);
+  });
+
+  test("rejects protocol-relative and non-http schemes", () => {
+    expect(resolvePostAuthRedirect("//evil.example/x", frontend)).toBe(
+      frontend,
+    );
+    expect(resolvePostAuthRedirect("javascript:alert(1)", frontend)).toBe(
+      frontend,
+    );
+  });
+});

--- a/src/modules/identity/utils/post-auth-redirect.ts
+++ b/src/modules/identity/utils/post-auth-redirect.ts
@@ -1,0 +1,44 @@
+import {
+  expandOriginVariants,
+  isVercelPreviewOrigin,
+  normalizeOrigin,
+} from "../../../config";
+
+/**
+ * After Google OAuth, redirect only to the configured frontend (or an
+ * allowed same-site / Vercel preview URL carried in OAuth `state`).
+ * Rejects open redirects.
+ */
+export function resolvePostAuthRedirect(
+  returnTo: string | undefined,
+  frontendUrl: string,
+): string {
+  const fallback = normalizeOrigin(frontendUrl) || frontendUrl;
+
+  const candidate = returnTo?.trim();
+  if (!candidate) return fallback;
+
+  if (candidate.startsWith("/") && !candidate.startsWith("//")) {
+    return `${fallback}${candidate}`;
+  }
+
+  try {
+    const target = new URL(candidate);
+    if (target.protocol !== "http:" && target.protocol !== "https:") {
+      return fallback;
+    }
+    if (target.username || target.password) {
+      return fallback;
+    }
+
+    const origin = target.origin;
+    const allowed = expandOriginVariants(frontendUrl);
+    if (!allowed.includes(origin) && !isVercelPreviewOrigin(origin)) {
+      return fallback;
+    }
+
+    return `${origin}${target.pathname}${target.search}${target.hash}`;
+  } catch {
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Problem

After Google sign-in started from **Follow venue** (or other CTAs that pass `returnTo`), users always land on the home page.

Sign-in puts `returnTo` into OAuth `state`, but the callback ignored it and redirected to `FRONTEND_URL`.

## Fix

- Read `state` on the Google callback
- Redirect via `resolvePostAuthRedirect` (same-site / www variants / Vercel previews only)

## Related

Frontend backup: https://github.com/leaguesports/landing-page/pull/53

## Test plan

- [x] `post-auth-redirect` unit tests
- [ ] Signed out → Follow on a venue → Google → back on that venue URL