### PR TITLE
Add GolfRound APIs for golf scoring

### DIFF
--- a/prisma/migrations/20260904180000_add_golf_rounds/migration.sql
+++ b/prisma/migrations/20260904180000_add_golf_rounds/migration.sql
@@ -1,0 +1,39 @@
+-- GolfRound identity, lock, and history.
+-- Additive only: existing Venue and Match rows are unchanged.
+
+CREATE TYPE "GolfRoundStatus" AS ENUM ('live', 'locked');
+
+CREATE TABLE "GolfRound" (
+    "id" TEXT NOT NULL,
+    "venueCmsId" TEXT NOT NULL,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "status" "GolfRoundStatus" NOT NULL DEFAULT 'live',
+    "holesPlayed" INTEGER NOT NULL,
+    "startingHole" INTEGER NOT NULL DEFAULT 1,
+    "teeName" TEXT,
+    "course" JSONB NOT NULL,
+    "score" JSONB,
+    "lockedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "GolfRound_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "GolfRoundPlayer" (
+    "id" TEXT NOT NULL,
+    "roundId" TEXT NOT NULL,
+    "slot" INTEGER NOT NULL,
+    "userId" TEXT,
+    "displayName" TEXT NOT NULL,
+    "isGuest" BOOLEAN NOT NULL,
+
+    CONSTRAINT "GolfRoundPlayer_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "GolfRound_venueCmsId_idx" ON "GolfRound"("venueCmsId");
+CREATE INDEX "GolfRound_status_startsAt_idx" ON "GolfRound"("status", "startsAt");
+CREATE UNIQUE INDEX "GolfRoundPlayer_roundId_slot_key" ON "GolfRoundPlayer"("roundId", "slot");
+CREATE INDEX "GolfRoundPlayer_userId_idx" ON "GolfRoundPlayer"("userId");
+
+ALTER TABLE "GolfRound" ADD CONSTRAINT "GolfRound_venueCmsId_fkey" FOREIGN KEY ("venueCmsId") REFERENCES "Venue"("cmsId") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "GolfRoundPlayer" ADD CONSTRAINT "GolfRoundPlayer_roundId_fkey" FOREIGN KEY ("roundId") REFERENCES "GolfRound"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,12 +48,13 @@ model Profile {
 }
 
 model Venue {
-  id      String        @id @default(uuid())
-  cmsId   String        @unique
-  name    String
-  slug    String
-  matches Match[]
-  follows VenueFollow[]
+  id         String        @id @default(uuid())
+  cmsId      String        @unique
+  name       String
+  slug       String
+  matches    Match[]
+  golfRounds GolfRound[]
+  follows    VenueFollow[]
 }
 
 model VenueFollow {
@@ -119,5 +120,42 @@ model MatchPlayer {
   isGuest     Boolean
 
   @@unique([matchId, slot])
+  @@index([userId])
+}
+
+enum GolfRoundStatus {
+  live
+  locked
+}
+
+model GolfRound {
+  id           String          @id @default(uuid())
+  venueCmsId   String
+  venue        Venue           @relation(fields: [venueCmsId], references: [cmsId])
+  startsAt     DateTime
+  status       GolfRoundStatus @default(live)
+  holesPlayed  Int
+  startingHole Int             @default(1)
+  teeName      String?
+  course       Json
+  score        Json?
+  lockedAt     DateTime?
+  createdAt    DateTime        @default(now())
+  players      GolfRoundPlayer[]
+
+  @@index([venueCmsId])
+  @@index([status, startsAt])
+}
+
+model GolfRoundPlayer {
+  id          String    @id @default(uuid())
+  roundId     String
+  round       GolfRound @relation(fields: [roundId], references: [id], onDelete: Cascade)
+  slot        Int
+  userId      String?
+  displayName String
+  isGuest     Boolean
+
+  @@unique([roundId, slot])
   @@index([userId])
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,10 @@ import express from "express";
 
 import { Config, corsReflectOrigin } from "./config";
 import { createPrismaClient } from "./lib/prisma";
+import {
+  createGolfRoundModule,
+  GolfRoundRepository,
+} from "./modules/golf-round";
 import { createIdentityModule } from "./modules/identity";
 import {
   createMatchModule,
@@ -18,6 +22,7 @@ export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
   venueFollowRepository?: import("./modules/venue").VenueFollowRepository;
   matchRepository?: MatchRepository;
+  golfRoundRepository?: GolfRoundRepository;
 };
 
 export async function createApp(
@@ -58,10 +63,17 @@ export async function createApp(
     matchRepository: dependencies.matchRepository,
     tryGetSessionUserId: identity.tryGetSessionUserId,
   });
+  const golfRound = createGolfRoundModule({
+    prisma,
+    venueRepository: venue.venueRepository,
+    golfRoundRepository: dependencies.golfRoundRepository,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
   app.use(match.router);
+  app.use(golfRound.router);
 
   app.use(
     (

--- a/src/modules/golf-round/controllers/golf-round.controller.ts
+++ b/src/modules/golf-round/controllers/golf-round.controller.ts
@@ -1,0 +1,169 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { GolfRoundLockConflictError } from "../entities/golf-round-lock-conflict-error";
+import { GolfRoundPersistenceError } from "../entities/golf-round-persistence-error";
+import { GolfRoundVenueNotFoundError } from "../entities/golf-round-venue-not-found-error";
+import { CreateGolfRound } from "../services/create-golf-round.service";
+import { GetGolfRoundById } from "../services/get-golf-round-by-id.service";
+import {
+  ListLockedGolfRoundsByPlayer,
+  ListLockedGolfRoundsByVenue,
+} from "../services/list-locked-golf-rounds.service";
+import { LockGolfRound } from "../services/lock-golf-round.service";
+import { bindSessionUserIdToPlayers } from "../utils/bind-session-user";
+
+const playerSchema = z.object({
+  slot: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
+  userId: z.string().nullable().optional(),
+  displayName: z.string(),
+  isGuest: z.boolean(),
+});
+
+const courseHoleSchema = z.object({
+  number: z.number(),
+  par: z.number(),
+  strokeIndex: z.number(),
+});
+
+const createGolfRoundBodySchema = z.object({
+  venueCmsId: z.string(),
+  startsAt: z.string(),
+  holesPlayed: z.union([z.literal(9), z.literal(18)]),
+  startingHole: z.number().optional(),
+  teeName: z.string().nullable().optional(),
+  course: z.object({
+    name: z.string().nullable().optional(),
+    holes: z.array(courseHoleSchema).min(1),
+  }),
+  players: z.array(playerSchema).min(1).max(4),
+});
+
+const golfRoundIdParamSchema = z.object({
+  id: z.string(),
+});
+
+const venueCmsIdParamSchema = z.object({
+  cmsId: z.string(),
+});
+
+const playerQuerySchema = z.object({
+  playerUserId: z.string(),
+});
+
+const lockGolfRoundBodySchema = z.object({
+  score: z.object({
+    holes: z.array(
+      z.object({
+        number: z.number(),
+        strokes: z.record(z.string(), z.number()),
+      }),
+    ),
+  }),
+});
+
+export function createGolfRoundController(deps: {
+  createGolfRound: CreateGolfRound;
+  getGolfRoundById: GetGolfRoundById;
+  lockGolfRound: LockGolfRound;
+  listLockedGolfRoundsByPlayer: ListLockedGolfRoundsByPlayer;
+  listLockedGolfRoundsByVenue: ListLockedGolfRoundsByVenue;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async create(req: Request, res: Response) {
+      try {
+        const body = z.parse(createGolfRoundBodySchema, req.body ?? {});
+        const sessionUserId = deps.tryGetSessionUserId(req);
+        const players = sessionUserId
+          ? bindSessionUserIdToPlayers(body.players, sessionUserId)
+          : body.players;
+        const round = await deps.createGolfRound.execute({ ...body, players });
+        return res.status(201).json(round.toSnapshot());
+      } catch (error) {
+        return sendGolfRoundError(res, error);
+      }
+    },
+
+    async getById(req: Request, res: Response) {
+      try {
+        const { id } = z.parse(golfRoundIdParamSchema, req.params);
+        const round = await deps.getGolfRoundById.execute(id);
+
+        if (!round) {
+          return res.status(404).json({ error: "Golf round not found" });
+        }
+
+        return res.status(200).json(round.toSnapshot());
+      } catch (error) {
+        return sendGolfRoundError(res, error);
+      }
+    },
+
+    async lock(req: Request, res: Response) {
+      try {
+        const { id } = z.parse(golfRoundIdParamSchema, req.params);
+        const body = z.parse(lockGolfRoundBodySchema, req.body ?? {});
+        const round = await deps.lockGolfRound.execute({
+          roundId: id,
+          score: body.score,
+        });
+
+        if (!round) {
+          return res.status(404).json({ error: "Golf round not found" });
+        }
+
+        return res.status(200).json(round.toSnapshot());
+      } catch (error) {
+        return sendGolfRoundError(res, error);
+      }
+    },
+
+    async listByPlayer(req: Request, res: Response) {
+      try {
+        const { playerUserId } = z.parse(playerQuerySchema, req.query);
+        const items =
+          await deps.listLockedGolfRoundsByPlayer.execute(playerUserId);
+        return res.status(200).json(items);
+      } catch (error) {
+        return sendGolfRoundError(res, error);
+      }
+    },
+
+    async listByVenue(req: Request, res: Response) {
+      try {
+        const { cmsId } = z.parse(venueCmsIdParamSchema, req.params);
+        const items = await deps.listLockedGolfRoundsByVenue.execute(cmsId);
+        return res.status(200).json(items);
+      } catch (error) {
+        return sendGolfRoundError(res, error);
+      }
+    },
+  };
+}
+
+function sendGolfRoundError(res: Response, error: unknown) {
+  if (error instanceof GolfRoundLockConflictError) {
+    return res.status(409).json({ error: error.message });
+  }
+
+  if (error instanceof GolfRoundVenueNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid golf round payload" });
+  }
+
+  if (error instanceof GolfRoundPersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/golf-round/controllers/golf-rounds.http.test.ts
+++ b/src/modules/golf-round/controllers/golf-rounds.http.test.ts
@@ -1,0 +1,408 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { signAuthenticationToken } from "../../identity/utils/jwt";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { GolfRoundPersistenceError } from "../entities/golf-round-persistence-error";
+import { InMemoryGolfRoundRepository } from "../repositories/in-memory-golf-round.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+const courseHoles9 = Array.from({ length: 9 }, (_, index) => ({
+  number: index + 1,
+  par: ((index % 3) + 3) as 3 | 4 | 5,
+  strokeIndex: index + 1,
+}));
+
+const players = [
+  { slot: 1 as const, displayName: "Alex", isGuest: true, userId: null },
+  { slot: 2 as const, displayName: "Sam", isGuest: true, userId: null },
+  {
+    slot: 3 as const,
+    displayName: "Riley",
+    isGuest: false,
+    userId: "user-riley",
+  },
+];
+
+const createBody = {
+  venueCmsId: "sanity-course-1",
+  startsAt: "2026-09-04T10:00:00.000Z",
+  holesPlayed: 9 as const,
+  startingHole: 1,
+  teeName: "White",
+  course: { name: "Links Nine", holes: courseHoles9 },
+  players,
+};
+
+function scoreForPlayers(
+  holeNumbers: number[],
+  slots: number[],
+  stroke = 4,
+) {
+  return {
+    holes: holeNumbers.map((number) => ({
+      number,
+      strokes: Object.fromEntries(slots.map((slot) => [String(slot), stroke])),
+    })),
+  };
+}
+
+const scoreA = scoreForPlayers(
+  courseHoles9.map((hole) => hole.number),
+  [1, 2, 3],
+  4,
+);
+
+describe("golf rounds HTTP", () => {
+  const config = makeConfig();
+  let venues: InMemoryVenueRepository;
+  let rounds: InMemoryGolfRoundRepository;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  function sessionCookie(userId: string) {
+    return `token=${signAuthenticationToken(config, { userId })}`;
+  }
+
+  beforeEach(async () => {
+    venues = new InMemoryVenueRepository();
+    rounds = new InMemoryGolfRoundRepository();
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-course-1"),
+        VenueName.from("Golf Club"),
+        Slug.from("golf-club"),
+      ),
+      { refreshDetails: false },
+    );
+    app = await createApp(config, {
+      venueRepository: venues,
+      golfRoundRepository: rounds,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("POST creates anonymously, GET returns it, history omits live rounds", async () => {
+    const created = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(createBody),
+    });
+    const createdBody = (await created.json()) as { id: string; status: string };
+
+    expect(created.status).toBe(201);
+    expect(createdBody.status).toBe("live");
+    expect(createdBody.id).toBeTruthy();
+
+    const read = await fetch(`${server.url}/api/golf-rounds/${createdBody.id}`);
+    expect(read.status).toBe(200);
+    expect(await read.json()).toMatchObject({
+      id: createdBody.id,
+      venueCmsId: "sanity-course-1",
+      status: "live",
+      holesPlayed: 9,
+      startingHole: 1,
+      teeName: "White",
+      players: [
+        { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+        { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+        {
+          slot: 3,
+          displayName: "Riley",
+          isGuest: false,
+          userId: "user-riley",
+        },
+      ],
+    });
+
+    const playerHistory = await fetch(
+      `${server.url}/api/golf-rounds?playerUserId=user-riley`,
+    );
+    const venueHistory = await fetch(
+      `${server.url}/api/venues/sanity-course-1/golf-rounds`,
+    );
+
+    expect(playerHistory.status).toBe(200);
+    expect(await playerHistory.json()).toEqual([]);
+    expect(venueHistory.status).toBe(200);
+    expect(await venueHistory.json()).toEqual([]);
+  });
+
+  test("authenticated create binds omitted userId, lock then lists by that player", async () => {
+    const created = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+          { slot: 3, displayName: "Riley", isGuest: false, userId: null },
+        ],
+      }),
+    });
+    const createdBody = (await created.json()) as {
+      id: string;
+      players: { displayName: string; isGuest: boolean; userId: string | null }[];
+    };
+
+    expect(created.status).toBe(201);
+    expect(createdBody.players[2]).toEqual({
+      slot: 3,
+      displayName: "Riley",
+      isGuest: false,
+      userId: "user-riley",
+    });
+
+    const locked = await fetch(
+      `${server.url}/api/golf-rounds/${createdBody.id}/lock`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ score: scoreA }),
+      },
+    );
+    expect(locked.status).toBe(200);
+
+    const history = await fetch(
+      `${server.url}/api/golf-rounds?playerUserId=user-riley`,
+    );
+    const items = (await history.json()) as { id: string }[];
+    expect(history.status).toBe(200);
+    expect(items.map((item) => item.id)).toEqual([createdBody.id]);
+  });
+
+  test("GET missing golf round is 404", async () => {
+    const response = await fetch(`${server.url}/api/golf-rounds/missing`);
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Golf round not found" });
+  });
+
+  test("POST rejects unknown venue and invalid course length", async () => {
+    const missingVenue = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...createBody, venueCmsId: "no-such-course" }),
+    });
+    expect(missingVenue.status).toBe(404);
+
+    const incomplete = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...createBody,
+        course: { name: "Links Nine", holes: courseHoles9.slice(0, 8) },
+      }),
+    });
+    expect(incomplete.status).toBe(400);
+
+    const blankVenue = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...createBody, venueCmsId: "   " }),
+    });
+    expect(blankVenue.status).toBe(400);
+  });
+
+  test("lock is 200, idempotent for the same score, 409 on conflict", async () => {
+    const created = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(createBody),
+    });
+    const { id } = (await created.json()) as { id: string };
+
+    const locked = await fetch(`${server.url}/api/golf-rounds/${id}/lock`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score: scoreA }),
+    });
+    const lockedBody = (await locked.json()) as {
+      status: string;
+      score: unknown;
+    };
+
+    expect(locked.status).toBe(200);
+    expect(lockedBody.status).toBe("locked");
+    expect(lockedBody.score).toEqual(scoreA);
+
+    const again = await fetch(`${server.url}/api/golf-rounds/${id}/lock`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score: scoreA }),
+    });
+    expect(again.status).toBe(200);
+
+    const conflict = await fetch(`${server.url}/api/golf-rounds/${id}/lock`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        score: scoreForPlayers(
+          courseHoles9.map((hole) => hole.number),
+          [1, 2, 3],
+          5,
+        ),
+      }),
+    });
+    expect(conflict.status).toBe(409);
+
+    const missing = await fetch(`${server.url}/api/golf-rounds/missing/lock`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score: scoreA }),
+    });
+    expect(missing.status).toBe(404);
+  });
+
+  test("history lists only locked rounds, newest first, with venue details", async () => {
+    const older = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...createBody,
+        startsAt: "2026-08-01T10:00:00.000Z",
+      }),
+    });
+    const newer = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...createBody,
+        startsAt: "2026-08-20T10:00:00.000Z",
+      }),
+    });
+    const olderBody = (await older.json()) as { id: string };
+    const newerBody = (await newer.json()) as { id: string };
+
+    await fetch(`${server.url}/api/golf-rounds/${olderBody.id}/lock`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score: scoreA }),
+    });
+    await fetch(`${server.url}/api/golf-rounds/${newerBody.id}/lock`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score: scoreA }),
+    });
+
+    const playerHistory = await fetch(
+      `${server.url}/api/golf-rounds?playerUserId=user-riley`,
+    );
+    const venueHistory = await fetch(
+      `${server.url}/api/venues/sanity-course-1/golf-rounds`,
+    );
+    const playerItems = (await playerHistory.json()) as { id: string }[];
+    const venueItems = (await venueHistory.json()) as {
+      id: string;
+      venueName: string;
+      venueSlug: string;
+      holesPlayed: number;
+    }[];
+
+    expect(playerItems.map((item) => item.id)).toEqual([
+      newerBody.id,
+      olderBody.id,
+    ]);
+    expect(venueItems.map((item) => item.id)).toEqual([
+      newerBody.id,
+      olderBody.id,
+    ]);
+    expect(venueItems[0]).toMatchObject({
+      venueCmsId: "sanity-course-1",
+      venueName: "Golf Club",
+      venueSlug: "golf-club",
+      holesPlayed: 9,
+    });
+
+    const otherPlayer = await fetch(
+      `${server.url}/api/golf-rounds?playerUserId=user-nobody`,
+    );
+    expect(await otherPlayer.json()).toEqual([]);
+  });
+
+  test("GET /api/golf-rounds without playerUserId is 400", async () => {
+    const response = await fetch(`${server.url}/api/golf-rounds`);
+    expect(response.status).toBe(400);
+  });
+
+  test("lock maps persistence failures instead of returning 200", async () => {
+    const created = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(createBody),
+    });
+    const { id } = (await created.json()) as { id: string };
+
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+    app = await createApp(config, {
+      venueRepository: venues,
+      golfRoundRepository: {
+        findById: (roundId) => rounds.findById(roundId),
+        create: (round) => rounds.create(round),
+        persistLock: async () => {
+          throw new GolfRoundPersistenceError();
+        },
+        listLockedByPlayerUserId: (userId) =>
+          rounds.listLockedByPlayerUserId(userId),
+        listLockedByVenueCmsId: (cmsId) =>
+          rounds.listLockedByVenueCmsId(cmsId),
+      },
+    });
+    server = await listen(app);
+
+    const response = await fetch(`${server.url}/api/golf-rounds/${id}/lock`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score: scoreA }),
+    });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "Unable to save golf round" });
+  });
+});

--- a/src/modules/golf-round/entities/course-snapshot.ts
+++ b/src/modules/golf-round/entities/course-snapshot.ts
@@ -1,0 +1,161 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export type CourseHoleSnapshot = {
+  number: number;
+  par: number;
+  strokeIndex: number;
+};
+
+export type CourseSnapshotData = {
+  name: string | null;
+  holes: CourseHoleSnapshot[];
+};
+
+export class CourseSnapshot {
+  private constructor(
+    readonly name: string | null,
+    readonly holes: readonly CourseHoleSnapshot[],
+  ) {}
+
+  static from(
+    raw: unknown,
+    options: { holesPlayed: number; startingHole: number },
+  ): CourseSnapshot {
+    if (!raw || typeof raw !== "object") {
+      throw new DomainError("course is required");
+    }
+
+    const course = raw as { name?: unknown; holes?: unknown };
+    const name = parseOptionalName(course.name);
+    if (!Array.isArray(course.holes)) {
+      throw new DomainError("course.holes must be an array");
+    }
+
+    if (course.holes.length !== options.holesPlayed) {
+      throw new DomainError(
+        `course.holes must include exactly ${options.holesPlayed} holes`,
+      );
+    }
+
+    const holes = course.holes.map((hole, index) => parseHole(hole, index));
+    assertUniqueHoleNumbers(holes);
+    assertConsecutiveHoles(holes, options.startingHole, options.holesPlayed);
+    assertUniqueStrokeIndexes(holes);
+
+    return new CourseSnapshot(name, holes);
+  }
+
+  holeNumbers(): number[] {
+    return this.holes.map((hole) => hole.number);
+  }
+
+  toSnapshot(): CourseSnapshotData {
+    return {
+      name: this.name,
+      holes: this.holes.map((hole) => ({
+        number: hole.number,
+        par: hole.par,
+        strokeIndex: hole.strokeIndex,
+      })),
+    };
+  }
+}
+
+function parseOptionalName(raw: unknown): string | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+
+  if (typeof raw !== "string") {
+    throw new DomainError("course.name must be a string");
+  }
+
+  const value = raw.trim();
+  return value.length === 0 ? null : value;
+}
+
+function parseHole(raw: unknown, index: number): CourseHoleSnapshot {
+  if (!raw || typeof raw !== "object") {
+    throw new DomainError(`course.holes[${index}] is invalid`);
+  }
+
+  const hole = raw as {
+    number?: unknown;
+    par?: unknown;
+    strokeIndex?: unknown;
+  };
+
+  const number = requiredIntInRange(
+    hole.number,
+    1,
+    18,
+    `course.holes[${index}].number`,
+  );
+  const par = requiredIntInRange(hole.par, 3, 5, `course.holes[${index}].par`);
+  const strokeIndex = requiredIntInRange(
+    hole.strokeIndex,
+    1,
+    18,
+    `course.holes[${index}].strokeIndex`,
+  );
+
+  return { number, par, strokeIndex };
+}
+
+function assertUniqueHoleNumbers(holes: CourseHoleSnapshot[]): void {
+  const seen = new Set<number>();
+  for (const hole of holes) {
+    if (seen.has(hole.number)) {
+      throw new DomainError(`course.holes has duplicate hole number ${hole.number}`);
+    }
+    seen.add(hole.number);
+  }
+}
+
+function assertUniqueStrokeIndexes(holes: CourseHoleSnapshot[]): void {
+  const seen = new Set<number>();
+  for (const hole of holes) {
+    if (seen.has(hole.strokeIndex)) {
+      throw new DomainError(
+        `course.holes has duplicate strokeIndex ${hole.strokeIndex}`,
+      );
+    }
+    seen.add(hole.strokeIndex);
+  }
+}
+
+function assertConsecutiveHoles(
+  holes: CourseHoleSnapshot[],
+  startingHole: number,
+  holesPlayed: number,
+): void {
+  const expected = Array.from(
+    { length: holesPlayed },
+    (_, index) => {
+      const number = startingHole + index;
+      return number > 18 ? number - 18 : number;
+    },
+  );
+  const actual = holes.map((hole) => hole.number);
+
+  for (let index = 0; index < expected.length; index++) {
+    if (actual[index] !== expected[index]) {
+      throw new DomainError(
+        `course.holes must be consecutive from startingHole ${startingHole}`,
+      );
+    }
+  }
+}
+
+function requiredIntInRange(
+  raw: unknown,
+  min: number,
+  max: number,
+  field: string,
+): number {
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < min || raw > max) {
+    throw new DomainError(`${field} must be an integer between ${min} and ${max}`);
+  }
+
+  return raw;
+}

--- a/src/modules/golf-round/entities/golf-player.ts
+++ b/src/modules/golf-round/entities/golf-player.ts
@@ -1,0 +1,102 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+export type GolfPlayerSlot = 1 | 2 | 3 | 4;
+
+export type GolfPlayerInput = {
+  slot: unknown;
+  userId?: string | null;
+  displayName: unknown;
+  isGuest: unknown;
+};
+
+export type GolfPlayerSnapshot = {
+  slot: GolfPlayerSlot;
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+};
+
+export class GolfPlayer {
+  private constructor(
+    readonly slot: GolfPlayerSlot,
+    readonly userId: string | null,
+    readonly displayName: string,
+    readonly isGuest: boolean,
+  ) {}
+
+  static from(input: GolfPlayerInput): GolfPlayer {
+    const slot = parseSlot(input.slot);
+    const displayName = requiredTrimmed(
+      input.displayName,
+      `players[${slot}].displayName`,
+    );
+    const isGuest = input.isGuest === true;
+    const userId = optionalUserId(input.userId, slot);
+
+    if (isGuest) {
+      if (userId !== null) {
+        throw new DomainError(
+          `players[${slot}] is a guest and cannot have a userId`,
+        );
+      }
+
+      return new GolfPlayer(slot, null, displayName, true);
+    }
+
+    if (userId === null) {
+      throw new DomainError(
+        `players[${slot}] requires a userId unless isGuest is true`,
+      );
+    }
+
+    return new GolfPlayer(slot, userId, displayName, false);
+  }
+
+  static fromPlayers(inputs: GolfPlayerInput[]): GolfPlayer[] {
+    if (!Array.isArray(inputs) || inputs.length < 1 || inputs.length > 4) {
+      throw new DomainError("players must include between 1 and 4 players");
+    }
+
+    const players = inputs.map((input) => GolfPlayer.from(input));
+    const slots = new Set(players.map((player) => player.slot));
+    if (slots.size !== players.length) {
+      throw new DomainError("players must have unique slots");
+    }
+
+    return [...players].sort((a, b) => a.slot - b.slot);
+  }
+
+  hasUserId(userId: string): boolean {
+    return this.userId === userId;
+  }
+
+  toSnapshot(): GolfPlayerSnapshot {
+    return {
+      slot: this.slot,
+      userId: this.userId,
+      displayName: this.displayName,
+      isGuest: this.isGuest,
+    };
+  }
+}
+
+function parseSlot(raw: unknown): GolfPlayerSlot {
+  if (raw !== 1 && raw !== 2 && raw !== 3 && raw !== 4) {
+    throw new DomainError("players.slot must be 1, 2, 3, or 4");
+  }
+
+  return raw;
+}
+
+function optionalUserId(raw: unknown, slot: GolfPlayerSlot): string | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+
+  if (typeof raw !== "string") {
+    throw new DomainError(`players[${slot}].userId must be a string`);
+  }
+
+  const value = raw.trim();
+  return value.length === 0 ? null : value;
+}

--- a/src/modules/golf-round/entities/golf-round-lock-conflict-error.ts
+++ b/src/modules/golf-round/entities/golf-round-lock-conflict-error.ts
@@ -1,0 +1,8 @@
+export class GolfRoundLockConflictError extends Error {
+  constructor(
+    message = "Golf round is already locked with a different score",
+  ) {
+    super(message);
+    this.name = "GolfRoundLockConflictError";
+  }
+}

--- a/src/modules/golf-round/entities/golf-round-persistence-error.ts
+++ b/src/modules/golf-round/entities/golf-round-persistence-error.ts
@@ -1,0 +1,6 @@
+export class GolfRoundPersistenceError extends Error {
+  constructor(message = "Unable to save golf round", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "GolfRoundPersistenceError";
+  }
+}

--- a/src/modules/golf-round/entities/golf-round-venue-not-found-error.ts
+++ b/src/modules/golf-round/entities/golf-round-venue-not-found-error.ts
@@ -1,0 +1,6 @@
+export class GolfRoundVenueNotFoundError extends Error {
+  constructor(message = "Venue not found") {
+    super(message);
+    this.name = "GolfRoundVenueNotFoundError";
+  }
+}

--- a/src/modules/golf-round/entities/golf-round.ts
+++ b/src/modules/golf-round/entities/golf-round.ts
@@ -1,0 +1,209 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError } from "../../../lib/domain-error";
+import { CmsId } from "../../venue/entities/cms-id";
+import {
+  CourseSnapshot,
+  CourseSnapshotData,
+} from "./course-snapshot";
+import { GolfPlayer, GolfPlayerInput, GolfPlayerSnapshot } from "./golf-player";
+import { GolfRoundLockConflictError } from "./golf-round-lock-conflict-error";
+import { GolfScore, GolfScoreSnapshot } from "./golf-score";
+import { StartsAt } from "./starts-at";
+
+export type GolfRoundStatusValue = "live" | "locked";
+
+export type GolfRoundSnapshot = {
+  id: string;
+  venueCmsId: string;
+  startsAt: string;
+  status: GolfRoundStatusValue;
+  holesPlayed: number;
+  startingHole: number;
+  teeName: string | null;
+  course: CourseSnapshotData;
+  players: GolfPlayerSnapshot[];
+  score: GolfScoreSnapshot | null;
+  lockedAt: string | null;
+};
+
+export type CreateGolfRoundProps = {
+  venueCmsId: CmsId;
+  startsAt: StartsAt;
+  holesPlayed: number;
+  startingHole?: number;
+  teeName?: string | null;
+  course: unknown;
+  players: GolfPlayerInput[];
+};
+
+export class GolfRound {
+  private constructor(
+    readonly id: string,
+    readonly venueCmsId: CmsId,
+    readonly startsAt: StartsAt,
+    private statusValue: GolfRoundStatusValue,
+    readonly holesPlayed: number,
+    readonly startingHole: number,
+    readonly teeName: string | null,
+    readonly course: CourseSnapshot,
+    readonly players: readonly GolfPlayer[],
+    private scoreValue: GolfScore | null,
+    private lockedAtValue: Date | null,
+  ) {}
+
+  static create(props: CreateGolfRoundProps): GolfRound {
+    const holesPlayed = parseHolesPlayed(props.holesPlayed);
+    const startingHole = parseStartingHole(props.startingHole ?? 1);
+    const teeName = parseOptionalTeeName(props.teeName);
+    const course = CourseSnapshot.from(props.course, {
+      holesPlayed,
+      startingHole,
+    });
+    const players = GolfPlayer.fromPlayers(props.players);
+
+    return new GolfRound(
+      randomUUID(),
+      props.venueCmsId,
+      props.startsAt,
+      "live",
+      holesPlayed,
+      startingHole,
+      teeName,
+      course,
+      players,
+      null,
+      null,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    venueCmsId: CmsId;
+    startsAt: StartsAt;
+    status: GolfRoundStatusValue;
+    holesPlayed: number;
+    startingHole: number;
+    teeName: string | null;
+    course: CourseSnapshot;
+    players: GolfPlayer[];
+    score: GolfScore | null;
+    lockedAt: Date | null;
+  }): GolfRound {
+    return new GolfRound(
+      props.id,
+      props.venueCmsId,
+      props.startsAt,
+      props.status,
+      props.holesPlayed,
+      props.startingHole,
+      props.teeName,
+      props.course,
+      props.players,
+      props.score,
+      props.lockedAt,
+    );
+  }
+
+  get status(): GolfRoundStatusValue {
+    return this.statusValue;
+  }
+
+  get score(): GolfScore | null {
+    return this.scoreValue;
+  }
+
+  get lockedAt(): Date | null {
+    return this.lockedAtValue;
+  }
+
+  get isLocked(): boolean {
+    return this.statusValue === "locked";
+  }
+
+  playerSlots() {
+    return this.players.map((player) => player.slot);
+  }
+
+  hasPlayerUserId(userId: string): boolean {
+    return this.players.some((player) => player.hasUserId(userId));
+  }
+
+  lock(score: GolfScore, lockedAt = new Date()): void {
+    if (this.statusValue === "locked") {
+      if (this.hasSameScore(score)) {
+        return;
+      }
+
+      throw new GolfRoundLockConflictError();
+    }
+
+    this.statusValue = "locked";
+    this.scoreValue = score;
+    this.lockedAtValue = lockedAt;
+  }
+
+  hasSameScore(score: GolfScore): boolean {
+    return (
+      this.statusValue === "locked" &&
+      this.scoreValue !== null &&
+      this.scoreValue.equals(score)
+    );
+  }
+
+  hasSameLockedScore(other: GolfRound): boolean {
+    if (!this.isLocked || !other.isLocked) {
+      return false;
+    }
+    if (!this.scoreValue || !other.scoreValue) {
+      return false;
+    }
+
+    return this.scoreValue.equals(other.scoreValue);
+  }
+
+  toSnapshot(): GolfRoundSnapshot {
+    return {
+      id: this.id,
+      venueCmsId: this.venueCmsId.value,
+      startsAt: this.startsAt.toIsoString(),
+      status: this.statusValue,
+      holesPlayed: this.holesPlayed,
+      startingHole: this.startingHole,
+      teeName: this.teeName,
+      course: this.course.toSnapshot(),
+      players: this.players.map((player) => player.toSnapshot()),
+      score: this.scoreValue?.toSnapshot() ?? null,
+      lockedAt: this.lockedAtValue?.toISOString() ?? null,
+    };
+  }
+}
+
+function parseHolesPlayed(raw: unknown): number {
+  if (raw !== 9 && raw !== 18) {
+    throw new DomainError("holesPlayed must be 9 or 18");
+  }
+
+  return raw;
+}
+
+function parseStartingHole(raw: unknown): number {
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 1 || raw > 18) {
+    throw new DomainError("startingHole must be an integer between 1 and 18");
+  }
+
+  return raw;
+}
+
+function parseOptionalTeeName(raw: unknown): string | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+
+  if (typeof raw !== "string") {
+    throw new DomainError("teeName must be a string");
+  }
+
+  const value = raw.trim();
+  return value.length === 0 ? null : value;
+}

--- a/src/modules/golf-round/entities/golf-score.ts
+++ b/src/modules/golf-round/entities/golf-score.ts
@@ -1,0 +1,107 @@
+import { DomainError } from "../../../lib/domain-error";
+import { GolfPlayerSlot } from "./golf-player";
+
+export type HoleScoreSnapshot = {
+  number: number;
+  strokes: Record<string, number>;
+};
+
+export type GolfScoreSnapshot = {
+  holes: HoleScoreSnapshot[];
+};
+
+export class GolfScore {
+  private constructor(readonly holes: readonly HoleScoreSnapshot[]) {}
+
+  static from(
+    raw: unknown,
+    options: { holeNumbers: number[]; playerSlots: GolfPlayerSlot[] },
+  ): GolfScore {
+    if (!raw || typeof raw !== "object" || !("holes" in raw)) {
+      throw new DomainError("score.holes is required");
+    }
+
+    const holesRaw = (raw as { holes: unknown }).holes;
+    if (!Array.isArray(holesRaw)) {
+      throw new DomainError("score.holes must be an array");
+    }
+
+    if (holesRaw.length !== options.holeNumbers.length) {
+      throw new DomainError(
+        `score.holes must include exactly ${options.holeNumbers.length} holes`,
+      );
+    }
+
+    const holes = holesRaw.map((hole, index) =>
+      parseHoleScore(hole, index, options.playerSlots),
+    );
+
+    const expected = options.holeNumbers;
+    for (let index = 0; index < expected.length; index++) {
+      if (holes[index].number !== expected[index]) {
+        throw new DomainError(
+          `score.holes must match course hole order starting at ${expected[0]}`,
+        );
+      }
+    }
+
+    return new GolfScore(holes);
+  }
+
+  equals(other: GolfScore): boolean {
+    return JSON.stringify(this.toSnapshot()) === JSON.stringify(other.toSnapshot());
+  }
+
+  toSnapshot(): GolfScoreSnapshot {
+    return {
+      holes: this.holes.map((hole) => ({
+        number: hole.number,
+        strokes: { ...hole.strokes },
+      })),
+    };
+  }
+}
+
+function parseHoleScore(
+  raw: unknown,
+  index: number,
+  playerSlots: GolfPlayerSlot[],
+): HoleScoreSnapshot {
+  if (!raw || typeof raw !== "object") {
+    throw new DomainError(`score.holes[${index}] is invalid`);
+  }
+
+  const hole = raw as { number?: unknown; strokes?: unknown };
+  if (typeof hole.number !== "number" || !Number.isInteger(hole.number)) {
+    throw new DomainError(`score.holes[${index}].number must be an integer`);
+  }
+
+  if (!hole.strokes || typeof hole.strokes !== "object" || Array.isArray(hole.strokes)) {
+    throw new DomainError(`score.holes[${index}].strokes is required`);
+  }
+
+  const strokesRaw = hole.strokes as Record<string, unknown>;
+  const strokes: Record<string, number> = {};
+
+  for (const slot of playerSlots) {
+    const key = String(slot);
+    const value = strokesRaw[key];
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 1 || value > 15) {
+      throw new DomainError(
+        `score.holes[${index}].strokes["${key}"] must be an integer between 1 and 15`,
+      );
+    }
+    strokes[key] = value;
+  }
+
+  const unexpected = Object.keys(strokesRaw).filter(
+    (key) => !playerSlots.includes(Number(key) as GolfPlayerSlot),
+  );
+  if (unexpected.length > 0) {
+    throw new DomainError(
+      `score.holes[${index}].strokes has unexpected player slots`,
+    );
+  }
+
+  return { number: hole.number, strokes };
+}

--- a/src/modules/golf-round/entities/starts-at.ts
+++ b/src/modules/golf-round/entities/starts-at.ts
@@ -1,0 +1,29 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export class StartsAt {
+  private constructor(readonly value: Date) {}
+
+  static from(raw: unknown): StartsAt {
+    if (raw instanceof Date) {
+      if (Number.isNaN(raw.getTime())) {
+        throw new DomainError("startsAt must be a valid date");
+      }
+      return new StartsAt(raw);
+    }
+
+    if (typeof raw !== "string" || raw.trim().length === 0) {
+      throw new DomainError("startsAt is required");
+    }
+
+    const parsed = new Date(raw);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new DomainError("startsAt must be a valid date");
+    }
+
+    return new StartsAt(parsed);
+  }
+
+  toIsoString(): string {
+    return this.value.toISOString();
+  }
+}

--- a/src/modules/golf-round/index.ts
+++ b/src/modules/golf-round/index.ts
@@ -1,0 +1,70 @@
+import { Request, Router } from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { VenueRepository } from "../venue/repositories/venue.repository";
+import { createGolfRoundController } from "./controllers/golf-round.controller";
+import { GolfRoundRepository } from "./repositories/golf-round.repository";
+import { PrismaGolfRoundRepository } from "./repositories/prisma-golf-round.repository";
+import { createGolfRoundRoutes } from "./routes/golf-round.routes";
+import { CreateGolfRound } from "./services/create-golf-round.service";
+import { GetGolfRoundById } from "./services/get-golf-round-by-id.service";
+import {
+  ListLockedGolfRoundsByPlayer,
+  ListLockedGolfRoundsByVenue,
+} from "./services/list-locked-golf-rounds.service";
+import { LockGolfRound } from "./services/lock-golf-round.service";
+
+export type CreateGolfRoundModuleParams = {
+  prisma: PrismaClient;
+  venueRepository: VenueRepository;
+  golfRoundRepository?: GolfRoundRepository;
+  tryGetSessionUserId: (req: Request) => string | null;
+};
+
+export type GolfRoundModule = {
+  router: Router;
+  golfRoundRepository: GolfRoundRepository;
+};
+
+export function createGolfRoundModule({
+  prisma,
+  venueRepository,
+  golfRoundRepository: golfRoundRepositoryOverride,
+  tryGetSessionUserId,
+}: CreateGolfRoundModuleParams): GolfRoundModule {
+  const golfRoundRepository =
+    golfRoundRepositoryOverride ?? new PrismaGolfRoundRepository(prisma);
+
+  const controller = createGolfRoundController({
+    createGolfRound: new CreateGolfRound(golfRoundRepository, venueRepository),
+    getGolfRoundById: new GetGolfRoundById(golfRoundRepository),
+    lockGolfRound: new LockGolfRound(golfRoundRepository),
+    listLockedGolfRoundsByPlayer: new ListLockedGolfRoundsByPlayer(
+      golfRoundRepository,
+      venueRepository,
+    ),
+    listLockedGolfRoundsByVenue: new ListLockedGolfRoundsByVenue(
+      golfRoundRepository,
+      venueRepository,
+    ),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createGolfRoundRoutes(controller),
+    golfRoundRepository,
+  };
+}
+
+export { createGolfRoundController } from "./controllers/golf-round.controller";
+export { GolfRound } from "./entities/golf-round";
+export { InMemoryGolfRoundRepository } from "./repositories/in-memory-golf-round.repository";
+export { PrismaGolfRoundRepository } from "./repositories/prisma-golf-round.repository";
+export type { GolfRoundRepository } from "./repositories/golf-round.repository";
+export { CreateGolfRound } from "./services/create-golf-round.service";
+export { GetGolfRoundById } from "./services/get-golf-round-by-id.service";
+export { LockGolfRound } from "./services/lock-golf-round.service";
+export {
+  ListLockedGolfRoundsByPlayer,
+  ListLockedGolfRoundsByVenue,
+} from "./services/list-locked-golf-rounds.service";

--- a/src/modules/golf-round/repositories/golf-round.repository.ts
+++ b/src/modules/golf-round/repositories/golf-round.repository.ts
@@ -1,0 +1,10 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { GolfRound } from "../entities/golf-round";
+
+export interface GolfRoundRepository {
+  findById(id: string): Promise<GolfRound | null>;
+  create(round: GolfRound): Promise<GolfRound>;
+  persistLock(round: GolfRound): Promise<GolfRound>;
+  listLockedByPlayerUserId(userId: string): Promise<GolfRound[]>;
+  listLockedByVenueCmsId(cmsId: CmsId): Promise<GolfRound[]>;
+}

--- a/src/modules/golf-round/repositories/in-memory-golf-round.repository.ts
+++ b/src/modules/golf-round/repositories/in-memory-golf-round.repository.ts
@@ -1,0 +1,75 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { GolfRound } from "../entities/golf-round";
+import { GolfRoundLockConflictError } from "../entities/golf-round-lock-conflict-error";
+import { GolfRoundRepository } from "./golf-round.repository";
+
+export class InMemoryGolfRoundRepository implements GolfRoundRepository {
+  private readonly byId = new Map<string, GolfRound>();
+
+  async findById(id: string): Promise<GolfRound | null> {
+    return clone(this.byId.get(id) ?? null);
+  }
+
+  async create(round: GolfRound): Promise<GolfRound> {
+    this.byId.set(round.id, clone(round)!);
+    return clone(round)!;
+  }
+
+  async persistLock(round: GolfRound): Promise<GolfRound> {
+    const stored = this.byId.get(round.id);
+    if (!stored) {
+      return clone(round)!;
+    }
+
+    if (stored.isLocked) {
+      if (stored.hasSameLockedScore(round)) {
+        return clone(stored)!;
+      }
+
+      throw new GolfRoundLockConflictError();
+    }
+
+    this.byId.set(round.id, clone(round)!);
+    return clone(round)!;
+  }
+
+  async listLockedByPlayerUserId(userId: string): Promise<GolfRound[]> {
+    return this.lockedNewestFirst().filter((round) =>
+      round.hasPlayerUserId(userId),
+    );
+  }
+
+  async listLockedByVenueCmsId(cmsId: CmsId): Promise<GolfRound[]> {
+    return this.lockedNewestFirst().filter((round) =>
+      round.venueCmsId.equals(cmsId),
+    );
+  }
+
+  private lockedNewestFirst(): GolfRound[] {
+    return [...this.byId.values()]
+      .filter((round) => round.isLocked)
+      .sort((a, b) => b.startsAt.value.getTime() - a.startsAt.value.getTime())
+      .map((round) => clone(round)!);
+  }
+}
+
+function clone(round: GolfRound | null): GolfRound | null {
+  if (!round) {
+    return null;
+  }
+
+  const snapshot = round.toSnapshot();
+  return GolfRound.rehydrate({
+    id: snapshot.id,
+    venueCmsId: round.venueCmsId,
+    startsAt: round.startsAt,
+    status: snapshot.status,
+    holesPlayed: round.holesPlayed,
+    startingHole: round.startingHole,
+    teeName: round.teeName,
+    course: round.course,
+    players: [...round.players],
+    score: round.score,
+    lockedAt: round.lockedAt,
+  });
+}

--- a/src/modules/golf-round/repositories/prisma-golf-round.repository.ts
+++ b/src/modules/golf-round/repositories/prisma-golf-round.repository.ts
@@ -1,0 +1,210 @@
+import { Prisma, PrismaClient } from "../../../generated/prisma/client";
+import { CmsId } from "../../venue/entities/cms-id";
+import { CourseSnapshot } from "../entities/course-snapshot";
+import { GolfPlayer } from "../entities/golf-player";
+import { GolfRound, GolfRoundStatusValue } from "../entities/golf-round";
+import { GolfRoundLockConflictError } from "../entities/golf-round-lock-conflict-error";
+import { GolfRoundPersistenceError } from "../entities/golf-round-persistence-error";
+import { GolfRoundVenueNotFoundError } from "../entities/golf-round-venue-not-found-error";
+import { GolfScore } from "../entities/golf-score";
+import { StartsAt } from "../entities/starts-at";
+import { GolfRoundRepository } from "./golf-round.repository";
+
+type GolfRoundPlayerRow = {
+  slot: number;
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+};
+
+type GolfRoundRow = {
+  id: string;
+  venueCmsId: string;
+  startsAt: Date;
+  status: "live" | "locked";
+  holesPlayed: number;
+  startingHole: number;
+  teeName: string | null;
+  course: Prisma.JsonValue;
+  score: Prisma.JsonValue | null;
+  lockedAt: Date | null;
+  players: GolfRoundPlayerRow[];
+};
+
+export class PrismaGolfRoundRepository implements GolfRoundRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(id: string): Promise<GolfRound | null> {
+    try {
+      const row = await this.prisma.golfRound.findUnique({
+        where: { id },
+        include: { players: true },
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw wrapPersistenceError(error, "Unable to load golf round");
+    }
+  }
+
+  async create(round: GolfRound): Promise<GolfRound> {
+    const snapshot = round.toSnapshot();
+
+    try {
+      const row = await this.prisma.golfRound.create({
+        data: {
+          id: snapshot.id,
+          venueCmsId: snapshot.venueCmsId,
+          startsAt: round.startsAt.value,
+          status: "live",
+          holesPlayed: snapshot.holesPlayed,
+          startingHole: snapshot.startingHole,
+          teeName: snapshot.teeName,
+          course: snapshot.course,
+          players: {
+            create: round.players.map((player) => ({
+              slot: player.slot,
+              userId: player.userId,
+              displayName: player.displayName,
+              isGuest: player.isGuest,
+            })),
+          },
+        },
+        include: { players: true },
+      });
+
+      return toDomain(row);
+    } catch (error) {
+      if (isForeignKeyViolation(error)) {
+        throw new GolfRoundVenueNotFoundError();
+      }
+
+      throw wrapPersistenceError(error, "Unable to save golf round");
+    }
+  }
+
+  async persistLock(round: GolfRound): Promise<GolfRound> {
+    const snapshot = round.toSnapshot();
+
+    try {
+      const updated = await this.prisma.golfRound.updateMany({
+        where: { id: round.id, status: "live" },
+        data: {
+          status: "locked",
+          lockedAt: round.lockedAt,
+          score: snapshot.score === null ? Prisma.JsonNull : snapshot.score,
+        },
+      });
+
+      if (updated.count === 1) {
+        const locked = await this.findById(round.id);
+        if (!locked) {
+          throw new GolfRoundPersistenceError("Unable to load golf round");
+        }
+        return locked;
+      }
+
+      const current = await this.findById(round.id);
+      if (!current) {
+        throw new GolfRoundPersistenceError("Unable to load golf round");
+      }
+
+      if (current.hasSameLockedScore(round)) {
+        return current;
+      }
+
+      throw new GolfRoundLockConflictError();
+    } catch (error) {
+      if (
+        error instanceof GolfRoundLockConflictError ||
+        error instanceof GolfRoundPersistenceError
+      ) {
+        throw error;
+      }
+
+      throw wrapPersistenceError(error, "Unable to save golf round");
+    }
+  }
+
+  async listLockedByPlayerUserId(userId: string): Promise<GolfRound[]> {
+    try {
+      const rows = await this.prisma.golfRound.findMany({
+        where: {
+          status: "locked",
+          players: { some: { userId } },
+        },
+        include: { players: true },
+        orderBy: { startsAt: "desc" },
+      });
+
+      return rows.map(toDomain);
+    } catch (error) {
+      throw wrapPersistenceError(error, "Unable to load golf round");
+    }
+  }
+
+  async listLockedByVenueCmsId(cmsId: CmsId): Promise<GolfRound[]> {
+    try {
+      const rows = await this.prisma.golfRound.findMany({
+        where: {
+          status: "locked",
+          venueCmsId: cmsId.value,
+        },
+        include: { players: true },
+        orderBy: { startsAt: "desc" },
+      });
+
+      return rows.map(toDomain);
+    } catch (error) {
+      throw wrapPersistenceError(error, "Unable to load golf round");
+    }
+  }
+}
+
+function toDomain(row: GolfRoundRow): GolfRound {
+  const players = GolfPlayer.fromPlayers(
+    row.players.map((player) => ({
+      slot: player.slot,
+      userId: player.userId,
+      displayName: player.displayName,
+      isGuest: player.isGuest,
+    })),
+  );
+  const course = CourseSnapshot.from(row.course, {
+    holesPlayed: row.holesPlayed,
+    startingHole: row.startingHole,
+  });
+
+  return GolfRound.rehydrate({
+    id: row.id,
+    venueCmsId: CmsId.from(row.venueCmsId),
+    startsAt: StartsAt.from(row.startsAt),
+    status: row.status as GolfRoundStatusValue,
+    holesPlayed: row.holesPlayed,
+    startingHole: row.startingHole,
+    teeName: row.teeName,
+    course,
+    players,
+    score: row.score
+      ? GolfScore.from(row.score, {
+          holeNumbers: course.holeNumbers(),
+          playerSlots: players.map((player) => player.slot),
+        })
+      : null,
+    lockedAt: row.lockedAt,
+  });
+}
+
+function isForeignKeyViolation(error: unknown): boolean {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === "P2003"
+  );
+}
+
+function wrapPersistenceError(error: unknown, message: string): Error {
+  if (error instanceof GolfRoundPersistenceError) {
+    return error;
+  }
+
+  return new GolfRoundPersistenceError(message, { cause: error });
+}

--- a/src/modules/golf-round/routes/golf-round.routes.ts
+++ b/src/modules/golf-round/routes/golf-round.routes.ts
@@ -1,0 +1,31 @@
+import { Router } from "express";
+
+import { createGolfRoundController } from "../controllers/golf-round.controller";
+
+export function createGolfRoundRoutes(
+  controller: ReturnType<typeof createGolfRoundController>,
+): Router {
+  const router = Router();
+
+  router.post("/api/golf-rounds", (req, res) => {
+    void controller.create(req, res);
+  });
+
+  router.get("/api/golf-rounds", (req, res) => {
+    void controller.listByPlayer(req, res);
+  });
+
+  router.get("/api/golf-rounds/:id", (req, res) => {
+    void controller.getById(req, res);
+  });
+
+  router.post("/api/golf-rounds/:id/lock", (req, res) => {
+    void controller.lock(req, res);
+  });
+
+  router.get("/api/venues/:cmsId/golf-rounds", (req, res) => {
+    void controller.listByVenue(req, res);
+  });
+
+  return router;
+}

--- a/src/modules/golf-round/services/create-golf-round.service.ts
+++ b/src/modules/golf-round/services/create-golf-round.service.ts
@@ -1,0 +1,45 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { GolfPlayerInput } from "../entities/golf-player";
+import { GolfRound } from "../entities/golf-round";
+import { GolfRoundVenueNotFoundError } from "../entities/golf-round-venue-not-found-error";
+import { StartsAt } from "../entities/starts-at";
+import { GolfRoundRepository } from "../repositories/golf-round.repository";
+
+export type CreateGolfRoundInput = {
+  venueCmsId: string;
+  startsAt: unknown;
+  holesPlayed: unknown;
+  startingHole?: unknown;
+  teeName?: string | null;
+  course: unknown;
+  players: GolfPlayerInput[];
+};
+
+export class CreateGolfRound {
+  constructor(
+    private readonly rounds: GolfRoundRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async execute(input: CreateGolfRoundInput): Promise<GolfRound> {
+    const venueCmsId = CmsId.from(input.venueCmsId);
+    const venue = await this.venues.findByCmsId(venueCmsId);
+    if (!venue) {
+      throw new GolfRoundVenueNotFoundError();
+    }
+
+    const round = GolfRound.create({
+      venueCmsId,
+      startsAt: StartsAt.from(input.startsAt),
+      holesPlayed: input.holesPlayed as number,
+      startingHole:
+        input.startingHole === undefined ? 1 : (input.startingHole as number),
+      teeName: input.teeName,
+      course: input.course,
+      players: input.players,
+    });
+
+    return this.rounds.create(round);
+  }
+}

--- a/src/modules/golf-round/services/get-golf-round-by-id.service.ts
+++ b/src/modules/golf-round/services/get-golf-round-by-id.service.ts
@@ -1,0 +1,9 @@
+import { GolfRoundRepository } from "../repositories/golf-round.repository";
+
+export class GetGolfRoundById {
+  constructor(private readonly rounds: GolfRoundRepository) {}
+
+  async execute(id: string) {
+    return this.rounds.findById(id);
+  }
+}

--- a/src/modules/golf-round/services/golf-round-history-item.ts
+++ b/src/modules/golf-round/services/golf-round-history-item.ts
@@ -1,0 +1,37 @@
+import { GolfRoundSnapshot } from "../entities/golf-round";
+import { GolfPlayerSnapshot } from "../entities/golf-player";
+import { CourseSnapshotData } from "../entities/course-snapshot";
+import { GolfScoreSnapshot } from "../entities/golf-score";
+
+export type GolfRoundHistoryItem = {
+  id: string;
+  startsAt: string;
+  venueCmsId: string;
+  venueName: string | null;
+  venueSlug: string | null;
+  holesPlayed: number;
+  startingHole: number;
+  teeName: string | null;
+  course: CourseSnapshotData;
+  players: GolfPlayerSnapshot[];
+  score: GolfScoreSnapshot | null;
+};
+
+export function toHistoryItem(
+  snapshot: GolfRoundSnapshot,
+  venue: { name: string; slug: string } | null,
+): GolfRoundHistoryItem {
+  return {
+    id: snapshot.id,
+    startsAt: snapshot.startsAt,
+    venueCmsId: snapshot.venueCmsId,
+    venueName: venue?.name ?? null,
+    venueSlug: venue?.slug ?? null,
+    holesPlayed: snapshot.holesPlayed,
+    startingHole: snapshot.startingHole,
+    teeName: snapshot.teeName,
+    course: snapshot.course,
+    players: snapshot.players,
+    score: snapshot.score,
+  };
+}

--- a/src/modules/golf-round/services/list-locked-golf-rounds.service.ts
+++ b/src/modules/golf-round/services/list-locked-golf-rounds.service.ts
@@ -1,0 +1,61 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { Venue } from "../../venue/entities/venue";
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { requiredTrimmed } from "../../../lib/domain-error";
+import { GolfRoundRepository } from "../repositories/golf-round.repository";
+import {
+  GolfRoundHistoryItem,
+  toHistoryItem,
+} from "./golf-round-history-item";
+
+export class ListLockedGolfRoundsByPlayer {
+  constructor(
+    private readonly rounds: GolfRoundRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async execute(playerUserId: unknown): Promise<GolfRoundHistoryItem[]> {
+    const userId = requiredTrimmed(playerUserId, "playerUserId");
+    const rounds = await this.rounds.listLockedByPlayerUserId(userId);
+    const venuesByCmsId = await loadVenuesByCmsId(
+      this.venues,
+      rounds.map((round) => round.venueCmsId),
+    );
+
+    return rounds.map((round) => {
+      const venue = venuesByCmsId.get(round.venueCmsId.value);
+      return toHistoryItem(
+        round.toSnapshot(),
+        venue ? { name: venue.name.value, slug: venue.slug.value } : null,
+      );
+    });
+  }
+}
+
+export class ListLockedGolfRoundsByVenue {
+  constructor(
+    private readonly rounds: GolfRoundRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async execute(venueCmsId: unknown): Promise<GolfRoundHistoryItem[]> {
+    const cmsId = CmsId.from(venueCmsId);
+    const venue = await this.venues.findByCmsId(cmsId);
+    const rounds = await this.rounds.listLockedByVenueCmsId(cmsId);
+    const venueDetails = venue
+      ? { name: venue.name.value, slug: venue.slug.value }
+      : null;
+
+    return rounds.map((round) => toHistoryItem(round.toSnapshot(), venueDetails));
+  }
+}
+
+async function loadVenuesByCmsId(
+  venues: VenueRepository,
+  cmsIds: CmsId[],
+): Promise<Map<string, Venue>> {
+  const unique = [...new Map(cmsIds.map((cmsId) => [cmsId.value, cmsId])).values()];
+  const found = unique.length === 0 ? [] : await venues.findByCmsIds(unique);
+
+  return new Map(found.map((venue) => [venue.cmsId.value, venue]));
+}

--- a/src/modules/golf-round/services/lock-golf-round.service.ts
+++ b/src/modules/golf-round/services/lock-golf-round.service.ts
@@ -1,0 +1,26 @@
+import { GolfRound } from "../entities/golf-round";
+import { GolfScore } from "../entities/golf-score";
+import { GolfRoundRepository } from "../repositories/golf-round.repository";
+
+export type LockGolfRoundInput = {
+  roundId: string;
+  score: unknown;
+};
+
+export class LockGolfRound {
+  constructor(private readonly rounds: GolfRoundRepository) {}
+
+  async execute(input: LockGolfRoundInput): Promise<GolfRound | null> {
+    const round = await this.rounds.findById(input.roundId);
+    if (!round) {
+      return null;
+    }
+
+    const score = GolfScore.from(input.score, {
+      holeNumbers: round.course.holeNumbers(),
+      playerSlots: round.playerSlots(),
+    });
+    round.lock(score);
+    return this.rounds.persistLock(round);
+  }
+}

--- a/src/modules/golf-round/utils/bind-session-user.ts
+++ b/src/modules/golf-round/utils/bind-session-user.ts
@@ -1,0 +1,49 @@
+import { GolfPlayerInput } from "../entities/golf-player";
+
+function normalizedUserId(userId: unknown): string | null {
+  if (typeof userId !== "string") {
+    return null;
+  }
+
+  const value = userId.trim();
+  return value.length === 0 ? null : value;
+}
+
+function withSessionUser(
+  player: GolfPlayerInput,
+  sessionUserId: string,
+): GolfPlayerInput {
+  return { ...player, userId: sessionUserId, isGuest: false };
+}
+
+export function bindSessionUserIdToPlayers(
+  players: GolfPlayerInput[],
+  sessionUserId: string,
+): GolfPlayerInput[] {
+  const bound = players.map((player) => ({ ...player }));
+
+  let alreadyBound = false;
+  for (let index = 0; index < bound.length; index++) {
+    const player = bound[index];
+    if (normalizedUserId(player.userId) === sessionUserId) {
+      bound[index] = withSessionUser(player, sessionUserId);
+      alreadyBound = true;
+    }
+  }
+
+  if (!alreadyBound) {
+    for (let index = 0; index < bound.length; index++) {
+      const player = bound[index];
+      if (player.isGuest === true) {
+        continue;
+      }
+      if (normalizedUserId(player.userId) !== null) {
+        continue;
+      }
+      bound[index] = withSessionUser(player, sessionUserId);
+      break;
+    }
+  }
+
+  return bound;
+}


### PR DESCRIPTION
Separate GolfRound module (not padel Match). Endpoints POST/GET /api/golf-rounds, lock, list by player/venue. Prisma migration add_golf_rounds. Pairs with landing-page golf rounds UI.