### PR TITLE
Add friends graph API (request / accept / list)

### DIFF
--- a/prisma/migrations/20260904194500_friendship/migration.sql
+++ b/prisma/migrations/20260904194500_friendship/migration.sql
@@ -1,0 +1,23 @@
+-- CreateEnum
+CREATE TYPE "FriendshipStatus" AS ENUM ('pending', 'accepted');
+
+-- CreateTable
+CREATE TABLE "Friendship" (
+    "id" TEXT NOT NULL,
+    "requesterId" TEXT NOT NULL,
+    "addresseeId" TEXT NOT NULL,
+    "status" "FriendshipStatus" NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Friendship_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Friendship_requesterId_status_idx" ON "Friendship"("requesterId", "status");
+
+-- CreateIndex
+CREATE INDEX "Friendship_addresseeId_status_idx" ON "Friendship"("addresseeId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Friendship_requesterId_addresseeId_key" ON "Friendship"("requesterId", "addresseeId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,24 @@ model VenueFollow {
   @@index([venueCmsId])
 }
 
+enum FriendshipStatus {
+  pending
+  accepted
+}
+
+model Friendship {
+  id          String           @id @default(uuid())
+  requesterId String
+  addresseeId String
+  status      FriendshipStatus @default(pending)
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+
+  @@unique([requesterId, addresseeId])
+  @@index([requesterId, status])
+  @@index([addresseeId, status])
+}
+
 enum MatchRuleset {
   golden_point
   advantage

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,11 @@ import {
   MatchRepository,
 } from "./modules/match";
 import {
+  createFriendsModule,
+  FriendProfileLookup,
+  FriendshipRepository,
+} from "./modules/friends";
+import {
   createVenueModule,
   VenueRepository,
 } from "./modules/venue";
@@ -21,6 +26,8 @@ import {
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
   venueFollowRepository?: import("./modules/venue").VenueFollowRepository;
+  friendshipRepository?: FriendshipRepository;
+  friendProfileLookup?: FriendProfileLookup;
   matchRepository?: MatchRepository;
   golfRoundRepository?: GolfRoundRepository;
 };
@@ -69,11 +76,19 @@ export async function createApp(
     golfRoundRepository: dependencies.golfRoundRepository,
     tryGetSessionUserId: identity.tryGetSessionUserId,
   });
+  const friends = createFriendsModule({
+    prisma,
+    friendshipRepository: dependencies.friendshipRepository,
+    friendProfileLookup: dependencies.friendProfileLookup,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
   app.use(match.router);
   app.use(golfRound.router);
+  app.use(friends.router);
 
   app.use(
     (

--- a/src/modules/friends/controllers/friends.controller.ts
+++ b/src/modules/friends/controllers/friends.controller.ts
@@ -1,0 +1,133 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { FriendshipPersistenceError } from "../repositories/friendship-persistence-error";
+import {
+  AcceptFriend,
+  AlreadyFriendsError,
+  FriendNotFoundError,
+  FriendRequestAlreadySentError,
+  FriendRequestNotFoundError,
+  ListFriends,
+  RemoveFriend,
+  RequestFriend,
+} from "../services/friends.service";
+
+const requestBodySchema = z.object({
+  handle: z.string(),
+});
+
+const userIdParamSchema = z.object({
+  userId: z.string(),
+});
+
+export function createFriendsController(deps: {
+  requestFriend: RequestFriend;
+  acceptFriend: AcceptFriend;
+  removeFriend: RemoveFriend;
+  listFriends: ListFriends;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async list(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const result = await deps.listFriends.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendFriendsError(res, error);
+      }
+    },
+
+    async request(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const body = z.parse(requestBodySchema, req.body ?? {});
+        const result = await deps.requestFriend.execute({
+          userId,
+          handle: body.handle,
+        });
+        return res.status(result.status === "accepted" ? 200 : 201).json(result);
+      } catch (error) {
+        return sendFriendsError(res, error);
+      }
+    },
+
+    async accept(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { userId: otherUserId } = z.parse(userIdParamSchema, req.params);
+        const result = await deps.acceptFriend.execute({
+          userId,
+          otherUserId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendFriendsError(res, error);
+      }
+    },
+
+    async remove(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { userId: otherUserId } = z.parse(userIdParamSchema, req.params);
+        const result = await deps.removeFriend.execute({
+          userId,
+          otherUserId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendFriendsError(res, error);
+      }
+    },
+  };
+}
+
+function sendFriendsError(res: Response, error: unknown) {
+  if (error instanceof FriendNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof FriendRequestNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (
+    error instanceof AlreadyFriendsError ||
+    error instanceof FriendRequestAlreadySentError
+  ) {
+    return res.status(409).json({ error: error.message });
+  }
+
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid friends payload" });
+  }
+
+  if (error instanceof FriendshipPersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/friends/controllers/friends.http.test.ts
+++ b/src/modules/friends/controllers/friends.http.test.ts
@@ -1,0 +1,161 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+import jwt from "jsonwebtoken";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryFriendProfileLookup } from "../repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../repositories/in-memory-friendship.repository";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+describe("friends HTTP", () => {
+  const config = makeConfig();
+  let friendships: InMemoryFriendshipRepository;
+  let profiles: InMemoryFriendProfileLookup;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  beforeEach(async () => {
+    friendships = new InMemoryFriendshipRepository();
+    profiles = new InMemoryFriendProfileLookup();
+    profiles.seed({
+      userId: "user-a",
+      displayName: "Alex",
+      handle: "alex",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-b",
+      displayName: "Blake",
+      handle: "blake",
+      avatarUrl: null,
+    });
+
+    app = await createApp(config, {
+      venueRepository: new InMemoryVenueRepository(),
+      friendshipRepository: friendships,
+      friendProfileLookup: profiles,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("request → accept → list friends for both users", async () => {
+    const tokenA = jwt.sign({ userId: "user-a" }, config.JWT_SECRET);
+    const tokenB = jwt.sign({ userId: "user-b" }, config.JWT_SECRET);
+
+    const unauth = await fetch(`${server.url}/api/me/friends`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ handle: "blake" }),
+    });
+    expect(unauth.status).toBe(401);
+
+    const requested = await fetch(`${server.url}/api/me/friends`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `token=${tokenA}`,
+      },
+      body: JSON.stringify({ handle: "blake" }),
+    });
+    expect(requested.status).toBe(201);
+    expect(await requested.json()).toMatchObject({
+      status: "pending",
+      request: { direction: "outgoing", user: { handle: "blake" } },
+    });
+
+    const incoming = await fetch(`${server.url}/api/me/friends`, {
+      headers: { Cookie: `token=${tokenB}` },
+    });
+    const incomingBody = (await incoming.json()) as {
+      incoming: Array<{ user: { id: string } }>;
+    };
+    expect(incomingBody.incoming).toHaveLength(1);
+
+    const accepted = await fetch(
+      `${server.url}/api/me/friends/user-a/accept`,
+      {
+        method: "POST",
+        headers: { Cookie: `token=${tokenB}` },
+      },
+    );
+    expect(accepted.status).toBe(200);
+    expect(await accepted.json()).toMatchObject({
+      friend: { handle: "alex" },
+    });
+
+    const listedA = await fetch(`${server.url}/api/me/friends`, {
+      headers: { Cookie: `token=${tokenA}` },
+    });
+    expect(await listedA.json()).toMatchObject({
+      friends: [{ handle: "blake" }],
+      incoming: [],
+      outgoing: [],
+    });
+  });
+
+  test("DELETE removes a pending or accepted friendship", async () => {
+    const tokenA = jwt.sign({ userId: "user-a" }, config.JWT_SECRET);
+    await fetch(`${server.url}/api/me/friends`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `token=${tokenA}`,
+      },
+      body: JSON.stringify({ handle: "blake" }),
+    });
+
+    const removed = await fetch(`${server.url}/api/me/friends/user-b`, {
+      method: "DELETE",
+      headers: { Cookie: `token=${tokenA}` },
+    });
+    expect(removed.status).toBe(200);
+    expect(await removed.json()).toEqual({ ok: true });
+
+    const listed = await fetch(`${server.url}/api/me/friends`, {
+      headers: { Cookie: `token=${tokenA}` },
+    });
+    expect(await listed.json()).toEqual({
+      friends: [],
+      incoming: [],
+      outgoing: [],
+    });
+  });
+});

--- a/src/modules/friends/index.ts
+++ b/src/modules/friends/index.ts
@@ -1,0 +1,92 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { createFriendsController } from "./controllers/friends.controller";
+import { InMemoryFriendProfileLookup } from "./repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "./repositories/in-memory-friendship.repository";
+import { PrismaFriendProfileLookup } from "./repositories/prisma-friend-profile.lookup";
+import { PrismaFriendshipRepository } from "./repositories/prisma-friendship.repository";
+import {
+  FriendProfileLookup,
+  FriendshipRepository,
+} from "./repositories/friendship.repository";
+import { createFriendsRoutes } from "./routes/friends.routes";
+import {
+  AcceptFriend,
+  ListFriends,
+  RemoveFriend,
+  RequestFriend,
+} from "./services/friends.service";
+
+export type CreateFriendsModuleParams = {
+  prisma: PrismaClient;
+  friendshipRepository?: FriendshipRepository;
+  friendProfileLookup?: FriendProfileLookup;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type FriendsModule = {
+  router: Router;
+  friendshipRepository: FriendshipRepository;
+  friendProfileLookup: FriendProfileLookup;
+};
+
+export function createFriendsModule({
+  prisma,
+  friendshipRepository: friendshipRepositoryOverride,
+  friendProfileLookup: friendProfileLookupOverride,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreateFriendsModuleParams): FriendsModule {
+  const friendshipRepository =
+    friendshipRepositoryOverride ?? new PrismaFriendshipRepository(prisma);
+
+  const friendProfileLookup =
+    friendProfileLookupOverride ??
+    (friendshipRepositoryOverride
+      ? new InMemoryFriendProfileLookup()
+      : new PrismaFriendProfileLookup(prisma));
+
+  const controller = createFriendsController({
+    requestFriend: new RequestFriend(friendshipRepository, friendProfileLookup),
+    acceptFriend: new AcceptFriend(friendshipRepository, friendProfileLookup),
+    removeFriend: new RemoveFriend(friendshipRepository),
+    listFriends: new ListFriends(friendshipRepository, friendProfileLookup),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createFriendsRoutes(controller, { requireAuth }),
+    friendshipRepository,
+    friendProfileLookup,
+  };
+}
+
+export { createFriendsController } from "./controllers/friends.controller";
+export { InMemoryFriendProfileLookup } from "./repositories/in-memory-friend-profile.lookup";
+export { InMemoryFriendshipRepository } from "./repositories/in-memory-friendship.repository";
+export { PrismaFriendProfileLookup } from "./repositories/prisma-friend-profile.lookup";
+export { PrismaFriendshipRepository } from "./repositories/prisma-friendship.repository";
+export { FriendshipPersistenceError } from "./repositories/friendship-persistence-error";
+export type {
+  FriendProfile,
+  FriendProfileLookup,
+  FriendshipRecord,
+  FriendshipRepository,
+} from "./repositories/friendship.repository";
+export {
+  AcceptFriend,
+  AlreadyFriendsError,
+  FriendNotFoundError,
+  FriendRequestAlreadySentError,
+  FriendRequestNotFoundError,
+  ListFriends,
+  RemoveFriend,
+  RequestFriend,
+} from "./services/friends.service";

--- a/src/modules/friends/repositories/friendship-persistence-error.ts
+++ b/src/modules/friends/repositories/friendship-persistence-error.ts
@@ -1,0 +1,6 @@
+export class FriendshipPersistenceError extends Error {
+  constructor(message = "Unable to save friendship", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "FriendshipPersistenceError";
+  }
+}

--- a/src/modules/friends/repositories/friendship.repository.ts
+++ b/src/modules/friends/repositories/friendship.repository.ts
@@ -1,0 +1,36 @@
+export type FriendshipStatus = "pending" | "accepted";
+
+export type FriendshipRecord = {
+  id: string;
+  requesterId: string;
+  addresseeId: string;
+  status: FriendshipStatus;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type FriendProfile = {
+  userId: string;
+  displayName: string;
+  handle: string;
+  avatarUrl: string | null;
+};
+
+export interface FriendProfileLookup {
+  findByUserId(userId: string): Promise<FriendProfile | null>;
+  findByHandle(handle: string): Promise<FriendProfile | null>;
+}
+
+export interface FriendshipRepository {
+  findBetween(
+    userIdA: string,
+    userIdB: string,
+  ): Promise<FriendshipRecord | null>;
+  createPending(
+    requesterId: string,
+    addresseeId: string,
+  ): Promise<FriendshipRecord>;
+  accept(id: string): Promise<FriendshipRecord | null>;
+  deleteBetween(userIdA: string, userIdB: string): Promise<boolean>;
+  listForUser(userId: string): Promise<FriendshipRecord[]>;
+}

--- a/src/modules/friends/repositories/in-memory-friend-profile.lookup.ts
+++ b/src/modules/friends/repositories/in-memory-friend-profile.lookup.ts
@@ -1,0 +1,25 @@
+import {
+  FriendProfile,
+  FriendProfileLookup,
+} from "./friendship.repository";
+
+export class InMemoryFriendProfileLookup implements FriendProfileLookup {
+  private readonly byUserId = new Map<string, FriendProfile>();
+  private readonly byHandle = new Map<string, string>();
+
+  seed(profile: FriendProfile): void {
+    this.byUserId.set(profile.userId, { ...profile });
+    this.byHandle.set(profile.handle.toLowerCase(), profile.userId);
+  }
+
+  async findByUserId(userId: string): Promise<FriendProfile | null> {
+    const row = this.byUserId.get(userId);
+    return row ? { ...row } : null;
+  }
+
+  async findByHandle(handle: string): Promise<FriendProfile | null> {
+    const userId = this.byHandle.get(handle.trim().toLowerCase());
+    if (!userId) return null;
+    return this.findByUserId(userId);
+  }
+}

--- a/src/modules/friends/repositories/in-memory-friendship.repository.ts
+++ b/src/modules/friends/repositories/in-memory-friendship.repository.ts
@@ -1,0 +1,79 @@
+import {
+  FriendshipRecord,
+  FriendshipRepository,
+} from "./friendship.repository";
+
+export class InMemoryFriendshipRepository implements FriendshipRepository {
+  private readonly rows = new Map<string, FriendshipRecord>();
+
+  async findBetween(
+    userIdA: string,
+    userIdB: string,
+  ): Promise<FriendshipRecord | null> {
+    for (const row of this.rows.values()) {
+      if (
+        (row.requesterId === userIdA && row.addresseeId === userIdB) ||
+        (row.requesterId === userIdB && row.addresseeId === userIdA)
+      ) {
+        return { ...row };
+      }
+    }
+    return null;
+  }
+
+  async createPending(
+    requesterId: string,
+    addresseeId: string,
+  ): Promise<FriendshipRecord> {
+    const existing = await this.findBetween(requesterId, addresseeId);
+    if (existing) {
+      return { ...existing };
+    }
+
+    const now = new Date();
+    const row: FriendshipRecord = {
+      id: `friendship_${this.rows.size + 1}`,
+      requesterId,
+      addresseeId,
+      status: "pending",
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.rows.set(row.id, row);
+    return { ...row };
+  }
+
+  async accept(id: string): Promise<FriendshipRecord | null> {
+    const row = this.rows.get(id);
+    if (!row) return null;
+    const next: FriendshipRecord = {
+      ...row,
+      status: "accepted",
+      updatedAt: new Date(),
+    };
+    this.rows.set(id, next);
+    return { ...next };
+  }
+
+  async deleteBetween(userIdA: string, userIdB: string): Promise<boolean> {
+    for (const [id, row] of this.rows) {
+      if (
+        (row.requesterId === userIdA && row.addresseeId === userIdB) ||
+        (row.requesterId === userIdB && row.addresseeId === userIdA)
+      ) {
+        this.rows.delete(id);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  async listForUser(userId: string): Promise<FriendshipRecord[]> {
+    return [...this.rows.values()]
+      .filter(
+        (row) => row.requesterId === userId || row.addresseeId === userId,
+      )
+      .map((row) => ({ ...row }))
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  }
+}

--- a/src/modules/friends/repositories/prisma-friend-profile.lookup.ts
+++ b/src/modules/friends/repositories/prisma-friend-profile.lookup.ts
@@ -1,0 +1,63 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { FriendshipPersistenceError } from "./friendship-persistence-error";
+import {
+  FriendProfile,
+  FriendProfileLookup,
+} from "./friendship.repository";
+
+function toProfile(row: {
+  userId: string;
+  firstName: string;
+  lastName: string;
+  handle: string;
+  avatarUrl: string | null;
+}): FriendProfile {
+  const displayName =
+    [row.firstName, row.lastName].filter(Boolean).join(" ").trim() ||
+    row.handle;
+  return {
+    userId: row.userId,
+    displayName,
+    handle: row.handle,
+    avatarUrl: row.avatarUrl,
+  };
+}
+
+export class PrismaFriendProfileLookup implements FriendProfileLookup {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findByUserId(userId: string): Promise<FriendProfile | null> {
+    try {
+      const row = await this.prisma.profile.findUnique({
+        where: { userId },
+      });
+      return row ? toProfile(row) : null;
+    } catch (error) {
+      throw new FriendshipPersistenceError("Failed to load friend profile", {
+        cause: error,
+      });
+    }
+  }
+
+  async findByHandle(handle: string): Promise<FriendProfile | null> {
+    const normalized = handle.trim().replace(/^@/, "").toLowerCase();
+    if (!normalized) return null;
+
+    try {
+      // Handles are stored lowercase from allocateHandle; match case-insensitively.
+      const row = await this.prisma.profile.findFirst({
+        where: {
+          handle: {
+            equals: normalized,
+            mode: "insensitive",
+          },
+        },
+      });
+      return row ? toProfile(row) : null;
+    } catch (error) {
+      throw new FriendshipPersistenceError("Failed to find handle", {
+        cause: error,
+      });
+    }
+  }
+}

--- a/src/modules/friends/repositories/prisma-friendship.repository.ts
+++ b/src/modules/friends/repositories/prisma-friendship.repository.ts
@@ -1,0 +1,130 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { FriendshipPersistenceError } from "./friendship-persistence-error";
+import {
+  FriendshipRecord,
+  FriendshipRepository,
+  FriendshipStatus,
+} from "./friendship.repository";
+
+function toRecord(row: {
+  id: string;
+  requesterId: string;
+  addresseeId: string;
+  status: FriendshipStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}): FriendshipRecord {
+  return {
+    id: row.id,
+    requesterId: row.requesterId,
+    addresseeId: row.addresseeId,
+    status: row.status,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export class PrismaFriendshipRepository implements FriendshipRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findBetween(
+    userIdA: string,
+    userIdB: string,
+  ): Promise<FriendshipRecord | null> {
+    try {
+      const row = await this.prisma.friendship.findFirst({
+        where: {
+          OR: [
+            { requesterId: userIdA, addresseeId: userIdB },
+            { requesterId: userIdB, addresseeId: userIdA },
+          ],
+        },
+      });
+      return row ? toRecord(row) : null;
+    } catch (error) {
+      throw new FriendshipPersistenceError("Failed to load friendship", {
+        cause: error,
+      });
+    }
+  }
+
+  async createPending(
+    requesterId: string,
+    addresseeId: string,
+  ): Promise<FriendshipRecord> {
+    try {
+      const existing = await this.findBetween(requesterId, addresseeId);
+      if (existing) {
+        return existing;
+      }
+
+      const row = await this.prisma.friendship.create({
+        data: {
+          requesterId,
+          addresseeId,
+          status: "pending",
+        },
+      });
+      return toRecord(row);
+    } catch (error) {
+      throw new FriendshipPersistenceError("Failed to create friend request", {
+        cause: error,
+      });
+    }
+  }
+
+  async accept(id: string): Promise<FriendshipRecord | null> {
+    try {
+      const row = await this.prisma.friendship.update({
+        where: { id },
+        data: { status: "accepted" },
+      });
+      return toRecord(row);
+    } catch (error) {
+      const code =
+        error && typeof error === "object" && "code" in error
+          ? String((error as { code?: unknown }).code)
+          : "";
+      if (code === "P2025") {
+        return null;
+      }
+      throw new FriendshipPersistenceError("Failed to accept friend request", {
+        cause: error,
+      });
+    }
+  }
+
+  async deleteBetween(userIdA: string, userIdB: string): Promise<boolean> {
+    try {
+      const result = await this.prisma.friendship.deleteMany({
+        where: {
+          OR: [
+            { requesterId: userIdA, addresseeId: userIdB },
+            { requesterId: userIdB, addresseeId: userIdA },
+          ],
+        },
+      });
+      return result.count > 0;
+    } catch (error) {
+      throw new FriendshipPersistenceError("Failed to remove friendship", {
+        cause: error,
+      });
+    }
+  }
+
+  async listForUser(userId: string): Promise<FriendshipRecord[]> {
+    try {
+      const rows = await this.prisma.friendship.findMany({
+        where: {
+          OR: [{ requesterId: userId }, { addresseeId: userId }],
+        },
+        orderBy: { updatedAt: "desc" },
+      });
+      return rows.map(toRecord);
+    } catch (error) {
+      throw new FriendshipPersistenceError("Failed to list friendships", {
+        cause: error,
+      });
+    }
+  }
+}

--- a/src/modules/friends/routes/friends.routes.ts
+++ b/src/modules/friends/routes/friends.routes.ts
@@ -1,0 +1,38 @@
+import { Router } from "express";
+
+import { createFriendsController } from "../controllers/friends.controller";
+
+export function createFriendsRoutes(
+  controller: ReturnType<typeof createFriendsController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.get("/api/me/friends", options.requireAuth, (req, res) => {
+    void controller.list(req, res);
+  });
+
+  router.post("/api/me/friends", options.requireAuth, (req, res) => {
+    void controller.request(req, res);
+  });
+
+  router.post(
+    "/api/me/friends/:userId/accept",
+    options.requireAuth,
+    (req, res) => {
+      void controller.accept(req, res);
+    },
+  );
+
+  router.delete("/api/me/friends/:userId", options.requireAuth, (req, res) => {
+    void controller.remove(req, res);
+  });
+
+  return router;
+}

--- a/src/modules/friends/services/friends.service.test.ts
+++ b/src/modules/friends/services/friends.service.test.ts
@@ -1,0 +1,124 @@
+import { DomainError } from "../../../lib/domain-error";
+import { InMemoryFriendProfileLookup } from "../repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../repositories/in-memory-friendship.repository";
+import {
+  AcceptFriend,
+  AlreadyFriendsError,
+  FriendNotFoundError,
+  FriendRequestAlreadySentError,
+  ListFriends,
+  RemoveFriend,
+  RequestFriend,
+} from "./friends.service";
+
+describe("friends services", () => {
+  function setup() {
+    const friendships = new InMemoryFriendshipRepository();
+    const profiles = new InMemoryFriendProfileLookup();
+    profiles.seed({
+      userId: "user-a",
+      displayName: "Alex",
+      handle: "alex",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-b",
+      displayName: "Blake",
+      handle: "blake",
+      avatarUrl: "https://example.test/b.png",
+    });
+    return {
+      friendships,
+      profiles,
+      request: new RequestFriend(friendships, profiles),
+      accept: new AcceptFriend(friendships, profiles),
+      remove: new RemoveFriend(friendships),
+      list: new ListFriends(friendships, profiles),
+    };
+  }
+
+  test("request by handle creates an outgoing pending request", async () => {
+    const { request, list } = setup();
+    const result = await request.execute({ userId: "user-a", handle: "@blake" });
+
+    expect(result.status).toBe("pending");
+    if (result.status !== "pending") return;
+    expect(result.request.user.handle).toBe("blake");
+
+    const listed = await list.execute({ userId: "user-a" });
+    expect(listed.outgoing).toHaveLength(1);
+    expect(listed.incoming).toHaveLength(0);
+    expect(listed.friends).toHaveLength(0);
+
+    const forB = await list.execute({ userId: "user-b" });
+    expect(forB.incoming).toHaveLength(1);
+    expect(forB.incoming[0]?.user.handle).toBe("alex");
+  });
+
+  test("accept turns a pending request into friends", async () => {
+    const { request, accept, list } = setup();
+    await request.execute({ userId: "user-a", handle: "blake" });
+
+    const accepted = await accept.execute({
+      userId: "user-b",
+      otherUserId: "user-a",
+    });
+    expect(accepted.friend.handle).toBe("alex");
+
+    const listed = await list.execute({ userId: "user-a" });
+    expect(listed.friends).toHaveLength(1);
+    expect(listed.friends[0]?.handle).toBe("blake");
+    expect(listed.outgoing).toHaveLength(0);
+  });
+
+  test("requesting when the other side already asked accepts instead", async () => {
+    const { request } = setup();
+    await request.execute({ userId: "user-a", handle: "blake" });
+
+    const result = await request.execute({
+      userId: "user-b",
+      handle: "alex",
+    });
+    expect(result.status).toBe("accepted");
+  });
+
+  test("rejects unknown handle, self, and duplicate outgoing", async () => {
+    const { request } = setup();
+
+    await expect(
+      request.execute({ userId: "user-a", handle: "missing" }),
+    ).rejects.toBeInstanceOf(FriendNotFoundError);
+
+    await expect(
+      request.execute({ userId: "user-a", handle: "alex" }),
+    ).rejects.toBeInstanceOf(DomainError);
+
+    await request.execute({ userId: "user-a", handle: "blake" });
+    await expect(
+      request.execute({ userId: "user-a", handle: "blake" }),
+    ).rejects.toBeInstanceOf(FriendRequestAlreadySentError);
+  });
+
+  test("remove deletes friendship or pending request", async () => {
+    const { request, accept, remove, list } = setup();
+    await request.execute({ userId: "user-a", handle: "blake" });
+    await accept.execute({ userId: "user-b", otherUserId: "user-a" });
+
+    await remove.execute({ userId: "user-a", otherUserId: "user-b" });
+    expect(await list.execute({ userId: "user-a" })).toEqual({
+      friends: [],
+      incoming: [],
+      outgoing: [],
+    });
+  });
+
+  test("already friends is a conflict", async () => {
+    const { request, accept } = setup();
+    await request.execute({ userId: "user-a", handle: "blake" });
+    await accept.execute({ userId: "user-b", otherUserId: "user-a" });
+
+    await expect(
+      request.execute({ userId: "user-a", handle: "blake" }),
+    ).rejects.toBeInstanceOf(AlreadyFriendsError);
+  });
+});

--- a/src/modules/friends/services/friends.service.ts
+++ b/src/modules/friends/services/friends.service.ts
@@ -1,0 +1,263 @@
+import { DomainError } from "../../../lib/domain-error";
+import {
+  FriendProfile,
+  FriendProfileLookup,
+  FriendshipRecord,
+  FriendshipRepository,
+} from "../repositories/friendship.repository";
+
+export type PublicFriend = {
+  id: string;
+  displayName: string;
+  handle: string;
+  avatarUrl: string | null;
+  since: string;
+};
+
+export type PublicFriendRequest = {
+  id: string;
+  direction: "incoming" | "outgoing";
+  createdAt: string;
+  user: {
+    id: string;
+    displayName: string;
+    handle: string;
+    avatarUrl: string | null;
+  };
+};
+
+function toPublicUser(profile: FriendProfile) {
+  return {
+    id: profile.userId,
+    displayName: profile.displayName,
+    handle: profile.handle,
+    avatarUrl: profile.avatarUrl,
+  };
+}
+
+function otherUserId(row: FriendshipRecord, selfId: string): string {
+  return row.requesterId === selfId ? row.addresseeId : row.requesterId;
+}
+
+async function resolveProfile(
+  lookup: FriendProfileLookup,
+  userId: string,
+): Promise<FriendProfile> {
+  const profile = await lookup.findByUserId(userId);
+  if (profile) return profile;
+  return {
+    userId,
+    displayName: "Player",
+    handle: userId.slice(0, 8),
+    avatarUrl: null,
+  };
+}
+
+export class RequestFriend {
+  constructor(
+    private readonly friendships: FriendshipRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string; handle: string }) {
+    const userId = input.userId.trim();
+    if (!userId) {
+      throw new DomainError("userId is required");
+    }
+
+    const handle = input.handle.trim().replace(/^@/, "");
+    if (!handle) {
+      throw new DomainError("handle is required");
+    }
+
+    const addressee = await this.profiles.findByHandle(handle);
+    if (!addressee) {
+      throw new FriendNotFoundError();
+    }
+    if (addressee.userId === userId) {
+      throw new DomainError("You cannot add yourself as a friend");
+    }
+
+    const existing = await this.friendships.findBetween(
+      userId,
+      addressee.userId,
+    );
+    if (existing?.status === "accepted") {
+      throw new AlreadyFriendsError();
+    }
+    if (existing?.status === "pending") {
+      if (existing.requesterId === userId) {
+        throw new FriendRequestAlreadySentError();
+      }
+      // Incoming pending — accept instead of creating a reverse request.
+      const accepted = await this.friendships.accept(existing.id);
+      if (!accepted) {
+        throw new FriendRequestNotFoundError();
+      }
+      const profile = await resolveProfile(this.profiles, addressee.userId);
+      return {
+        status: "accepted" as const,
+        friend: {
+          ...toPublicUser(profile),
+          since: accepted.updatedAt.toISOString(),
+        } satisfies PublicFriend,
+      };
+    }
+
+    const created = await this.friendships.createPending(
+      userId,
+      addressee.userId,
+    );
+    return {
+      status: "pending" as const,
+      request: {
+        id: created.id,
+        direction: "outgoing" as const,
+        createdAt: created.createdAt.toISOString(),
+        user: toPublicUser(addressee),
+      } satisfies PublicFriendRequest,
+    };
+  }
+}
+
+export class AcceptFriend {
+  constructor(
+    private readonly friendships: FriendshipRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string; otherUserId: string }) {
+    const userId = input.userId.trim();
+    const otherUserIdValue = input.otherUserId.trim();
+    if (!userId) {
+      throw new DomainError("userId is required");
+    }
+    if (!otherUserIdValue) {
+      throw new DomainError("friend user id is required");
+    }
+
+    const existing = await this.friendships.findBetween(
+      userId,
+      otherUserIdValue,
+    );
+    if (!existing || existing.status !== "pending") {
+      throw new FriendRequestNotFoundError();
+    }
+    if (existing.addresseeId !== userId) {
+      throw new FriendRequestNotFoundError();
+    }
+
+    const accepted = await this.friendships.accept(existing.id);
+    if (!accepted) {
+      throw new FriendRequestNotFoundError();
+    }
+
+    const profile = await resolveProfile(this.profiles, otherUserIdValue);
+    return {
+      friend: {
+        ...toPublicUser(profile),
+        since: accepted.updatedAt.toISOString(),
+      } satisfies PublicFriend,
+    };
+  }
+}
+
+export class RemoveFriend {
+  constructor(private readonly friendships: FriendshipRepository) {}
+
+  async execute(input: { userId: string; otherUserId: string }) {
+    const userId = input.userId.trim();
+    const otherUserIdValue = input.otherUserId.trim();
+    if (!userId) {
+      throw new DomainError("userId is required");
+    }
+    if (!otherUserIdValue) {
+      throw new DomainError("friend user id is required");
+    }
+
+    const removed = await this.friendships.deleteBetween(
+      userId,
+      otherUserIdValue,
+    );
+    if (!removed) {
+      throw new FriendRequestNotFoundError();
+    }
+
+    return { ok: true as const };
+  }
+}
+
+export class ListFriends {
+  constructor(
+    private readonly friendships: FriendshipRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string }) {
+    const userId = input.userId.trim();
+    if (!userId) {
+      throw new DomainError("userId is required");
+    }
+
+    const rows = await this.friendships.listForUser(userId);
+    const friends: PublicFriend[] = [];
+    const incoming: PublicFriendRequest[] = [];
+    const outgoing: PublicFriendRequest[] = [];
+
+    for (const row of rows) {
+      const otherId = otherUserId(row, userId);
+      const profile = await resolveProfile(this.profiles, otherId);
+      const user = toPublicUser(profile);
+
+      if (row.status === "accepted") {
+        friends.push({
+          ...user,
+          since: row.updatedAt.toISOString(),
+        });
+        continue;
+      }
+
+      const request: PublicFriendRequest = {
+        id: row.id,
+        direction: row.addresseeId === userId ? "incoming" : "outgoing",
+        createdAt: row.createdAt.toISOString(),
+        user,
+      };
+      if (request.direction === "incoming") {
+        incoming.push(request);
+      } else {
+        outgoing.push(request);
+      }
+    }
+
+    return { friends, incoming, outgoing };
+  }
+}
+
+export class FriendNotFoundError extends Error {
+  constructor() {
+    super("Player not found");
+    this.name = "FriendNotFoundError";
+  }
+}
+
+export class AlreadyFriendsError extends Error {
+  constructor() {
+    super("Already friends");
+    this.name = "AlreadyFriendsError";
+  }
+}
+
+export class FriendRequestAlreadySentError extends Error {
+  constructor() {
+    super("Friend request already sent");
+    this.name = "FriendRequestAlreadySentError";
+  }
+}
+
+export class FriendRequestNotFoundError extends Error {
+  constructor() {
+    super("Friend request not found");
+    this.name = "FriendRequestNotFoundError";
+  }
+}


### PR DESCRIPTION
## Summary

Adds a minimal **Friendship** model and authenticated `/api/me/friends` endpoints so signed-in users can request friends by handle, accept pending requests, list friends/incoming/outgoing, and remove friendships.

### Model
- `Friendship` with `requesterId`, `addresseeId`, `status` (`pending` | `accepted`)
- Unique pair + indexes for requester/addressee by status
- Prisma migration `20260904194500_friendship`

### Endpoints
- `GET /api/me/friends` — list friends, incoming, and outgoing requests
- `POST /api/me/friends` — request friend by `{ handle }` (auto-accepts if reverse pending)
- `POST /api/me/friends/:userId/accept` — accept an incoming request
- `DELETE /api/me/friends/:userId` — remove pending or accepted friendship

Closes related work for landing-page #63 backend.