### PR TITLE
Add server-evaluated GET/POST /api/me/badges

### DIFF
--- a/prisma/migrations/20260905060000_badge_award/migration.sql
+++ b/prisma/migrations/20260905060000_badge_award/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "BadgeAward" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "badgeId" TEXT NOT NULL,
+    "earnedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BadgeAward_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BadgeAward_userId_idx" ON "BadgeAward"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BadgeAward_userId_badgeId_key" ON "BadgeAward"("userId", "badgeId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,6 +88,19 @@ model Friendship {
   @@index([addresseeId, status])
 }
 
+
+model BadgeAward {
+  id        String   @id @default(uuid())
+  userId    String
+  badgeId   String
+  earnedAt  DateTime
+  createdAt DateTime @default(now())
+
+  @@unique([userId, badgeId])
+  @@index([userId])
+}
+
+
 enum MatchRuleset {
   golden_point
   advantage

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,10 @@ import {
   FriendshipRepository,
 } from "./modules/friends";
 import {
+  createBadgesModule,
+  BadgeAwardRepository,
+} from "./modules/badges";
+import {
   createVenueModule,
   VenueRepository,
 } from "./modules/venue";
@@ -30,6 +34,7 @@ export type CreateAppDependencies = {
   friendProfileLookup?: FriendProfileLookup;
   matchRepository?: MatchRepository;
   golfRoundRepository?: GolfRoundRepository;
+  badgeAwardRepository?: BadgeAwardRepository;
 };
 
 export async function createApp(
@@ -83,12 +88,22 @@ export async function createApp(
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
+  const badges = createBadgesModule({
+    prisma,
+    matchRepository: match.matchRepository,
+    golfRoundRepository: golfRound.golfRoundRepository,
+    friendshipRepository: friends.friendshipRepository,
+    badgeAwardRepository: dependencies.badgeAwardRepository,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
   app.use(match.router);
   app.use(golfRound.router);
   app.use(friends.router);
+  app.use(badges.router);
 
   app.use(
     (

--- a/src/modules/badges/catalog.ts
+++ b/src/modules/badges/catalog.ts
@@ -1,0 +1,19 @@
+/** V1 server badge catalog — ids must match the landing-page client. */
+
+export const SERVER_BADGE_IDS = [
+  "first_lock",
+  "first_win",
+  "matches_5",
+  "first_golf",
+  "first_friend",
+  "hot_form",
+] as const;
+
+export type ServerBadgeId = (typeof SERVER_BADGE_IDS)[number];
+
+/** Device-local only until a share *action* is recorded server-side. */
+export const CLIENT_ONLY_BADGE_IDS = ["whatsapp_share"] as const;
+
+export function isServerBadgeId(value: string): value is ServerBadgeId {
+  return (SERVER_BADGE_IDS as readonly string[]).includes(value);
+}

--- a/src/modules/badges/controllers/badges.controller.ts
+++ b/src/modules/badges/controllers/badges.controller.ts
@@ -1,0 +1,74 @@
+import { Request, Response } from "express";
+
+import { DomainError } from "../../../lib/domain-error";
+import { ListBadges, RecomputeBadges } from "../services/badges.service";
+
+function rejectClientBadgeGrants(body: unknown): string | null {
+  if (body == null) return null;
+  if (typeof body !== "object" || Array.isArray(body)) {
+    return "Badge recompute accepts an empty JSON object only";
+  }
+
+  const keys = Object.keys(body as Record<string, unknown>);
+  if (keys.length === 0) return null;
+
+  if (
+    keys.some((key) =>
+      ["earnedIds", "badgeIds", "badges", "ids"].includes(key),
+    )
+  ) {
+    return "Client-supplied badge ids are not accepted";
+  }
+
+  return "Badge recompute accepts an empty JSON object only";
+}
+
+export function createBadgesController(deps: {
+  listBadges: ListBadges;
+  recomputeBadges: RecomputeBadges;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async list(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const result = await deps.listBadges.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendBadgesError(res, error);
+      }
+    },
+
+    async recompute(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const rejection = rejectClientBadgeGrants(req.body);
+        if (rejection) {
+          return res.status(400).json({ error: rejection });
+        }
+
+        const result = await deps.recomputeBadges.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendBadgesError(res, error);
+      }
+    },
+  };
+}
+
+function sendBadgesError(res: Response, error: unknown) {
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/badges/controllers/badges.http.test.ts
+++ b/src/modules/badges/controllers/badges.http.test.ts
@@ -1,0 +1,166 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+import jwt from "jsonwebtoken";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { InMemoryMatchRepository } from "../../match/repositories/in-memory-match.repository";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { Match } from "../../match/entities/match";
+import { MatchScore } from "../../match/entities/match-score";
+import { Ruleset } from "../../match/entities/ruleset";
+import { StartsAt } from "../../match/entities/starts-at";
+import { Team } from "../../match/entities/team";
+import { InMemoryBadgeAwardRepository } from "../repositories/in-memory-badge-award.repository";
+import { InMemoryGolfRoundRepository } from "../../golf-round/repositories/in-memory-golf-round.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+describe("badges HTTP", () => {
+  const config = makeConfig();
+  let matches: InMemoryMatchRepository;
+  let friendships: InMemoryFriendshipRepository;
+  let awards: InMemoryBadgeAwardRepository;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  beforeEach(async () => {
+    matches = new InMemoryMatchRepository();
+    friendships = new InMemoryFriendshipRepository();
+    awards = new InMemoryBadgeAwardRepository();
+    const venues = new InMemoryVenueRepository();
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-court-1"),
+        VenueName.from("Padel Club"),
+        Slug.from("padel-club"),
+      ),
+      { refreshDetails: false },
+    );
+
+    const profiles = new InMemoryFriendProfileLookup();
+    profiles.seed({
+      userId: "user-1",
+      displayName: "Alex",
+      handle: "alex",
+      avatarUrl: null,
+    });
+
+    app = await createApp(config, {
+      venueRepository: venues,
+      matchRepository: matches,
+      golfRoundRepository: new InMemoryGolfRoundRepository(),
+      friendshipRepository: friendships,
+      friendProfileLookup: profiles,
+      badgeAwardRepository: awards,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("GET requires auth and returns evaluated badges", async () => {
+    const unauth = await fetch(`${server.url}/api/me/badges`);
+    expect(unauth.status).toBe(401);
+
+    const match = Match.create({
+      venueCmsId: CmsId.from("sanity-court-1"),
+      startsAt: StartsAt.from("2026-09-01T10:00:00.000Z"),
+      ruleset: Ruleset.from("golden_point"),
+      pairings: {
+        teamA: [
+          { displayName: "Alex", isGuest: false, userId: "user-1" },
+          { displayName: "Sam", isGuest: true, userId: null },
+        ],
+        teamB: [
+          { displayName: "Jordan", isGuest: true, userId: null },
+          { displayName: "Riley", isGuest: true, userId: null },
+        ],
+      },
+    });
+    match.lock(
+      MatchScore.from({
+        sets: [{ gamesA: 6, gamesB: 4, tieBreak: null, winner: "A" }],
+      }),
+      Team.A,
+      new Date("2026-09-01T11:00:00.000Z"),
+    );
+    await matches.create(match);
+
+    const token = jwt.sign({ userId: "user-1" }, config.JWT_SECRET);
+    const res = await fetch(`${server.url}/api/me/badges`, {
+      headers: { Cookie: `token=${token}` },
+    });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      badges: [
+        { id: "first_lock", earnedAt: "2026-09-01T11:00:00.000Z" },
+        { id: "first_win", earnedAt: "2026-09-01T11:00:00.000Z" },
+      ],
+    });
+  });
+
+  test("POST rejects client earnedIds and accepts empty recompute", async () => {
+    const token = jwt.sign({ userId: "user-1" }, config.JWT_SECRET);
+
+    const rejected = await fetch(`${server.url}/api/me/badges`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `token=${token}`,
+      },
+      body: JSON.stringify({ earnedIds: ["first_lock"] }),
+    });
+    expect(rejected.status).toBe(400);
+
+    const ok = await fetch(`${server.url}/api/me/badges`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `token=${token}`,
+      },
+      body: "{}",
+    });
+    expect(ok.status).toBe(200);
+    await expect(ok.json()).resolves.toEqual({ badges: [] });
+  });
+});

--- a/src/modules/badges/evaluate.test.ts
+++ b/src/modules/badges/evaluate.test.ts
@@ -1,0 +1,79 @@
+import { evaluateServerBadges } from "./evaluate";
+
+describe("evaluateServerBadges", () => {
+  test("starts with nothing earned", () => {
+    expect(
+      evaluateServerBadges({
+        padelResults: [],
+        golfLockedAt: [],
+        friendSince: [],
+      }),
+    ).toEqual([]);
+  });
+
+  test("unlocks padel lock, win, and matches_5 milestones", () => {
+    const padelResults = [
+      { lockedAt: "2026-09-01T10:00:00.000Z", won: true },
+      { lockedAt: "2026-09-02T10:00:00.000Z", won: false },
+      { lockedAt: "2026-09-03T10:00:00.000Z", won: true },
+      { lockedAt: "2026-09-04T10:00:00.000Z", won: false },
+      { lockedAt: "2026-09-05T10:00:00.000Z", won: true },
+    ];
+
+    const earned = evaluateServerBadges({
+      padelResults,
+      golfLockedAt: [],
+      friendSince: [],
+    });
+
+    expect(earned).toEqual(
+      expect.arrayContaining([
+        { id: "first_lock", earnedAt: "2026-09-01T10:00:00.000Z" },
+        { id: "first_win", earnedAt: "2026-09-01T10:00:00.000Z" },
+        { id: "matches_5", earnedAt: "2026-09-05T10:00:00.000Z" },
+        { id: "hot_form", earnedAt: expect.any(String) },
+      ]),
+    );
+  });
+
+  test("unlocks golf and friend badges from evidence", () => {
+    const earned = evaluateServerBadges({
+      padelResults: [],
+      golfLockedAt: ["2026-09-03T12:00:00.000Z", "2026-09-01T12:00:00.000Z"],
+      friendSince: ["2026-09-04T08:00:00.000Z"],
+    });
+
+    expect(earned).toEqual([
+      { id: "first_golf", earnedAt: "2026-09-01T12:00:00.000Z" },
+      { id: "first_friend", earnedAt: "2026-09-04T08:00:00.000Z" },
+    ]);
+  });
+
+  test("hot_form requires three wins in the newest five decided results", () => {
+    const withoutHot = evaluateServerBadges({
+      padelResults: [
+        { lockedAt: "2026-09-05T10:00:00.000Z", won: true },
+        { lockedAt: "2026-09-04T10:00:00.000Z", won: true },
+        { lockedAt: "2026-09-03T10:00:00.000Z", won: false },
+      ],
+      golfLockedAt: [],
+      friendSince: [],
+    });
+    expect(withoutHot.some((badge) => badge.id === "hot_form")).toBe(false);
+
+    const withHot = evaluateServerBadges({
+      padelResults: [
+        { lockedAt: "2026-09-05T10:00:00.000Z", won: true },
+        { lockedAt: "2026-09-04T10:00:00.000Z", won: false },
+        { lockedAt: "2026-09-03T10:00:00.000Z", won: true },
+        { lockedAt: "2026-09-02T10:00:00.000Z", won: true },
+      ],
+      golfLockedAt: [],
+      friendSince: [],
+    });
+    // Chronological third win in the form window is when hot_form unlocks.
+    expect(withHot.find((badge) => badge.id === "hot_form")?.earnedAt).toBe(
+      "2026-09-05T10:00:00.000Z",
+    );
+  });
+});

--- a/src/modules/badges/evaluate.ts
+++ b/src/modules/badges/evaluate.ts
@@ -1,0 +1,78 @@
+import { SERVER_BADGE_IDS, type ServerBadgeId } from "./catalog";
+
+export type PadelLockedResult = {
+  lockedAt: string;
+  /** null when the locked match has no known winner for this player. */
+  won: boolean | null;
+};
+
+export type BadgeEvidence = {
+  padelResults: PadelLockedResult[];
+  golfLockedAt: string[];
+  friendSince: string[];
+};
+
+export type EarnedBadge = {
+  id: ServerBadgeId;
+  earnedAt: string;
+};
+
+function byTimeAsc(a: string, b: string): number {
+  return new Date(a).getTime() - new Date(b).getTime();
+}
+
+function byTimeDesc(a: string, b: string): number {
+  return new Date(b).getTime() - new Date(a).getTime();
+}
+
+/**
+ * Server-side unlock evaluation from session-owned evidence.
+ * Never awards `whatsapp_share` — that stays device-local until a share action API exists.
+ */
+export function evaluateServerBadges(evidence: BadgeEvidence): EarnedBadge[] {
+  const earned = new Map<ServerBadgeId, string>();
+
+  const padelAsc = [...evidence.padelResults].sort((a, b) =>
+    byTimeAsc(a.lockedAt, b.lockedAt),
+  );
+
+  if (padelAsc.length >= 1) {
+    earned.set("first_lock", padelAsc[0]!.lockedAt);
+  }
+
+  const winsAsc = padelAsc.filter((row) => row.won === true);
+  if (winsAsc.length >= 1) {
+    earned.set("first_win", winsAsc[0]!.lockedAt);
+  }
+
+  if (padelAsc.length >= 5) {
+    earned.set("matches_5", padelAsc[4]!.lockedAt);
+  }
+
+  const golfAsc = [...evidence.golfLockedAt].sort(byTimeAsc);
+  if (golfAsc.length >= 1) {
+    earned.set("first_golf", golfAsc[0]!);
+  }
+
+  const friendsAsc = [...evidence.friendSince].sort(byTimeAsc);
+  if (friendsAsc.length >= 1) {
+    earned.set("first_friend", friendsAsc[0]!);
+  }
+
+  const decidedNewestFirst = [...evidence.padelResults]
+    .filter((row) => row.won !== null)
+    .sort((a, b) => byTimeDesc(a.lockedAt, b.lockedAt));
+  const form = decidedNewestFirst.slice(0, 5);
+  const formWins = form.filter((row) => row.won === true);
+  if (formWins.length >= 3) {
+    const thirdWin = [...formWins].sort((a, b) =>
+      byTimeAsc(a.lockedAt, b.lockedAt),
+    )[2]!;
+    earned.set("hot_form", thirdWin.lockedAt);
+  }
+
+  return SERVER_BADGE_IDS.filter((id) => earned.has(id)).map((id) => ({
+    id,
+    earnedAt: earned.get(id)!,
+  }));
+}

--- a/src/modules/badges/index.ts
+++ b/src/modules/badges/index.ts
@@ -1,0 +1,78 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { FriendshipRepository } from "../friends/repositories/friendship.repository";
+import { GolfRoundRepository } from "../golf-round/repositories/golf-round.repository";
+import { MatchRepository } from "../match/repositories/match.repository";
+import { createBadgesController } from "./controllers/badges.controller";
+import { BadgeAwardRepository } from "./repositories/badge-award.repository";
+import { InMemoryBadgeAwardRepository } from "./repositories/in-memory-badge-award.repository";
+import { PrismaBadgeAwardRepository } from "./repositories/prisma-badge-award.repository";
+import { createBadgesRoutes } from "./routes/badges.routes";
+import {
+  EvaluateUserBadges,
+  ListBadges,
+  RecomputeBadges,
+} from "./services/badges.service";
+
+export type CreateBadgesModuleParams = {
+  prisma: PrismaClient;
+  matchRepository: MatchRepository;
+  golfRoundRepository: GolfRoundRepository;
+  friendshipRepository: FriendshipRepository;
+  badgeAwardRepository?: BadgeAwardRepository;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type BadgesModule = {
+  router: Router;
+  badgeAwardRepository: BadgeAwardRepository;
+};
+
+export function createBadgesModule({
+  prisma,
+  matchRepository,
+  golfRoundRepository,
+  friendshipRepository,
+  badgeAwardRepository: badgeAwardRepositoryOverride,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreateBadgesModuleParams): BadgesModule {
+  const badgeAwardRepository =
+    badgeAwardRepositoryOverride ?? new PrismaBadgeAwardRepository(prisma);
+
+  const evaluate = new EvaluateUserBadges(
+    matchRepository,
+    golfRoundRepository,
+    friendshipRepository,
+  );
+
+  const controller = createBadgesController({
+    listBadges: new ListBadges(evaluate),
+    recomputeBadges: new RecomputeBadges(evaluate, badgeAwardRepository),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createBadgesRoutes(controller, { requireAuth }),
+    badgeAwardRepository,
+  };
+}
+
+export { createBadgesController } from "./controllers/badges.controller";
+export { InMemoryBadgeAwardRepository } from "./repositories/in-memory-badge-award.repository";
+export { PrismaBadgeAwardRepository } from "./repositories/prisma-badge-award.repository";
+export type { BadgeAwardRepository } from "./repositories/badge-award.repository";
+export {
+  EvaluateUserBadges,
+  ListBadges,
+  RecomputeBadges,
+} from "./services/badges.service";
+export { evaluateServerBadges } from "./evaluate";
+export { SERVER_BADGE_IDS } from "./catalog";

--- a/src/modules/badges/repositories/badge-award.repository.ts
+++ b/src/modules/badges/repositories/badge-award.repository.ts
@@ -1,0 +1,18 @@
+import type { ServerBadgeId } from "../catalog";
+
+export type BadgeAwardRecord = {
+  userId: string;
+  badgeId: ServerBadgeId;
+  earnedAt: Date;
+};
+
+export interface BadgeAwardRepository {
+  listForUser(userId: string): Promise<BadgeAwardRecord[]>;
+  /**
+   * Persist awards. Keeps the earliest earnedAt when an award already exists.
+   */
+  upsertAwards(
+    userId: string,
+    awards: BadgeAwardRecord[],
+  ): Promise<BadgeAwardRecord[]>;
+}

--- a/src/modules/badges/repositories/in-memory-badge-award.repository.ts
+++ b/src/modules/badges/repositories/in-memory-badge-award.repository.ts
@@ -1,0 +1,42 @@
+import type { ServerBadgeId } from "../catalog";
+import {
+  BadgeAwardRecord,
+  BadgeAwardRepository,
+} from "./badge-award.repository";
+
+export class InMemoryBadgeAwardRepository implements BadgeAwardRepository {
+  private readonly rows = new Map<string, BadgeAwardRecord>();
+
+  private key(userId: string, badgeId: string): string {
+    return `${userId}::${badgeId}`;
+  }
+
+  async listForUser(userId: string): Promise<BadgeAwardRecord[]> {
+    return [...this.rows.values()]
+      .filter((row) => row.userId === userId)
+      .map((row) => ({ ...row, earnedAt: new Date(row.earnedAt) }));
+  }
+
+  async upsertAwards(
+    userId: string,
+    awards: BadgeAwardRecord[],
+  ): Promise<BadgeAwardRecord[]> {
+    for (const award of awards) {
+      if (award.userId !== userId) continue;
+      const key = this.key(userId, award.badgeId);
+      const existing = this.rows.get(key);
+      if (!existing) {
+        this.rows.set(key, {
+          userId,
+          badgeId: award.badgeId as ServerBadgeId,
+          earnedAt: new Date(award.earnedAt),
+        });
+        continue;
+      }
+      if (award.earnedAt.getTime() < existing.earnedAt.getTime()) {
+        existing.earnedAt = new Date(award.earnedAt);
+      }
+    }
+    return this.listForUser(userId);
+  }
+}

--- a/src/modules/badges/repositories/prisma-badge-award.repository.ts
+++ b/src/modules/badges/repositories/prisma-badge-award.repository.ts
@@ -1,0 +1,60 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { isServerBadgeId, type ServerBadgeId } from "../catalog";
+import {
+  BadgeAwardRecord,
+  BadgeAwardRepository,
+} from "./badge-award.repository";
+
+export class PrismaBadgeAwardRepository implements BadgeAwardRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async listForUser(userId: string): Promise<BadgeAwardRecord[]> {
+    const rows = await this.prisma.badgeAward.findMany({
+      where: { userId },
+      orderBy: { earnedAt: "asc" },
+    });
+
+    return rows.flatMap((row) => {
+      if (!isServerBadgeId(row.badgeId)) return [];
+      return [
+        {
+          userId: row.userId,
+          badgeId: row.badgeId,
+          earnedAt: row.earnedAt,
+        },
+      ];
+    });
+  }
+
+  async upsertAwards(
+    userId: string,
+    awards: BadgeAwardRecord[],
+  ): Promise<BadgeAwardRecord[]> {
+    const existing = await this.listForUser(userId);
+    const earliest = new Map<ServerBadgeId, Date>(
+      existing.map((row) => [row.badgeId, row.earnedAt]),
+    );
+
+    for (const award of awards) {
+      if (award.userId !== userId) continue;
+      const prior = earliest.get(award.badgeId);
+      if (!prior || award.earnedAt.getTime() < prior.getTime()) {
+        earliest.set(award.badgeId, award.earnedAt);
+      }
+    }
+
+    await this.prisma.$transaction(
+      [...earliest.entries()].map(([badgeId, earnedAt]) =>
+        this.prisma.badgeAward.upsert({
+          where: {
+            userId_badgeId: { userId, badgeId },
+          },
+          create: { userId, badgeId, earnedAt },
+          update: { earnedAt },
+        }),
+      ),
+    );
+
+    return this.listForUser(userId);
+  }
+}

--- a/src/modules/badges/routes/badges.routes.ts
+++ b/src/modules/badges/routes/badges.routes.ts
@@ -1,0 +1,26 @@
+import { Router } from "express";
+
+import { createBadgesController } from "../controllers/badges.controller";
+
+export function createBadgesRoutes(
+  controller: ReturnType<typeof createBadgesController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.get("/api/me/badges", options.requireAuth, (req, res) => {
+    void controller.list(req, res);
+  });
+
+  router.post("/api/me/badges", options.requireAuth, (req, res) => {
+    void controller.recompute(req, res);
+  });
+
+  return router;
+}

--- a/src/modules/badges/services/badges.service.ts
+++ b/src/modules/badges/services/badges.service.ts
@@ -1,0 +1,108 @@
+import { DomainError } from "../../../lib/domain-error";
+import { FriendshipRepository } from "../../friends/repositories/friendship.repository";
+import { GolfRoundRepository } from "../../golf-round/repositories/golf-round.repository";
+import { Match } from "../../match/entities/match";
+import { MatchRepository } from "../../match/repositories/match.repository";
+import type { ServerBadgeId } from "../catalog";
+import {
+  BadgeEvidence,
+  EarnedBadge,
+  evaluateServerBadges,
+} from "../evaluate";
+import { BadgeAwardRepository } from "../repositories/badge-award.repository";
+
+export type PublicBadge = {
+  id: ServerBadgeId;
+  earnedAt: string;
+};
+
+export type BadgesSnapshot = {
+  badges: PublicBadge[];
+};
+
+function toPublic(badges: EarnedBadge[]): PublicBadge[] {
+  return badges.map((badge) => ({
+    id: badge.id,
+    earnedAt: badge.earnedAt,
+  }));
+}
+
+function playerWonMatch(match: Match, userId: string): boolean | null {
+  const player = match.pairings.playerOnTeam(userId);
+  const winner = match.winner;
+  if (!player || !winner) return null;
+  return player.slot.team.equals(winner);
+}
+
+export class EvaluateUserBadges {
+  constructor(
+    private readonly matches: MatchRepository,
+    private readonly golfRounds: GolfRoundRepository,
+    private readonly friendships: FriendshipRepository,
+  ) {}
+
+  async collectEvidence(userId: string): Promise<BadgeEvidence> {
+    const [lockedMatches, lockedGolf, friendshipRows] = await Promise.all([
+      this.matches.listLockedByPlayerUserId(userId),
+      this.golfRounds.listLockedByPlayerUserId(userId),
+      this.friendships.listForUser(userId),
+    ]);
+
+    return {
+      padelResults: lockedMatches.map((match) => ({
+        lockedAt: (match.lockedAt ?? match.startsAt.value).toISOString(),
+        won: playerWonMatch(match, userId),
+      })),
+      golfLockedAt: lockedGolf.map((round) =>
+        (round.lockedAt ?? round.startsAt.value).toISOString(),
+      ),
+      friendSince: friendshipRows
+        .filter((row) => row.status === "accepted")
+        .map((row) => row.updatedAt.toISOString()),
+    };
+  }
+
+  async execute(userIdRaw: string): Promise<BadgesSnapshot> {
+    const userId = userIdRaw.trim();
+    if (!userId) {
+      throw new DomainError("userId is required");
+    }
+
+    const evidence = await this.collectEvidence(userId);
+    return { badges: toPublic(evaluateServerBadges(evidence)) };
+  }
+}
+
+export class ListBadges {
+  constructor(private readonly evaluate: EvaluateUserBadges) {}
+
+  async execute(input: { userId: string }): Promise<BadgesSnapshot> {
+    return this.evaluate.execute(input.userId);
+  }
+}
+
+export class RecomputeBadges {
+  constructor(
+    private readonly evaluate: EvaluateUserBadges,
+    private readonly awards: BadgeAwardRepository,
+  ) {}
+
+  async execute(input: { userId: string }): Promise<BadgesSnapshot> {
+    const userId = input.userId.trim();
+    if (!userId) {
+      throw new DomainError("userId is required");
+    }
+
+    const snapshot = await this.evaluate.execute(userId);
+    await this.awards.upsertAwards(
+      userId,
+      snapshot.badges.map((badge) => ({
+        userId,
+        badgeId: badge.id,
+        earnedAt: new Date(badge.earnedAt),
+      })),
+    );
+
+    return snapshot;
+  }
+}


### PR DESCRIPTION
## Summary

Adds server-evaluated badge unlocks for authenticated users via `GET` / `POST /api/me/badges`.

## Behavior

- **GET `/api/me/badges`** — evaluates badges from session-owned evidence: locked padel matches, locked golf rounds, and accepted friendships. Returns `{ badges: [{ id, earnedAt }] }`.
- **POST `/api/me/badges`** — accepts `{}` only; recomputes the same server evaluation and persists awards (`BadgeAward`, earliest `earnedAt` wins).
- **Rejects client grants** — request bodies with `earnedIds` / `badgeIds` / `badges` / `ids` (or any other keys) return `400`. Clients cannot self-award.
- **`whatsapp_share` stays device-local** — the server never awards it; that unlock remains client-side until a share-action API exists.

## Implementation notes

- Prisma `BadgeAward` model + migration
- Pure `evaluateServerBadges` (catalog-ordered) with unit + HTTP coverage
- Module wiring in `createApp` (match / golf / friends repositories)

Closes the Railway half of leaguesports/landing-page#62.