### PR TITLE
Harden badge evidence: session-owned locks + GET persist merge

### DIFF
--- a/prisma/migrations/20260905101500_lock_attributed_to_session/migration.sql
+++ b/prisma/migrations/20260905101500_lock_attributed_to_session/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "Match" ADD COLUMN "lockedByUserId" TEXT;
+
+-- AlterTable
+ALTER TABLE "GolfRound" ADD COLUMN "lockedByUserId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Match_lockedByUserId_idx" ON "Match"("lockedByUserId");
+
+-- CreateIndex
+CREATE INDEX "GolfRound_lockedByUserId_idx" ON "GolfRound"("lockedByUserId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,12 +133,14 @@ model Match {
   servingTeam MatchTeam?
   winnerTeam  MatchTeam?
   lockedAt    DateTime?
+  lockedByUserId String?
   score       Json?
   createdAt   DateTime      @default(now())
   players     MatchPlayer[]
 
   @@index([venueCmsId])
   @@index([status, startsAt])
+  @@index([lockedByUserId])
 }
 
 model MatchPlayer {
@@ -171,11 +173,13 @@ model GolfRound {
   course       Json
   score        Json?
   lockedAt     DateTime?
+  lockedByUserId String?
   createdAt    DateTime        @default(now())
   players      GolfRoundPlayer[]
 
   @@index([venueCmsId])
   @@index([status, startsAt])
+  @@index([lockedByUserId])
 }
 
 model GolfRoundPlayer {

--- a/src/modules/badges/controllers/badges.http.test.ts
+++ b/src/modules/badges/controllers/badges.http.test.ts
@@ -123,6 +123,7 @@ describe("badges HTTP", () => {
       }),
       Team.A,
       new Date("2026-09-01T11:00:00.000Z"),
+      "user-1",
     );
     await matches.create(match);
 
@@ -139,16 +140,23 @@ describe("badges HTTP", () => {
     });
   });
 
-  test("GET merges persisted awards with live evaluation", async () => {
-    const token = jwt.sign({ userId: "user-1" }, config.JWT_SECRET);
+  test("GET uses earlier persisted earnedAt only for ids that still evaluate", async () => {
+    const pending = await friendships.createPending("user-1", "user-2");
+    await friendships.accept(pending.id);
     await awards.upsertAwards("user-1", [
       {
         userId: "user-1",
         badgeId: "first_friend",
         earnedAt: new Date("2026-08-01T09:00:00.000Z"),
       },
+      {
+        userId: "user-1",
+        badgeId: "first_lock",
+        earnedAt: new Date("2026-07-01T09:00:00.000Z"),
+      },
     ]);
 
+    const token = jwt.sign({ userId: "user-1" }, config.JWT_SECRET);
     const res = await fetch(`${server.url}/api/me/badges`, {
       headers: { Cookie: `token=${token}` },
     });
@@ -158,6 +166,39 @@ describe("badges HTTP", () => {
         { id: "first_friend", earnedAt: "2026-08-01T09:00:00.000Z" },
       ],
     });
+  });
+
+  test("GET ignores planted locks that were not session-attributed", async () => {
+    const match = Match.create({
+      venueCmsId: CmsId.from("sanity-court-1"),
+      startsAt: StartsAt.from("2026-09-01T10:00:00.000Z"),
+      ruleset: Ruleset.from("golden_point"),
+      pairings: {
+        teamA: [
+          { displayName: "Alex", isGuest: false, userId: "user-1" },
+          { displayName: "Sam", isGuest: true, userId: null },
+        ],
+        teamB: [
+          { displayName: "Jordan", isGuest: true, userId: null },
+          { displayName: "Riley", isGuest: true, userId: null },
+        ],
+      },
+    });
+    match.lock(
+      MatchScore.from({
+        sets: [{ gamesA: 6, gamesB: 4, tieBreak: null, winner: "A" }],
+      }),
+      Team.A,
+      new Date("2026-09-01T11:00:00.000Z"),
+    );
+    await matches.create(match);
+
+    const token = jwt.sign({ userId: "user-1" }, config.JWT_SECRET);
+    const res = await fetch(`${server.url}/api/me/badges`, {
+      headers: { Cookie: `token=${token}` },
+    });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ badges: [] });
   });
 
   test("POST rejects client earnedIds and accepts empty recompute", async () => {

--- a/src/modules/badges/controllers/badges.http.test.ts
+++ b/src/modules/badges/controllers/badges.http.test.ts
@@ -139,6 +139,27 @@ describe("badges HTTP", () => {
     });
   });
 
+  test("GET merges persisted awards with live evaluation", async () => {
+    const token = jwt.sign({ userId: "user-1" }, config.JWT_SECRET);
+    await awards.upsertAwards("user-1", [
+      {
+        userId: "user-1",
+        badgeId: "first_friend",
+        earnedAt: new Date("2026-08-01T09:00:00.000Z"),
+      },
+    ]);
+
+    const res = await fetch(`${server.url}/api/me/badges`, {
+      headers: { Cookie: `token=${token}` },
+    });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      badges: [
+        { id: "first_friend", earnedAt: "2026-08-01T09:00:00.000Z" },
+      ],
+    });
+  });
+
   test("POST rejects client earnedIds and accepts empty recompute", async () => {
     const token = jwt.sign({ userId: "user-1" }, config.JWT_SECRET);
 

--- a/src/modules/badges/index.ts
+++ b/src/modules/badges/index.ts
@@ -54,7 +54,7 @@ export function createBadgesModule({
   );
 
   const controller = createBadgesController({
-    listBadges: new ListBadges(evaluate),
+    listBadges: new ListBadges(evaluate, badgeAwardRepository),
     recomputeBadges: new RecomputeBadges(evaluate, badgeAwardRepository),
     tryGetSessionUserId,
   });

--- a/src/modules/badges/services/badges.service.test.ts
+++ b/src/modules/badges/services/badges.service.test.ts
@@ -1,0 +1,38 @@
+import { mergeBadgeSnapshots } from "./badges.service";
+import type { BadgeAwardRecord } from "../repositories/badge-award.repository";
+
+describe("mergeBadgeSnapshots", () => {
+  test("keeps live membership and uses earlier persisted earnedAt", () => {
+    const persisted: BadgeAwardRecord[] = [
+      {
+        userId: "user-1",
+        badgeId: "first_lock",
+        earnedAt: new Date("2026-08-01T09:00:00.000Z"),
+      },
+      {
+        userId: "user-1",
+        badgeId: "first_friend",
+        earnedAt: new Date("2026-07-01T09:00:00.000Z"),
+      },
+    ];
+
+    expect(
+      mergeBadgeSnapshots(
+        [{ id: "first_lock", earnedAt: "2026-09-01T11:00:00.000Z" }],
+        persisted,
+      ),
+    ).toEqual([{ id: "first_lock", earnedAt: "2026-08-01T09:00:00.000Z" }]);
+  });
+
+  test("drops persisted ids that are not in live evaluation", () => {
+    const persisted: BadgeAwardRecord[] = [
+      {
+        userId: "user-1",
+        badgeId: "first_friend",
+        earnedAt: new Date("2026-08-01T09:00:00.000Z"),
+      },
+    ];
+
+    expect(mergeBadgeSnapshots([], persisted)).toEqual([]);
+  });
+});

--- a/src/modules/badges/services/badges.service.ts
+++ b/src/modules/badges/services/badges.service.ts
@@ -1,15 +1,17 @@
 import { DomainError } from "../../../lib/domain-error";
 import { FriendshipRepository } from "../../friends/repositories/friendship.repository";
 import { GolfRoundRepository } from "../../golf-round/repositories/golf-round.repository";
-import { Match } from "../../match/entities/match";
 import { MatchRepository } from "../../match/repositories/match.repository";
-import type { ServerBadgeId } from "../catalog";
+import { SERVER_BADGE_IDS, type ServerBadgeId } from "../catalog";
 import {
   BadgeEvidence,
   EarnedBadge,
   evaluateServerBadges,
 } from "../evaluate";
-import { BadgeAwardRepository } from "../repositories/badge-award.repository";
+import {
+  BadgeAwardRecord,
+  BadgeAwardRepository,
+} from "../repositories/badge-award.repository";
 
 export type PublicBadge = {
   id: ServerBadgeId;
@@ -27,11 +29,33 @@ function toPublic(badges: EarnedBadge[]): PublicBadge[] {
   }));
 }
 
-function playerWonMatch(match: Match, userId: string): boolean | null {
-  const player = match.pairings.playerOnTeam(userId);
-  const winner = match.winner;
-  if (!player || !winner) return null;
-  return player.slot.team.equals(winner);
+function earliestIso(a: string, b: string): string {
+  return new Date(a).getTime() <= new Date(b).getTime() ? a : b;
+}
+
+/** Union live evaluation with persisted awards; earliest earnedAt wins. */
+export function mergeBadgeSnapshots(
+  live: PublicBadge[],
+  persisted: BadgeAwardRecord[],
+): PublicBadge[] {
+  const byId = new Map<ServerBadgeId, string>();
+
+  for (const award of persisted) {
+    byId.set(award.badgeId, award.earnedAt.toISOString());
+  }
+
+  for (const badge of live) {
+    const existing = byId.get(badge.id);
+    byId.set(
+      badge.id,
+      existing ? earliestIso(existing, badge.earnedAt) : badge.earnedAt,
+    );
+  }
+
+  return SERVER_BADGE_IDS.filter((id) => byId.has(id)).map((id) => ({
+    id,
+    earnedAt: byId.get(id)!,
+  }));
 }
 
 export class EvaluateUserBadges {
@@ -42,20 +66,18 @@ export class EvaluateUserBadges {
   ) {}
 
   async collectEvidence(userId: string): Promise<BadgeEvidence> {
-    const [lockedMatches, lockedGolf, friendshipRows] = await Promise.all([
-      this.matches.listLockedByPlayerUserId(userId),
-      this.golfRounds.listLockedByPlayerUserId(userId),
+    const [padelRows, golfTimes, friendshipRows] = await Promise.all([
+      this.matches.listLockedPadelResultsForBadges(userId),
+      this.golfRounds.listLockedAtForBadges(userId),
       this.friendships.listForUser(userId),
     ]);
 
     return {
-      padelResults: lockedMatches.map((match) => ({
-        lockedAt: (match.lockedAt ?? match.startsAt.value).toISOString(),
-        won: playerWonMatch(match, userId),
+      padelResults: padelRows.map((row) => ({
+        lockedAt: row.lockedAt.toISOString(),
+        won: row.won,
       })),
-      golfLockedAt: lockedGolf.map((round) =>
-        (round.lockedAt ?? round.startsAt.value).toISOString(),
-      ),
+      golfLockedAt: golfTimes.map((lockedAt) => lockedAt.toISOString()),
       friendSince: friendshipRows
         .filter((row) => row.status === "accepted")
         .map((row) => row.updatedAt.toISOString()),
@@ -74,10 +96,17 @@ export class EvaluateUserBadges {
 }
 
 export class ListBadges {
-  constructor(private readonly evaluate: EvaluateUserBadges) {}
+  constructor(
+    private readonly evaluate: EvaluateUserBadges,
+    private readonly awards: BadgeAwardRepository,
+  ) {}
 
   async execute(input: { userId: string }): Promise<BadgesSnapshot> {
-    return this.evaluate.execute(input.userId);
+    const [live, persisted] = await Promise.all([
+      this.evaluate.execute(input.userId),
+      this.awards.listForUser(input.userId),
+    ]);
+    return { badges: mergeBadgeSnapshots(live.badges, persisted) };
   }
 }
 
@@ -93,16 +122,16 @@ export class RecomputeBadges {
       throw new DomainError("userId is required");
     }
 
-    const snapshot = await this.evaluate.execute(userId);
+    const live = await this.evaluate.execute(userId);
     await this.awards.upsertAwards(
       userId,
-      snapshot.badges.map((badge) => ({
+      live.badges.map((badge) => ({
         userId,
         badgeId: badge.id,
         earnedAt: new Date(badge.earnedAt),
       })),
     );
-
-    return snapshot;
+    const persisted = await this.awards.listForUser(userId);
+    return { badges: mergeBadgeSnapshots(live.badges, persisted) };
   }
 }

--- a/src/modules/badges/services/badges.service.ts
+++ b/src/modules/badges/services/badges.service.ts
@@ -33,29 +33,29 @@ function earliestIso(a: string, b: string): string {
   return new Date(a).getTime() <= new Date(b).getTime() ? a : b;
 }
 
-/** Union live evaluation with persisted awards; earliest earnedAt wins. */
+/**
+ * Live evaluation is authoritative for membership.
+ * Persist only supplies an earlier earnedAt for ids that still evaluate (∩).
+ */
 export function mergeBadgeSnapshots(
   live: PublicBadge[],
   persisted: BadgeAwardRecord[],
 ): PublicBadge[] {
-  const byId = new Map<ServerBadgeId, string>();
+  const liveAt = new Map(live.map((badge) => [badge.id, badge.earnedAt]));
+  const persistedAt = new Map<ServerBadgeId, string>();
 
   for (const award of persisted) {
-    byId.set(award.badgeId, award.earnedAt.toISOString());
+    persistedAt.set(award.badgeId, award.earnedAt.toISOString());
   }
 
-  for (const badge of live) {
-    const existing = byId.get(badge.id);
-    byId.set(
-      badge.id,
-      existing ? earliestIso(existing, badge.earnedAt) : badge.earnedAt,
-    );
-  }
-
-  return SERVER_BADGE_IDS.filter((id) => byId.has(id)).map((id) => ({
-    id,
-    earnedAt: byId.get(id)!,
-  }));
+  return SERVER_BADGE_IDS.filter((id) => liveAt.has(id)).map((id) => {
+    const liveIso = liveAt.get(id)!;
+    const persistedIso = persistedAt.get(id);
+    return {
+      id,
+      earnedAt: persistedIso ? earliestIso(persistedIso, liveIso) : liveIso,
+    };
+  });
 }
 
 export class EvaluateUserBadges {

--- a/src/modules/golf-round/controllers/golf-round.controller.ts
+++ b/src/modules/golf-round/controllers/golf-round.controller.ts
@@ -121,6 +121,7 @@ export function createGolfRoundController(deps: {
         const round = await deps.lockGolfRound.execute({
           roundId: id,
           score: body.score,
+          lockedByUserId: sessionUserId,
         });
 
         if (!round) {

--- a/src/modules/golf-round/controllers/golf-round.controller.ts
+++ b/src/modules/golf-round/controllers/golf-round.controller.ts
@@ -12,7 +12,7 @@ import {
   ListLockedGolfRoundsByVenue,
 } from "../services/list-locked-golf-rounds.service";
 import { LockGolfRound } from "../services/lock-golf-round.service";
-import { bindSessionUserIdToPlayers } from "../utils/bind-session-user";
+import { sanitizePlayersForCreate } from "../utils/bind-session-user";
 
 const playerSchema = z.object({
   slot: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
@@ -76,9 +76,7 @@ export function createGolfRoundController(deps: {
       try {
         const body = z.parse(createGolfRoundBodySchema, req.body ?? {});
         const sessionUserId = deps.tryGetSessionUserId(req);
-        const players = sessionUserId
-          ? bindSessionUserIdToPlayers(body.players, sessionUserId)
-          : body.players;
+        const players = sanitizePlayersForCreate(body.players, sessionUserId);
         const round = await deps.createGolfRound.execute({ ...body, players });
         return res.status(201).json(round.toSnapshot());
       } catch (error) {
@@ -103,8 +101,23 @@ export function createGolfRoundController(deps: {
 
     async lock(req: Request, res: Response) {
       try {
+        const sessionUserId = deps.tryGetSessionUserId(req);
+        if (!sessionUserId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
         const { id } = z.parse(golfRoundIdParamSchema, req.params);
         const body = z.parse(lockGolfRoundBodySchema, req.body ?? {});
+        const existing = await deps.getGolfRoundById.execute(id);
+        if (!existing) {
+          return res.status(404).json({ error: "Golf round not found" });
+        }
+        if (!existing.hasPlayerUserId(sessionUserId)) {
+          return res.status(403).json({
+            error: "Only a seated player can lock this golf round",
+          });
+        }
+
         const round = await deps.lockGolfRound.execute({
           roundId: id,
           score: body.score,

--- a/src/modules/golf-round/controllers/golf-rounds.http.test.ts
+++ b/src/modules/golf-round/controllers/golf-rounds.http.test.ts
@@ -151,8 +151,8 @@ describe("golf rounds HTTP", () => {
         {
           slot: 3,
           displayName: "Riley",
-          isGuest: false,
-          userId: "user-riley",
+          isGuest: true,
+          userId: null,
         },
       ],
     });
@@ -203,7 +203,10 @@ describe("golf rounds HTTP", () => {
       `${server.url}/api/golf-rounds/${createdBody.id}/lock`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: sessionCookie("user-riley"),
+        },
         body: JSON.stringify({ score: scoreA }),
       },
     );
@@ -249,7 +252,7 @@ describe("golf rounds HTTP", () => {
     expect(blankVenue.status).toBe(400);
   });
 
-  test("lock is 200, idempotent for the same score, 409 on conflict", async () => {
+  test("lock requires a seated session player", async () => {
     const created = await fetch(`${server.url}/api/golf-rounds`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -257,9 +260,48 @@ describe("golf rounds HTTP", () => {
     });
     const { id } = (await created.json()) as { id: string };
 
-    const locked = await fetch(`${server.url}/api/golf-rounds/${id}/lock`, {
+    const unauth = await fetch(`${server.url}/api/golf-rounds/${id}/lock`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score: scoreA }),
+    });
+    expect(unauth.status).toBe(401);
+
+    const notSeated = await fetch(`${server.url}/api/golf-rounds/${id}/lock`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({ score: scoreA }),
+    });
+    expect(notSeated.status).toBe(403);
+  });
+
+  test("lock is 200, idempotent for the same score, 409 on conflict", async () => {
+    const created = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+          { slot: 3, displayName: "Riley", isGuest: false, userId: null },
+        ],
+      }),
+    });
+    const { id } = (await created.json()) as { id: string };
+
+    const locked = await fetch(`${server.url}/api/golf-rounds/${id}/lock`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA }),
     });
     const lockedBody = (await locked.json()) as {
@@ -273,14 +315,20 @@ describe("golf rounds HTTP", () => {
 
     const again = await fetch(`${server.url}/api/golf-rounds/${id}/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA }),
     });
     expect(again.status).toBe(200);
 
     const conflict = await fetch(`${server.url}/api/golf-rounds/${id}/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({
         score: scoreForPlayers(
           courseHoles9.map((hole) => hole.number),
@@ -293,7 +341,10 @@ describe("golf rounds HTTP", () => {
 
     const missing = await fetch(`${server.url}/api/golf-rounds/missing/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA }),
     });
     expect(missing.status).toBe(404);
@@ -302,18 +353,34 @@ describe("golf rounds HTTP", () => {
   test("history lists only locked rounds, newest first, with venue details", async () => {
     const older = await fetch(`${server.url}/api/golf-rounds`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({
         ...createBody,
         startsAt: "2026-08-01T10:00:00.000Z",
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+          { slot: 3, displayName: "Riley", isGuest: false, userId: null },
+        ],
       }),
     });
     const newer = await fetch(`${server.url}/api/golf-rounds`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({
         ...createBody,
         startsAt: "2026-08-20T10:00:00.000Z",
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+          { slot: 3, displayName: "Riley", isGuest: false, userId: null },
+        ],
       }),
     });
     const olderBody = (await older.json()) as { id: string };
@@ -321,12 +388,18 @@ describe("golf rounds HTTP", () => {
 
     await fetch(`${server.url}/api/golf-rounds/${olderBody.id}/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA }),
     });
     await fetch(`${server.url}/api/golf-rounds/${newerBody.id}/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA }),
     });
 
@@ -373,8 +446,18 @@ describe("golf rounds HTTP", () => {
   test("lock maps persistence failures instead of returning 200", async () => {
     const created = await fetch(`${server.url}/api/golf-rounds`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(createBody),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+          { slot: 3, displayName: "Riley", isGuest: false, userId: null },
+        ],
+      }),
     });
     const { id } = (await created.json()) as { id: string };
 
@@ -392,13 +475,17 @@ describe("golf rounds HTTP", () => {
           rounds.listLockedByPlayerUserId(userId),
         listLockedByVenueCmsId: (cmsId) =>
           rounds.listLockedByVenueCmsId(cmsId),
+        listLockedAtForBadges: (userId) => rounds.listLockedAtForBadges(userId),
       },
     });
     server = await listen(app);
 
     const response = await fetch(`${server.url}/api/golf-rounds/${id}/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA }),
     });
 

--- a/src/modules/golf-round/entities/golf-round.ts
+++ b/src/modules/golf-round/entities/golf-round.ts
@@ -50,6 +50,7 @@ export class GolfRound {
     readonly players: readonly GolfPlayer[],
     private scoreValue: GolfScore | null,
     private lockedAtValue: Date | null,
+    private lockedByUserIdValue: string | null,
   ) {}
 
   static create(props: CreateGolfRoundProps): GolfRound {
@@ -74,6 +75,7 @@ export class GolfRound {
       players,
       null,
       null,
+      null,
     );
   }
 
@@ -89,6 +91,7 @@ export class GolfRound {
     players: GolfPlayer[];
     score: GolfScore | null;
     lockedAt: Date | null;
+    lockedByUserId?: string | null;
   }): GolfRound {
     return new GolfRound(
       props.id,
@@ -102,6 +105,7 @@ export class GolfRound {
       props.players,
       props.score,
       props.lockedAt,
+      normalizeLockedByUserId(props.lockedByUserId),
     );
   }
 
@@ -117,6 +121,10 @@ export class GolfRound {
     return this.lockedAtValue;
   }
 
+  get lockedByUserId(): string | null {
+    return this.lockedByUserIdValue;
+  }
+
   get isLocked(): boolean {
     return this.statusValue === "locked";
   }
@@ -129,7 +137,11 @@ export class GolfRound {
     return this.players.some((player) => player.hasUserId(userId));
   }
 
-  lock(score: GolfScore, lockedAt = new Date()): void {
+  lock(
+    score: GolfScore,
+    lockedAt = new Date(),
+    lockedByUserId: string | null = null,
+  ): void {
     if (this.statusValue === "locked") {
       if (this.hasSameScore(score)) {
         return;
@@ -141,6 +153,7 @@ export class GolfRound {
     this.statusValue = "locked";
     this.scoreValue = score;
     this.lockedAtValue = lockedAt;
+    this.lockedByUserIdValue = normalizeLockedByUserId(lockedByUserId);
   }
 
   hasSameScore(score: GolfScore): boolean {
@@ -177,6 +190,14 @@ export class GolfRound {
       lockedAt: this.lockedAtValue?.toISOString() ?? null,
     };
   }
+}
+
+function normalizeLockedByUserId(userId: string | null | undefined): string | null {
+  if (typeof userId !== "string") {
+    return null;
+  }
+  const value = userId.trim();
+  return value.length === 0 ? null : value;
 }
 
 function parseHolesPlayed(raw: unknown): number {

--- a/src/modules/golf-round/repositories/golf-round.repository.ts
+++ b/src/modules/golf-round/repositories/golf-round.repository.ts
@@ -7,6 +7,6 @@ export interface GolfRoundRepository {
   persistLock(round: GolfRound): Promise<GolfRound>;
   listLockedByPlayerUserId(userId: string): Promise<GolfRound[]>;
   listLockedByVenueCmsId(cmsId: CmsId): Promise<GolfRound[]>;
-  /** Locked timestamps for badge evaluation (no full score hydration). */
+  /** Session-attributed lock timestamps for badge evaluation. */
   listLockedAtForBadges(userId: string): Promise<Date[]>;
 }

--- a/src/modules/golf-round/repositories/golf-round.repository.ts
+++ b/src/modules/golf-round/repositories/golf-round.repository.ts
@@ -7,4 +7,6 @@ export interface GolfRoundRepository {
   persistLock(round: GolfRound): Promise<GolfRound>;
   listLockedByPlayerUserId(userId: string): Promise<GolfRound[]>;
   listLockedByVenueCmsId(cmsId: CmsId): Promise<GolfRound[]>;
+  /** Locked timestamps for badge evaluation (no full score hydration). */
+  listLockedAtForBadges(userId: string): Promise<Date[]>;
 }

--- a/src/modules/golf-round/repositories/in-memory-golf-round.repository.ts
+++ b/src/modules/golf-round/repositories/in-memory-golf-round.repository.ts
@@ -48,7 +48,9 @@ export class InMemoryGolfRoundRepository implements GolfRoundRepository {
 
   async listLockedAtForBadges(userId: string): Promise<Date[]> {
     const rounds = await this.listLockedByPlayerUserId(userId);
-    return rounds.map((round) => round.lockedAt ?? round.startsAt.value);
+    return rounds
+      .filter((round) => round.lockedByUserId === userId)
+      .map((round) => round.lockedAt ?? round.startsAt.value);
   }
 
   private lockedNewestFirst(): GolfRound[] {
@@ -77,5 +79,6 @@ function clone(round: GolfRound | null): GolfRound | null {
     players: [...round.players],
     score: round.score,
     lockedAt: round.lockedAt,
+    lockedByUserId: round.lockedByUserId,
   });
 }

--- a/src/modules/golf-round/repositories/in-memory-golf-round.repository.ts
+++ b/src/modules/golf-round/repositories/in-memory-golf-round.repository.ts
@@ -45,6 +45,12 @@ export class InMemoryGolfRoundRepository implements GolfRoundRepository {
     );
   }
 
+
+  async listLockedAtForBadges(userId: string): Promise<Date[]> {
+    const rounds = await this.listLockedByPlayerUserId(userId);
+    return rounds.map((round) => round.lockedAt ?? round.startsAt.value);
+  }
+
   private lockedNewestFirst(): GolfRound[] {
     return [...this.byId.values()]
       .filter((round) => round.isLocked)

--- a/src/modules/golf-round/repositories/prisma-golf-round.repository.ts
+++ b/src/modules/golf-round/repositories/prisma-golf-round.repository.ts
@@ -158,6 +158,24 @@ export class PrismaGolfRoundRepository implements GolfRoundRepository {
       throw wrapPersistenceError(error, "Unable to load golf round");
     }
   }
+
+  async listLockedAtForBadges(userId: string): Promise<Date[]> {
+    try {
+      const rows = await this.prisma.golfRound.findMany({
+        where: {
+          status: "locked",
+          players: { some: { userId } },
+        },
+        select: {
+          lockedAt: true,
+          startsAt: true,
+        },
+      });
+      return rows.map((row) => row.lockedAt ?? row.startsAt);
+    } catch (error) {
+      throw wrapPersistenceError(error, "Unable to load golf round");
+    }
+  }
 }
 
 function toDomain(row: GolfRoundRow): GolfRound {

--- a/src/modules/golf-round/repositories/prisma-golf-round.repository.ts
+++ b/src/modules/golf-round/repositories/prisma-golf-round.repository.ts
@@ -28,6 +28,7 @@ type GolfRoundRow = {
   course: Prisma.JsonValue;
   score: Prisma.JsonValue | null;
   lockedAt: Date | null;
+  lockedByUserId: string | null;
   players: GolfRoundPlayerRow[];
 };
 
@@ -91,6 +92,7 @@ export class PrismaGolfRoundRepository implements GolfRoundRepository {
         data: {
           status: "locked",
           lockedAt: round.lockedAt,
+          lockedByUserId: round.lockedByUserId,
           score: snapshot.score === null ? Prisma.JsonNull : snapshot.score,
         },
       });
@@ -164,7 +166,7 @@ export class PrismaGolfRoundRepository implements GolfRoundRepository {
       const rows = await this.prisma.golfRound.findMany({
         where: {
           status: "locked",
-          players: { some: { userId } },
+          lockedByUserId: userId,
         },
         select: {
           lockedAt: true,
@@ -209,6 +211,7 @@ function toDomain(row: GolfRoundRow): GolfRound {
         })
       : null,
     lockedAt: row.lockedAt,
+    lockedByUserId: row.lockedByUserId,
   });
 }
 

--- a/src/modules/golf-round/services/lock-golf-round.service.ts
+++ b/src/modules/golf-round/services/lock-golf-round.service.ts
@@ -5,6 +5,7 @@ import { GolfRoundRepository } from "../repositories/golf-round.repository";
 export type LockGolfRoundInput = {
   roundId: string;
   score: unknown;
+  lockedByUserId: string;
 };
 
 export class LockGolfRound {
@@ -20,7 +21,7 @@ export class LockGolfRound {
       holeNumbers: round.course.holeNumbers(),
       playerSlots: round.playerSlots(),
     });
-    round.lock(score);
+    round.lock(score, new Date(), input.lockedByUserId);
     return this.rounds.persistLock(round);
   }
 }

--- a/src/modules/golf-round/utils/bind-session-user.ts
+++ b/src/modules/golf-round/utils/bind-session-user.ts
@@ -16,6 +16,27 @@ function withSessionUser(
   return { ...player, userId: sessionUserId, isGuest: false };
 }
 
+function stripNonSessionUserIds(
+  players: GolfPlayerInput[],
+  sessionUserId: string | null,
+): GolfPlayerInput[] {
+  return players.map((player) => {
+    const id = normalizedUserId(player.userId);
+    if (sessionUserId && id === sessionUserId) {
+      return withSessionUser(player, sessionUserId);
+    }
+    if (id !== null) {
+      return {
+        ...player,
+        displayName: player.displayName,
+        isGuest: true,
+        userId: null,
+      };
+    }
+    return { ...player, userId: null };
+  });
+}
+
 export function bindSessionUserIdToPlayers(
   players: GolfPlayerInput[],
   sessionUserId: string,
@@ -46,4 +67,16 @@ export function bindSessionUserIdToPlayers(
   }
 
   return bound;
+}
+
+/** Sanitize create payload: only the session user may be stamped as a userId. */
+export function sanitizePlayersForCreate(
+  players: GolfPlayerInput[],
+  sessionUserId: string | null,
+): GolfPlayerInput[] {
+  const stripped = stripNonSessionUserIds(players, sessionUserId);
+  if (!sessionUserId) {
+    return stripped;
+  }
+  return bindSessionUserIdToPlayers(stripped, sessionUserId);
 }

--- a/src/modules/match/controllers/match.controller.ts
+++ b/src/modules/match/controllers/match.controller.ts
@@ -124,6 +124,7 @@ export function createMatchController(deps: {
           matchId: id,
           score: body.score,
           winner: body.winner,
+          lockedByUserId: sessionUserId,
         });
 
         if (!match) {

--- a/src/modules/match/controllers/match.controller.ts
+++ b/src/modules/match/controllers/match.controller.ts
@@ -12,7 +12,7 @@ import { DomainError } from "../../../lib/domain-error";
 import { MatchLockConflictError } from "../entities/match-lock-conflict-error";
 import { MatchVenueNotFoundError } from "../entities/match-venue-not-found-error";
 import { MatchPersistenceError } from "../entities/match-persistence-error";
-import { bindSessionUserIdToPairings } from "../utils/bind-session-user";
+import { sanitizePairingsForCreate } from "../utils/bind-session-user";
 
 const playerSchema = z.object({
   userId: z.string().nullable().optional(),
@@ -78,9 +78,7 @@ export function createMatchController(deps: {
       try {
         const body = z.parse(createMatchBodySchema, req.body ?? {});
         const sessionUserId = deps.tryGetSessionUserId(req);
-        const pairings = sessionUserId
-          ? bindSessionUserIdToPairings(body.pairings, sessionUserId)
-          : body.pairings;
+        const pairings = sanitizePairingsForCreate(body.pairings, sessionUserId);
         const match = await deps.createMatch.execute({ ...body, pairings });
         return res.status(201).json(match.toSnapshot());
       } catch (error) {
@@ -105,8 +103,23 @@ export function createMatchController(deps: {
 
     async lock(req: Request, res: Response) {
       try {
+        const sessionUserId = deps.tryGetSessionUserId(req);
+        if (!sessionUserId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
         const { id } = z.parse(matchIdParamSchema, req.params);
         const body = z.parse(lockMatchBodySchema, req.body ?? {});
+        const existing = await deps.getMatchById.execute(id);
+        if (!existing) {
+          return res.status(404).json({ error: "Match not found" });
+        }
+        if (!existing.pairings.playerOnTeam(sessionUserId)) {
+          return res.status(403).json({
+            error: "Only a seated player can lock this match",
+          });
+        }
+
         const match = await deps.lockMatch.execute({
           matchId: id,
           score: body.score,

--- a/src/modules/match/controllers/matches.http.test.ts
+++ b/src/modules/match/controllers/matches.http.test.ts
@@ -129,8 +129,8 @@ describe("matches HTTP", () => {
           {
             slot: "B2",
             displayName: "Riley",
-            isGuest: false,
-            userId: "user-riley",
+            isGuest: true,
+            userId: null,
           },
         ],
       },
@@ -184,7 +184,10 @@ describe("matches HTTP", () => {
 
     const locked = await fetch(`${server.url}/api/matches/${createdBody.id}/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA, winner: "A" }),
     });
     expect(locked.status).toBe(200);
@@ -212,7 +215,7 @@ describe("matches HTTP", () => {
 
     expect(invalid.status).toBe(201);
     expect(invalid.status).not.toBe(401);
-    expect(invalidBody.pairings.teamB[1].userId).toBe("user-riley");
+    expect(invalidBody.pairings.teamB[1].userId).toBeNull();
 
     const guestsOnly = {
       teamA: [
@@ -294,7 +297,7 @@ describe("matches HTTP", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ...createBody, venueCmsId: "no-such-court" }),
     });
-    expect(missingVenue.status).toBe(404);
+    expect(missingVenue.status).toBe(400);
 
     const incomplete = await fetch(`${server.url}/api/matches`, {
       method: "POST",
@@ -314,7 +317,7 @@ describe("matches HTTP", () => {
     expect(blankVenue.status).toBe(400);
   });
 
-  test("lock is 200, idempotent for the same score, 409 on conflict", async () => {
+  test("lock requires a seated session player", async () => {
     const created = await fetch(`${server.url}/api/matches`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -322,9 +325,50 @@ describe("matches HTTP", () => {
     });
     const { id } = (await created.json()) as { id: string };
 
-    const locked = await fetch(`${server.url}/api/matches/${id}/lock`, {
+    const unauth = await fetch(`${server.url}/api/matches/${id}/lock`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ score: scoreA, winner: "A" }),
+    });
+    expect(unauth.status).toBe(401);
+
+    const notSeated = await fetch(`${server.url}/api/matches/${id}/lock`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({ score: scoreA, winner: "A" }),
+    });
+    expect(notSeated.status).toBe(403);
+  });
+
+  test("lock is 200, idempotent for the same score, 409 on conflict", async () => {
+    const created = await fetch(`${server.url}/api/matches`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        pairings: {
+          teamA: pairings.teamA,
+          teamB: [
+            { displayName: "Jordan", isGuest: true, userId: null },
+            { displayName: "Riley", isGuest: false, userId: null },
+          ],
+        },
+      }),
+    });
+    const { id } = (await created.json()) as { id: string };
+
+    const locked = await fetch(`${server.url}/api/matches/${id}/lock`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA, winner: "A" }),
     });
     const lockedBody = (await locked.json()) as {
@@ -340,14 +384,20 @@ describe("matches HTTP", () => {
 
     const again = await fetch(`${server.url}/api/matches/${id}/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA, winner: "A" }),
     });
     expect(again.status).toBe(200);
 
     const conflict = await fetch(`${server.url}/api/matches/${id}/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({
         score: { sets: [{ gamesA: 4, gamesB: 6, winner: "B" }] },
         winner: "B",
@@ -357,7 +407,10 @@ describe("matches HTTP", () => {
 
     const missing = await fetch(`${server.url}/api/matches/missing/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA, winner: "A" }),
     });
     expect(missing.status).toBe(404);
@@ -366,18 +419,38 @@ describe("matches HTTP", () => {
   test("history lists only locked matches, newest first, with venue details", async () => {
     const older = await fetch(`${server.url}/api/matches`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({
         ...createBody,
         startsAt: "2026-08-01T10:00:00.000Z",
+        pairings: {
+          teamA: pairings.teamA,
+          teamB: [
+            { displayName: "Jordan", isGuest: true, userId: null },
+            { displayName: "Riley", isGuest: false, userId: null },
+          ],
+        },
       }),
     });
     const newer = await fetch(`${server.url}/api/matches`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({
         ...createBody,
         startsAt: "2026-08-20T10:00:00.000Z",
+        pairings: {
+          teamA: pairings.teamA,
+          teamB: [
+            { displayName: "Jordan", isGuest: true, userId: null },
+            { displayName: "Riley", isGuest: false, userId: null },
+          ],
+        },
       }),
     });
     const olderBody = (await older.json()) as { id: string };
@@ -385,12 +458,18 @@ describe("matches HTTP", () => {
 
     await fetch(`${server.url}/api/matches/${olderBody.id}/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA, winner: "A" }),
     });
     await fetch(`${server.url}/api/matches/${newerBody.id}/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA, winner: "A" }),
     });
 
@@ -467,8 +546,20 @@ describe("matches HTTP", () => {
   test("lock maps persistence failures instead of returning 200", async () => {
     const created = await fetch(`${server.url}/api/matches`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(createBody),
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        pairings: {
+          teamA: pairings.teamA,
+          teamB: [
+            { displayName: "Jordan", isGuest: true, userId: null },
+            { displayName: "Riley", isGuest: false, userId: null },
+          ],
+        },
+      }),
     });
     const { id } = (await created.json()) as { id: string };
 
@@ -486,13 +577,18 @@ describe("matches HTTP", () => {
           matches.listLockedByPlayerUserId(userId),
         listLockedByVenueCmsId: (cmsId) =>
           matches.listLockedByVenueCmsId(cmsId),
+        listLockedPadelResultsForBadges: (userId) =>
+          matches.listLockedPadelResultsForBadges(userId),
       },
     });
     server = await listen(app);
 
     const response = await fetch(`${server.url}/api/matches/${id}/lock`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
       body: JSON.stringify({ score: scoreA, winner: "A" }),
     });
 

--- a/src/modules/match/controllers/matches.http.test.ts
+++ b/src/modules/match/controllers/matches.http.test.ts
@@ -297,7 +297,7 @@ describe("matches HTTP", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ...createBody, venueCmsId: "no-such-court" }),
     });
-    expect(missingVenue.status).toBe(400);
+    expect(missingVenue.status).toBe(404);
 
     const incomplete = await fetch(`${server.url}/api/matches`, {
       method: "POST",

--- a/src/modules/match/entities/match.test.ts
+++ b/src/modules/match/entities/match.test.ts
@@ -113,8 +113,8 @@ describe(Match, () => {
     const match = createLiveMatch();
     const lockedAt = new Date("2026-08-29T11:00:00.000Z");
 
-    match.lock(MatchScore.from(lockScore), Team.A, lockedAt);
-    match.lock(MatchScore.from(lockScore), Team.A, new Date("2026-08-29T12:00:00.000Z"));
+    match.lock(MatchScore.from(lockScore), Team.A, lockedAt, "user-1");
+    match.lock(MatchScore.from(lockScore), Team.A, new Date("2026-08-29T12:00:00.000Z"), "user-other");
 
     expect(match.toSnapshot()).toMatchObject({
       status: "locked",
@@ -122,6 +122,7 @@ describe(Match, () => {
       lockedAt: "2026-08-29T11:00:00.000Z",
       score: lockScore,
     });
+    expect(match.lockedByUserId).toBe("user-1");
   });
 
   test("lock conflicts when the match is already locked with a different result", () => {

--- a/src/modules/match/entities/match.ts
+++ b/src/modules/match/entities/match.ts
@@ -43,6 +43,7 @@ export class Match {
     private scoreValue: MatchScore | null,
     private winnerValue: Team | null,
     private lockedAtValue: Date | null,
+    private lockedByUserIdValue: string | null,
   ) {}
 
   static create(props: CreateMatchProps): Match {
@@ -54,6 +55,7 @@ export class Match {
       "live",
       props.servingTeam ?? Team.A,
       Pairings.from(props.pairings),
+      null,
       null,
       null,
       null,
@@ -71,6 +73,7 @@ export class Match {
     score: MatchScore | null;
     winner: Team | null;
     lockedAt: Date | null;
+    lockedByUserId?: string | null;
   }): Match {
     return new Match(
       props.id,
@@ -83,6 +86,7 @@ export class Match {
       props.score,
       props.winner,
       props.lockedAt,
+      normalizeLockedByUserId(props.lockedByUserId),
     );
   }
 
@@ -102,11 +106,20 @@ export class Match {
     return this.lockedAtValue;
   }
 
+  get lockedByUserId(): string | null {
+    return this.lockedByUserIdValue;
+  }
+
   get isLocked(): boolean {
     return this.statusValue === "locked";
   }
 
-  lock(score: MatchScore, winner: Team, lockedAt = new Date()): void {
+  lock(
+    score: MatchScore,
+    winner: Team,
+    lockedAt = new Date(),
+    lockedByUserId: string | null = null,
+  ): void {
     if (this.statusValue === "locked") {
       if (this.hasSameResult(score, winner)) {
         return;
@@ -119,6 +132,7 @@ export class Match {
     this.scoreValue = score;
     this.winnerValue = winner;
     this.lockedAtValue = lockedAt;
+    this.lockedByUserIdValue = normalizeLockedByUserId(lockedByUserId);
   }
 
   hasSameResult(score: MatchScore, winner: Team): boolean {
@@ -159,4 +173,12 @@ export class Match {
       lockedAt: this.lockedAtValue?.toISOString() ?? null,
     };
   }
+}
+
+function normalizeLockedByUserId(userId: string | null | undefined): string | null {
+  if (typeof userId !== "string") {
+    return null;
+  }
+  const value = userId.trim();
+  return value.length === 0 ? null : value;
 }

--- a/src/modules/match/repositories/in-memory-match.repository.ts
+++ b/src/modules/match/repositories/in-memory-match.repository.ts
@@ -53,15 +53,20 @@ export class InMemoryMatchRepository implements MatchRepository {
     userId: string,
   ): Promise<LockedPadelBadgeRow[]> {
     const matches = await this.listLockedByPlayerUserId(userId);
-    return matches.map((match) => {
+    return matches.flatMap((match) => {
+      if (match.lockedByUserId !== userId) {
+        return [];
+      }
       const player = match.pairings.playerOnTeam(userId);
       const winner = match.winner;
       const won =
         !player || !winner ? null : player.slot.team.equals(winner);
-      return {
-        lockedAt: match.lockedAt ?? match.startsAt.value,
-        won,
-      };
+      return [
+        {
+          lockedAt: match.lockedAt ?? match.startsAt.value,
+          won,
+        },
+      ];
     });
   }
 
@@ -90,5 +95,6 @@ function clone(match: Match | null): Match | null {
     score: match.score,
     winner: match.winner,
     lockedAt: match.lockedAt,
+    lockedByUserId: match.lockedByUserId,
   });
 }

--- a/src/modules/match/repositories/in-memory-match.repository.ts
+++ b/src/modules/match/repositories/in-memory-match.repository.ts
@@ -1,7 +1,10 @@
 import { CmsId } from "../../venue/entities/cms-id";
 import { Match } from "../entities/match";
 import { MatchLockConflictError } from "../entities/match-lock-conflict-error";
-import { MatchRepository } from "./match.repository";
+import {
+  LockedPadelBadgeRow,
+  MatchRepository,
+} from "./match.repository";
 
 export class InMemoryMatchRepository implements MatchRepository {
   private readonly byId = new Map<string, Match>();
@@ -43,6 +46,23 @@ export class InMemoryMatchRepository implements MatchRepository {
     return this.lockedNewestFirst().filter((match) =>
       match.venueCmsId.equals(cmsId),
     );
+  }
+
+  
+  async listLockedPadelResultsForBadges(
+    userId: string,
+  ): Promise<LockedPadelBadgeRow[]> {
+    const matches = await this.listLockedByPlayerUserId(userId);
+    return matches.map((match) => {
+      const player = match.pairings.playerOnTeam(userId);
+      const winner = match.winner;
+      const won =
+        !player || !winner ? null : player.slot.team.equals(winner);
+      return {
+        lockedAt: match.lockedAt ?? match.startsAt.value,
+        won,
+      };
+    });
   }
 
   private lockedNewestFirst(): Match[] {

--- a/src/modules/match/repositories/match.repository.ts
+++ b/src/modules/match/repositories/match.repository.ts
@@ -12,6 +12,6 @@ export interface MatchRepository {
   persistLock(match: Match): Promise<Match>;
   listLockedByPlayerUserId(userId: string): Promise<Match[]>;
   listLockedByVenueCmsId(cmsId: CmsId): Promise<Match[]>;
-  /** Slim locked-match rows for badge evaluation (no full score hydration). */
+  /** Slim session-attributed locked-match rows for badge evaluation. */
   listLockedPadelResultsForBadges(userId: string): Promise<LockedPadelBadgeRow[]>;
 }

--- a/src/modules/match/repositories/match.repository.ts
+++ b/src/modules/match/repositories/match.repository.ts
@@ -1,10 +1,17 @@
 import { CmsId } from "../../venue/entities/cms-id";
 import { Match } from "../entities/match";
 
+export type LockedPadelBadgeRow = {
+  lockedAt: Date;
+  won: boolean | null;
+};
+
 export interface MatchRepository {
   findById(id: string): Promise<Match | null>;
   create(match: Match): Promise<Match>;
   persistLock(match: Match): Promise<Match>;
   listLockedByPlayerUserId(userId: string): Promise<Match[]>;
   listLockedByVenueCmsId(cmsId: CmsId): Promise<Match[]>;
+  /** Slim locked-match rows for badge evaluation (no full score hydration). */
+  listLockedPadelResultsForBadges(userId: string): Promise<LockedPadelBadgeRow[]>;
 }

--- a/src/modules/match/repositories/prisma-match.repository.test.ts
+++ b/src/modules/match/repositories/prisma-match.repository.test.ts
@@ -17,6 +17,7 @@ type StoredMatch = {
   servingTeam: "A" | "B" | null;
   winnerTeam: "A" | "B" | null;
   lockedAt: Date | null;
+  lockedByUserId?: string | null;
   score: unknown;
   createdAt: Date;
 };
@@ -53,13 +54,17 @@ function createPrismaMap() {
           where: {
             status: string;
             venueCmsId?: string;
+            lockedByUserId?: string;
             players?: { some: { userId: string } };
           };
-          orderBy: { startsAt: "asc" | "desc" };
+          orderBy?: { startsAt: "asc" | "desc" };
         }) => {
           let rows = [...matches.values()].filter((row) => row.status === where.status);
           if (where.venueCmsId) {
             rows = rows.filter((row) => row.venueCmsId === where.venueCmsId);
+          }
+          if (where.lockedByUserId) {
+            rows = rows.filter((row) => row.lockedByUserId === where.lockedByUserId);
           }
           if (where.players?.some.userId) {
             const userId = where.players.some.userId;
@@ -67,11 +72,13 @@ function createPrismaMap() {
               (players.get(row.id) ?? []).some((player) => player.userId === userId),
             );
           }
-          rows.sort((a, b) =>
-            orderBy.startsAt === "desc"
-              ? b.startsAt.getTime() - a.startsAt.getTime()
-              : a.startsAt.getTime() - b.startsAt.getTime(),
-          );
+          if (orderBy?.startsAt) {
+            rows.sort((a, b) =>
+              orderBy.startsAt === "desc"
+                ? b.startsAt.getTime() - a.startsAt.getTime()
+                : a.startsAt.getTime() - b.startsAt.getTime(),
+            );
+          }
           return rows.map((row) => ({
             ...row,
             players: players.get(row.id) ?? [],
@@ -167,6 +174,8 @@ describe(PrismaMatchRepository, () => {
         sets: [{ gamesA: 6, gamesB: 4, winner: "A" }],
       }),
       Team.A,
+      new Date(),
+      "user-1",
     );
     const locked = await repository.persistLock(first);
     const again = await repository.persistLock(first);
@@ -177,6 +186,23 @@ describe(PrismaMatchRepository, () => {
 
     const listed = await repository.listLockedByPlayerUserId("user-1");
     expect(listed.map((match) => match.id)).toEqual([first.id]);
+
+    const badgeRows = await repository.listLockedPadelResultsForBadges("user-1");
+    expect(badgeRows).toHaveLength(1);
+
+    const planted = await repository.create(
+      liveMatch("2026-08-02T10:00:00.000Z", "user-1"),
+    );
+    planted.lock(
+      MatchScore.from({
+        sets: [{ gamesA: 6, gamesB: 4, winner: "A" }],
+      }),
+      Team.A,
+    );
+    await repository.persistLock(planted);
+    expect(await repository.listLockedPadelResultsForBadges("user-1")).toHaveLength(
+      1,
+    );
   });
 
   test("persistLock conflicts when another result already won the race", async () => {

--- a/src/modules/match/repositories/prisma-match.repository.ts
+++ b/src/modules/match/repositories/prisma-match.repository.ts
@@ -2,7 +2,10 @@ import { Prisma, PrismaClient } from "../../../generated/prisma/client";
 import { CmsId } from "../../venue/entities/cms-id";
 import { Match, MatchStatusValue } from "../entities/match";
 import { MatchLockConflictError } from "../entities/match-lock-conflict-error";
-import { MatchRepository } from "./match.repository";
+import {
+  LockedPadelBadgeRow,
+  MatchRepository,
+} from "./match.repository";
 import { MatchScore } from "../entities/match-score";
 import { Pairings } from "../entities/pairings";
 import { MatchPersistenceError } from "../entities/match-persistence-error";
@@ -159,6 +162,48 @@ export class PrismaMatchRepository implements MatchRepository {
       throw wrapPersistenceError(error, "Unable to load match");
     }
   }
+  async listLockedPadelResultsForBadges(
+    userId: string,
+  ): Promise<LockedPadelBadgeRow[]> {
+    try {
+      const rows = await this.prisma.match.findMany({
+        where: {
+          status: "locked",
+          players: { some: { userId } },
+        },
+        select: {
+          lockedAt: true,
+          startsAt: true,
+          winnerTeam: true,
+          players: {
+            where: { userId },
+            select: { slot: true },
+          },
+        },
+      });
+
+      return rows.map((row) => {
+        const slot = row.players[0]?.slot ?? null;
+        const playerTeam =
+          typeof slot === "string" && slot.startsWith("A")
+            ? "A"
+            : typeof slot === "string" && slot.startsWith("B")
+              ? "B"
+              : null;
+        const won =
+          row.winnerTeam && playerTeam
+            ? row.winnerTeam === playerTeam
+            : null;
+        return {
+          lockedAt: row.lockedAt ?? row.startsAt,
+          won,
+        };
+      });
+    } catch (error) {
+      throw wrapPersistenceError(error, "Unable to load match");
+    }
+  }
+
 }
 
 function toDomain(row: MatchRow): Match {

--- a/src/modules/match/repositories/prisma-match.repository.ts
+++ b/src/modules/match/repositories/prisma-match.repository.ts
@@ -32,6 +32,7 @@ type MatchRow = {
   servingTeam: "A" | "B" | null;
   winnerTeam: "A" | "B" | null;
   lockedAt: Date | null;
+  lockedByUserId: string | null;
   score: Prisma.JsonValue | null;
   players: MatchPlayerRow[];
 };
@@ -95,6 +96,7 @@ export class PrismaMatchRepository implements MatchRepository {
           status: "locked",
           winnerTeam: snapshot.winner,
           lockedAt: match.lockedAt,
+          lockedByUserId: match.lockedByUserId,
           score: snapshot.score === null ? Prisma.JsonNull : snapshot.score,
         },
       });
@@ -169,7 +171,7 @@ export class PrismaMatchRepository implements MatchRepository {
       const rows = await this.prisma.match.findMany({
         where: {
           status: "locked",
-          players: { some: { userId } },
+          lockedByUserId: userId,
         },
         select: {
           lockedAt: true,
@@ -226,6 +228,7 @@ function toDomain(row: MatchRow): Match {
     score: row.score ? MatchScore.from(row.score) : null,
     winner: row.winnerTeam ? Team.from(row.winnerTeam, "winner") : null,
     lockedAt: row.lockedAt,
+    lockedByUserId: row.lockedByUserId,
   });
 }
 

--- a/src/modules/match/services/create-match.service.test.ts
+++ b/src/modules/match/services/create-match.service.test.ts
@@ -128,11 +128,13 @@ describe("match application", () => {
       matchId: created.id,
       score: scoreA,
       winner: "A",
+      lockedByUserId: "user-riley",
     });
     const again = await lock.execute({
       matchId: created.id,
       score: scoreA,
       winner: "A",
+      lockedByUserId: "user-riley",
     });
 
     expect(locked?.status).toBe("locked");
@@ -199,9 +201,24 @@ describe("match application", () => {
       },
     });
 
-    await lock.execute({ matchId: older.id, score: scoreA, winner: "A" });
-    await lock.execute({ matchId: newer.id, score: scoreA, winner: "A" });
-    await lock.execute({ matchId: otherCourt.id, score: scoreA, winner: "A" });
+    await lock.execute({
+      matchId: older.id,
+      score: scoreA,
+      winner: "A",
+      lockedByUserId: "user-riley",
+    });
+    await lock.execute({
+      matchId: newer.id,
+      score: scoreA,
+      winner: "A",
+      lockedByUserId: "user-riley",
+    });
+    await lock.execute({
+      matchId: otherCourt.id,
+      score: scoreA,
+      winner: "A",
+      lockedByUserId: "user-pat",
+    });
 
     const playerHistory = await new ListLockedMatchesByPlayer(
       matches,
@@ -244,8 +261,18 @@ describe("match application", () => {
       ruleset: "golden_point",
       pairings: guests,
     });
-    await lock.execute({ matchId: atCourt1.id, score: scoreA, winner: "A" });
-    await lock.execute({ matchId: atCourt2.id, score: scoreA, winner: "A" });
+    await lock.execute({
+      matchId: atCourt1.id,
+      score: scoreA,
+      winner: "A",
+      lockedByUserId: "user-riley",
+    });
+    await lock.execute({
+      matchId: atCourt2.id,
+      score: scoreA,
+      winner: "A",
+      lockedByUserId: "user-riley",
+    });
 
     const findByCmsId = jest.spyOn(venues, "findByCmsId");
     const findByCmsIds = jest.spyOn(venues, "findByCmsIds");

--- a/src/modules/match/services/lock-match.service.ts
+++ b/src/modules/match/services/lock-match.service.ts
@@ -7,6 +7,7 @@ export type LockMatchInput = {
   matchId: string;
   score: unknown;
   winner: unknown;
+  lockedByUserId: string;
 };
 
 export class LockMatch {
@@ -18,7 +19,12 @@ export class LockMatch {
       return null;
     }
 
-    match.lock(MatchScore.from(input.score), Team.from(input.winner, "winner"));
+    match.lock(
+      MatchScore.from(input.score),
+      Team.from(input.winner, "winner"),
+      new Date(),
+      input.lockedByUserId,
+    );
     return this.matches.persistLock(match);
   }
 }

--- a/src/modules/match/utils/bind-session-user.test.ts
+++ b/src/modules/match/utils/bind-session-user.test.ts
@@ -1,4 +1,7 @@
-import { bindSessionUserIdToPairings } from "./bind-session-user";
+import {
+  bindSessionUserIdToPairings,
+  sanitizePairingsForCreate,
+} from "./bind-session-user";
 
 const guest = (displayName: string) => ({
   displayName,
@@ -81,6 +84,50 @@ describe("bindSessionUserIdToPairings", () => {
       displayName: "Sam",
       isGuest: false,
       userId: "user-sam",
+    });
+  });
+});
+
+describe("sanitizePairingsForCreate", () => {
+  test("strips all userIds when there is no session", () => {
+    const sanitized = sanitizePairingsForCreate(
+      {
+        teamA: [named("Alex", "user-alex"), guest("Sam")],
+        teamB: [guest("Jordan"), named("Riley", "user-riley")],
+      },
+      null,
+    );
+
+    expect(sanitized).toEqual({
+      teamA: [
+        { displayName: "Alex", isGuest: true, userId: null },
+        guest("Sam"),
+      ],
+      teamB: [
+        guest("Jordan"),
+        { displayName: "Riley", isGuest: true, userId: null },
+      ],
+    });
+  });
+
+  test("keeps only the session userId and binds an empty non-guest seat", () => {
+    const sanitized = sanitizePairingsForCreate(
+      {
+        teamA: [named("Alex", "user-alex"), guest("Sam")],
+        teamB: [guest("Jordan"), named("Riley", null)],
+      },
+      "user-riley",
+    );
+
+    expect(sanitized.teamA[0]).toEqual({
+      displayName: "Alex",
+      isGuest: true,
+      userId: null,
+    });
+    expect(sanitized.teamB[1]).toEqual({
+      displayName: "Riley",
+      isGuest: false,
+      userId: "user-riley",
     });
   });
 });

--- a/src/modules/match/utils/bind-session-user.ts
+++ b/src/modules/match/utils/bind-session-user.ts
@@ -14,6 +14,35 @@ function withSessionUser(player: MatchPlayerInput, sessionUserId: string): Match
   return { ...player, userId: sessionUserId, isGuest: false };
 }
 
+/**
+ * Strip account ids that are not the session user. Foreign ids become guests so
+ * create cannot plant another user's id for badge evidence.
+ */
+function stripNonSessionUserIds(
+  pairings: PairingsInput,
+  sessionUserId: string | null,
+): PairingsInput {
+  const strip = (player: MatchPlayerInput): MatchPlayerInput => {
+    const id = normalizedUserId(player.userId);
+    if (sessionUserId && id === sessionUserId) {
+      return withSessionUser(player, sessionUserId);
+    }
+    if (id !== null) {
+      return {
+        displayName: player.displayName,
+        isGuest: true,
+        userId: null,
+      };
+    }
+    return { ...player, userId: null };
+  };
+
+  return {
+    teamA: [strip(pairings.teamA[0]), strip(pairings.teamA[1])],
+    teamB: [strip(pairings.teamB[0]), strip(pairings.teamB[1])],
+  };
+}
+
 export function bindSessionUserIdToPairings(
   pairings: PairingsInput,
   sessionUserId: string,
@@ -57,4 +86,16 @@ export function bindSessionUserIdToPairings(
   }
 
   return { teamA, teamB };
+}
+
+/** Sanitize create payload: only the session user may be stamped as a userId. */
+export function sanitizePairingsForCreate(
+  pairings: PairingsInput,
+  sessionUserId: string | null,
+): PairingsInput {
+  const stripped = stripNonSessionUserIds(pairings, sessionUserId);
+  if (!sessionUserId) {
+    return stripped;
+  }
+  return bindSessionUserIdToPairings(stripped, sessionUserId);
 }


### PR DESCRIPTION
Follow-up to #22 review (forgeable padel/golf evidence + write-only BadgeAward), plus Cursor Automation on this PR.

## Changes
- **Create sanitize:** match/golf create strips non-session `userId`s (anonymous create cannot plant account ids; authenticated create only stamps the session user).
- **Lock auth:** `POST .../lock` requires a session and that the caller is seated (401 / 403 otherwise).
- **Lock attribution:** first lock persists `lockedByUserId` from the seated session. Idempotent re-lock does not change it. Public snapshots omit the field.
- **Badge evidence:** `listLockedPadelResultsForBadges` / `listLockedAtForBadges` filter `status: locked` **and** `lockedByUserId = session user`. Pre-this-PR planted locks (player `userId` only) do not mint badges.
- **Badges GET/POST:** `GET /api/me/badges` returns **live ∩ persist** — live evaluation is authoritative for membership; persist may only make `earnedAt` earlier. `POST {}` upserts then returns the same merge (no client ids).
- **Lean evidence queries:** badge evaluation uses slim locked padel rows + golf lock timestamps instead of hydrating full match/round graphs on hub GET.

## Tests
- Unit + HTTP coverage for sanitize, seated lock, planted-lock ignore, and GET intersection merge.
- Full suite green locally (112).

## Notes
- Addresses automation review on #22 and CHANGES_REQUESTED on this PR.
- Deploy/migrate still needed for Railway so `/api/me/badges` and `lockedByUserId` are live in prod.
- `whatsapp_share` remains device-local.