### PR TITLE
Add onboarding preferences API and friend user search

### DIFF
--- a/PLACEHOLDER
+++ b/PLACEHOLDER
@@ -1,0 +1,1 @@
+will-replace

--- a/PLACEHOLDER
+++ b/PLACEHOLDER
@@ -1,1 +1,0 @@
-will-replace

--- a/prisma/migrations/20260905120000_onboarding_preferences/migration.sql
+++ b/prisma/migrations/20260905120000_onboarding_preferences/migration.sql
@@ -1,0 +1,20 @@
+-- AlterTable
+ALTER TABLE "Profile" ADD COLUMN "activeSportSlug" TEXT;
+ALTER TABLE "Profile" ADD COLUMN "onboardingCompletedAt" TIMESTAMP(3);
+ALTER TABLE "Profile" ADD COLUMN "onboardingSkippedAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "SportFollow" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "sportSlug" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SportFollow_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "SportFollow_userId_idx" ON "SportFollow"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SportFollow_userId_sportSlug_key" ON "SportFollow"("userId", "sportSlug");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,15 +36,28 @@ model Account {
 }
 
 model Profile {
-  id        String  @id @default(uuid())
-  userId    String  @unique
-  firstName String
-  lastName  String
-  email     String  @unique @default("")
-  handle    String  @unique
-  avatarUrl String?
+  id                     String    @id @default(uuid())
+  userId                 String    @unique
+  firstName              String
+  lastName               String
+  email                  String    @unique @default("")
+  handle                 String    @unique
+  avatarUrl              String?
+  activeSportSlug        String?
+  onboardingCompletedAt  DateTime?
+  onboardingSkippedAt    DateTime?
 
   user User @relation(fields: [userId], references: [id])
+}
+
+model SportFollow {
+  id        String   @id @default(uuid())
+  userId    String
+  sportSlug String
+  createdAt DateTime @default(now())
+
+  @@unique([userId, sportSlug])
+  @@index([userId])
 }
 
 model Venue {

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,10 @@ import {
   BadgeAwardRepository,
 } from "./modules/badges";
 import {
+  createPreferencesModule,
+  PreferencesRepository,
+} from "./modules/preferences";
+import {
   createVenueModule,
   VenueRepository,
 } from "./modules/venue";
@@ -35,6 +39,7 @@ export type CreateAppDependencies = {
   matchRepository?: MatchRepository;
   golfRoundRepository?: GolfRoundRepository;
   badgeAwardRepository?: BadgeAwardRepository;
+  preferencesRepository?: PreferencesRepository;
 };
 
 export async function createApp(
@@ -88,6 +93,12 @@ export async function createApp(
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
+  const preferences = createPreferencesModule({
+    prisma,
+    preferencesRepository: dependencies.preferencesRepository,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
   const badges = createBadgesModule({
     prisma,
     matchRepository: match.matchRepository,
@@ -103,6 +114,7 @@ export async function createApp(
   app.use(match.router);
   app.use(golfRound.router);
   app.use(friends.router);
+  app.use(preferences.router);
   app.use(badges.router);
 
   app.use(

--- a/src/modules/friends/controllers/friends.controller.ts
+++ b/src/modules/friends/controllers/friends.controller.ts
@@ -12,6 +12,7 @@ import {
   ListFriends,
   RemoveFriend,
   RequestFriend,
+  SearchUsers,
 } from "../services/friends.service";
 
 const requestBodySchema = z.object({
@@ -22,11 +23,18 @@ const userIdParamSchema = z.object({
   userId: z.string(),
 });
 
+const searchQuerySchema = z.object({
+  q: z.string().optional(),
+  query: z.string().optional(),
+  limit: z.string().optional(),
+});
+
 export function createFriendsController(deps: {
   requestFriend: RequestFriend;
   acceptFriend: AcceptFriend;
   removeFriend: RemoveFriend;
   listFriends: ListFriends;
+  searchUsers: SearchUsers;
   tryGetSessionUserId: (req: Request) => string | null;
 }) {
   return {
@@ -91,6 +99,29 @@ export function createFriendsController(deps: {
         const result = await deps.removeFriend.execute({
           userId,
           otherUserId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendFriendsError(res, error);
+      }
+    },
+
+    async search(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const query = z.parse(searchQuerySchema, req.query ?? {});
+        const q = (query.q ?? query.query ?? "").trim();
+        const limitRaw = query.limit ? Number.parseInt(query.limit, 10) : 10;
+        const limit = Number.isFinite(limitRaw) ? limitRaw : 10;
+
+        const result = await deps.searchUsers.execute({
+          userId,
+          query: q,
+          limit,
         });
         return res.status(200).json(result);
       } catch (error) {

--- a/src/modules/friends/index.ts
+++ b/src/modules/friends/index.ts
@@ -21,6 +21,7 @@ import {
   ListFriends,
   RemoveFriend,
   RequestFriend,
+  SearchUsers,
 } from "./services/friends.service";
 
 export type CreateFriendsModuleParams = {
@@ -58,6 +59,7 @@ export function createFriendsModule({
     acceptFriend: new AcceptFriend(friendshipRepository, friendProfileLookup),
     removeFriend: new RemoveFriend(friendshipRepository),
     listFriends: new ListFriends(friendshipRepository, friendProfileLookup),
+    searchUsers: new SearchUsers(friendshipRepository, friendProfileLookup),
     tryGetSessionUserId,
   });
 
@@ -89,4 +91,9 @@ export {
   ListFriends,
   RemoveFriend,
   RequestFriend,
+  SearchUsers,
+} from "./services/friends.service";
+export type {
+  PublicUserSearchResult,
+  UserSearchRelationship,
 } from "./services/friends.service";

--- a/src/modules/friends/repositories/friendship.repository.ts
+++ b/src/modules/friends/repositories/friendship.repository.ts
@@ -16,9 +16,18 @@ export type FriendProfile = {
   avatarUrl: string | null;
 };
 
+export type FriendProfileSearchOptions = {
+  limit?: number;
+  excludeUserId?: string;
+};
+
 export interface FriendProfileLookup {
   findByUserId(userId: string): Promise<FriendProfile | null>;
   findByHandle(handle: string): Promise<FriendProfile | null>;
+  search(
+    query: string,
+    options?: FriendProfileSearchOptions,
+  ): Promise<FriendProfile[]>;
 }
 
 export interface FriendshipRepository {

--- a/src/modules/friends/repositories/in-memory-friend-profile.lookup.ts
+++ b/src/modules/friends/repositories/in-memory-friend-profile.lookup.ts
@@ -22,4 +22,26 @@ export class InMemoryFriendProfileLookup implements FriendProfileLookup {
     if (!userId) return null;
     return this.findByUserId(userId);
   }
+
+  async search(
+    query: string,
+    options: { limit?: number; excludeUserId?: string } = {},
+  ): Promise<FriendProfile[]> {
+    const needle = query.trim().replace(/^@/, "").toLowerCase();
+    if (!needle) return [];
+
+    const limit = Math.min(Math.max(options.limit ?? 10, 1), 20);
+    const excludeUserId = options.excludeUserId?.trim() || "";
+
+    const matches: FriendProfile[] = [];
+    for (const profile of this.byUserId.values()) {
+      if (excludeUserId && profile.userId === excludeUserId) continue;
+      const handle = profile.handle.toLowerCase();
+      const name = profile.displayName.toLowerCase();
+      if (!handle.includes(needle) && !name.includes(needle)) continue;
+      matches.push({ ...profile });
+      if (matches.length >= limit) break;
+    }
+    return matches;
+  }
 }

--- a/src/modules/friends/repositories/prisma-friend-profile.lookup.ts
+++ b/src/modules/friends/repositories/prisma-friend-profile.lookup.ts
@@ -60,4 +60,54 @@ export class PrismaFriendProfileLookup implements FriendProfileLookup {
       });
     }
   }
+
+  async search(
+    query: string,
+    options: { limit?: number; excludeUserId?: string } = {},
+  ): Promise<FriendProfile[]> {
+    const needle = query.trim().replace(/^@/, "");
+    if (!needle) return [];
+
+    const limit = Math.min(Math.max(options.limit ?? 10, 1), 20);
+    const excludeUserId = options.excludeUserId?.trim() || undefined;
+
+    try {
+      const rows = await this.prisma.profile.findMany({
+        where: {
+          AND: [
+            excludeUserId ? { userId: { not: excludeUserId } } : {},
+            {
+              OR: [
+                {
+                  handle: {
+                    contains: needle,
+                    mode: "insensitive",
+                  },
+                },
+                {
+                  firstName: {
+                    contains: needle,
+                    mode: "insensitive",
+                  },
+                },
+                {
+                  lastName: {
+                    contains: needle,
+                    mode: "insensitive",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        take: limit,
+        orderBy: { handle: "asc" },
+      });
+      return rows.map(toProfile);
+    } catch (error) {
+      throw new FriendshipPersistenceError("Failed to search profiles", {
+        cause: error,
+      });
+    }
+  }
 }

--- a/src/modules/friends/routes/friends.routes.ts
+++ b/src/modules/friends/routes/friends.routes.ts
@@ -34,5 +34,9 @@ export function createFriendsRoutes(
     void controller.remove(req, res);
   });
 
+  router.get("/api/users/search", options.requireAuth, (req, res) => {
+    void controller.search(req, res);
+  });
+
   return router;
 }

--- a/src/modules/friends/services/friends.service.ts
+++ b/src/modules/friends/services/friends.service.ts
@@ -261,3 +261,69 @@ export class FriendRequestNotFoundError extends Error {
     this.name = "FriendRequestNotFoundError";
   }
 }
+
+export type UserSearchRelationship =
+  | "none"
+  | "friend"
+  | "incoming"
+  | "outgoing"
+  | "self";
+
+export type PublicUserSearchResult = {
+  id: string;
+  displayName: string;
+  handle: string;
+  avatarUrl: string | null;
+  relationship: UserSearchRelationship;
+};
+
+export class SearchUsers {
+  constructor(
+    private readonly friendships: FriendshipRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    query: string;
+    limit?: number;
+  }): Promise<{ users: PublicUserSearchResult[] }> {
+    const userId = input.userId.trim();
+    if (!userId) {
+      throw new DomainError("userId is required");
+    }
+
+    const query = input.query.trim().replace(/^@/, "");
+    if (query.length < 1) {
+      return { users: [] };
+    }
+
+    const profiles = await this.profiles.search(query, {
+      limit: input.limit ?? 10,
+      excludeUserId: userId,
+    });
+
+    const users: PublicUserSearchResult[] = [];
+    for (const profile of profiles) {
+      const existing = await this.friendships.findBetween(
+        userId,
+        profile.userId,
+      );
+      let relationship: UserSearchRelationship = "none";
+      if (existing?.status === "accepted") {
+        relationship = "friend";
+      } else if (existing?.status === "pending") {
+        relationship =
+          existing.requesterId === userId ? "outgoing" : "incoming";
+      }
+
+      users.push({
+        ...toPublicUser(profile),
+        relationship,
+      });
+    }
+
+    return { users };
+  }
+}
+

--- a/src/modules/preferences/controllers/preferences.controller.ts
+++ b/src/modules/preferences/controllers/preferences.controller.ts
@@ -1,0 +1,85 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { PreferencesPersistenceError } from "../repositories/preferences-persistence-error";
+import {
+  GetPreferences,
+  UpdatePreferences,
+} from "../services/preferences.service";
+
+const updateBodySchema = z
+  .object({
+    sports: z.array(z.string()).optional(),
+    activeSport: z.union([z.string(), z.null()]).optional(),
+    completeOnboarding: z.boolean().optional(),
+    skipOnboarding: z.boolean().optional(),
+  })
+  .refine(
+    (body) =>
+      body.sports !== undefined ||
+      body.activeSport !== undefined ||
+      body.completeOnboarding === true ||
+      body.skipOnboarding === true,
+    { message: "No preference fields to update" },
+  );
+
+export function createPreferencesController(deps: {
+  getPreferences: GetPreferences;
+  updatePreferences: UpdatePreferences;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async get(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const result = await deps.getPreferences.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendPreferencesError(res, error);
+      }
+    },
+
+    async update(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const body = z.parse(updateBodySchema, req.body ?? {});
+        const result = await deps.updatePreferences.execute({
+          userId,
+          sports: body.sports,
+          activeSport: body.activeSport,
+          completeOnboarding: body.completeOnboarding,
+          skipOnboarding: body.skipOnboarding,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendPreferencesError(res, error);
+      }
+    },
+  };
+}
+
+function sendPreferencesError(res: Response, error: unknown) {
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid preferences payload" });
+  }
+
+  if (error instanceof PreferencesPersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/preferences/controllers/preferences.http.test.ts
+++ b/src/modules/preferences/controllers/preferences.http.test.ts
@@ -1,0 +1,148 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+import jwt from "jsonwebtoken";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { InMemoryPreferencesRepository } from "../repositories/in-memory-preferences.repository";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+describe("preferences + user search HTTP", () => {
+  const config = makeConfig();
+  let preferences: InMemoryPreferencesRepository;
+  let friendships: InMemoryFriendshipRepository;
+  let profiles: InMemoryFriendProfileLookup;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  beforeEach(async () => {
+    preferences = new InMemoryPreferencesRepository();
+    friendships = new InMemoryFriendshipRepository();
+    profiles = new InMemoryFriendProfileLookup();
+    profiles.seed({
+      userId: "user-a",
+      displayName: "Alex Player",
+      handle: "alex",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-b",
+      displayName: "Blake Golfer",
+      handle: "blake",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-c",
+      displayName: "Casey Padel",
+      handle: "casey",
+      avatarUrl: null,
+    });
+
+    app = await createApp(config, {
+      venueRepository: new InMemoryVenueRepository(),
+      friendshipRepository: friendships,
+      friendProfileLookup: profiles,
+      preferencesRepository: preferences,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  function cookie(userId: string) {
+    return `token=${jwt.sign({ userId }, config.JWT_SECRET)}`;
+  }
+
+  test("PUT/GET /api/me/preferences persists sports and onboarding", async () => {
+    const put = await fetch(`${server.url}/api/me/preferences`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        sports: ["padel", "golf"],
+        activeSport: "padel",
+        completeOnboarding: true,
+      }),
+    });
+    expect(put.status).toBe(200);
+    const putBody = (await put.json()) as {
+      sports: string[];
+      activeSport: string | null;
+      onboardingCompletedAt: string | null;
+    };
+    expect(putBody.sports).toEqual(["padel", "golf"]);
+    expect(putBody.activeSport).toBe("padel");
+    expect(putBody.onboardingCompletedAt).toEqual(expect.any(String));
+
+    const get = await fetch(`${server.url}/api/me/preferences`, {
+      headers: { Cookie: cookie("user-a") },
+    });
+    expect(get.status).toBe(200);
+    expect(await get.json()).toEqual(putBody);
+  });
+
+  test("GET /api/users/search finds handles and names", async () => {
+    const byHandle = await fetch(`${server.url}/api/users/search?q=bla`, {
+      headers: { Cookie: cookie("user-a") },
+    });
+    expect(byHandle.status).toBe(200);
+    const handleBody = (await byHandle.json()) as { users: unknown[] };
+    expect(handleBody.users).toEqual([
+      expect.objectContaining({
+        id: "user-b",
+        handle: "blake",
+        relationship: "none",
+      }),
+    ]);
+
+    const byName = await fetch(`${server.url}/api/users/search?q=padel`, {
+      headers: { Cookie: cookie("user-a") },
+    });
+    expect(byName.status).toBe(200);
+    const nameBody = (await byName.json()) as { users: unknown[] };
+    expect(nameBody.users).toEqual([
+      expect.objectContaining({
+        id: "user-c",
+        handle: "casey",
+      }),
+    ]);
+  });
+});

--- a/src/modules/preferences/index.ts
+++ b/src/modules/preferences/index.ts
@@ -1,0 +1,67 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { createPreferencesController } from "./controllers/preferences.controller";
+import { InMemoryPreferencesRepository } from "./repositories/in-memory-preferences.repository";
+import { PreferencesRepository } from "./repositories/preferences.repository";
+import { PrismaPreferencesRepository } from "./repositories/prisma-preferences.repository";
+import { createPreferencesRoutes } from "./routes/preferences.routes";
+import {
+  GetPreferences,
+  UpdatePreferences,
+} from "./services/preferences.service";
+
+export type CreatePreferencesModuleParams = {
+  prisma: PrismaClient;
+  preferencesRepository?: PreferencesRepository;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type PreferencesModule = {
+  router: Router;
+  preferencesRepository: PreferencesRepository;
+};
+
+export function createPreferencesModule({
+  prisma,
+  preferencesRepository: preferencesRepositoryOverride,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreatePreferencesModuleParams): PreferencesModule {
+  const preferencesRepository =
+    preferencesRepositoryOverride ?? new PrismaPreferencesRepository(prisma);
+
+  const controller = createPreferencesController({
+    getPreferences: new GetPreferences(preferencesRepository),
+    updatePreferences: new UpdatePreferences(preferencesRepository),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createPreferencesRoutes(controller, { requireAuth }),
+    preferencesRepository,
+  };
+}
+
+export { createPreferencesController } from "./controllers/preferences.controller";
+export { InMemoryPreferencesRepository } from "./repositories/in-memory-preferences.repository";
+export { PreferencesPersistenceError } from "./repositories/preferences-persistence-error";
+export { PrismaPreferencesRepository } from "./repositories/prisma-preferences.repository";
+export type {
+  PreferencesRepository,
+  UpdateUserPreferencesInput,
+  UserPreferences,
+} from "./repositories/preferences.repository";
+export {
+  GetPreferences,
+  UpdatePreferences,
+  assertSportSlug,
+  assertSportSlugs,
+  toPublicPreferences,
+} from "./services/preferences.service";

--- a/src/modules/preferences/repositories/in-memory-preferences.repository.ts
+++ b/src/modules/preferences/repositories/in-memory-preferences.repository.ts
@@ -1,0 +1,57 @@
+import {
+  PreferencesRepository,
+  UpdateUserPreferencesInput,
+  UserPreferences,
+} from "./preferences.repository";
+
+function emptyPrefs(userId: string): UserPreferences {
+  return {
+    userId,
+    sports: [],
+    activeSport: null,
+    onboardingCompletedAt: null,
+    onboardingSkippedAt: null,
+  };
+}
+
+export class InMemoryPreferencesRepository implements PreferencesRepository {
+  private readonly byUserId = new Map<string, UserPreferences>();
+
+  seed(prefs: UserPreferences): void {
+    this.byUserId.set(prefs.userId, {
+      ...prefs,
+      sports: [...prefs.sports],
+    });
+  }
+
+  async getForUser(userId: string): Promise<UserPreferences> {
+    const existing = this.byUserId.get(userId);
+    if (!existing) return emptyPrefs(userId);
+    return { ...existing, sports: [...existing.sports] };
+  }
+
+  async updateForUser(
+    userId: string,
+    input: UpdateUserPreferencesInput,
+  ): Promise<UserPreferences> {
+    const current = await this.getForUser(userId);
+    const next: UserPreferences = {
+      userId,
+      sports: input.sports !== undefined ? [...input.sports] : current.sports,
+      activeSport:
+        input.activeSport !== undefined
+          ? input.activeSport
+          : current.activeSport,
+      onboardingCompletedAt:
+        input.onboardingCompletedAt !== undefined
+          ? input.onboardingCompletedAt
+          : current.onboardingCompletedAt,
+      onboardingSkippedAt:
+        input.onboardingSkippedAt !== undefined
+          ? input.onboardingSkippedAt
+          : current.onboardingSkippedAt,
+    };
+    this.byUserId.set(userId, next);
+    return { ...next, sports: [...next.sports] };
+  }
+}

--- a/src/modules/preferences/repositories/preferences-persistence-error.ts
+++ b/src/modules/preferences/repositories/preferences-persistence-error.ts
@@ -1,0 +1,6 @@
+export class PreferencesPersistenceError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options?.cause ? { cause: options.cause } : undefined);
+    this.name = "PreferencesPersistenceError";
+  }
+}

--- a/src/modules/preferences/repositories/preferences.repository.ts
+++ b/src/modules/preferences/repositories/preferences.repository.ts
@@ -1,0 +1,22 @@
+export type UserPreferences = {
+  userId: string;
+  sports: string[];
+  activeSport: string | null;
+  onboardingCompletedAt: Date | null;
+  onboardingSkippedAt: Date | null;
+};
+
+export type UpdateUserPreferencesInput = {
+  sports?: string[];
+  activeSport?: string | null;
+  onboardingCompletedAt?: Date | null;
+  onboardingSkippedAt?: Date | null;
+};
+
+export interface PreferencesRepository {
+  getForUser(userId: string): Promise<UserPreferences>;
+  updateForUser(
+    userId: string,
+    input: UpdateUserPreferencesInput,
+  ): Promise<UserPreferences>;
+}

--- a/src/modules/preferences/repositories/prisma-preferences.repository.ts
+++ b/src/modules/preferences/repositories/prisma-preferences.repository.ts
@@ -1,0 +1,106 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { PreferencesPersistenceError } from "./preferences-persistence-error";
+import {
+  PreferencesRepository,
+  UpdateUserPreferencesInput,
+  UserPreferences,
+} from "./preferences.repository";
+
+function emptyPrefs(userId: string): UserPreferences {
+  return {
+    userId,
+    sports: [],
+    activeSport: null,
+    onboardingCompletedAt: null,
+    onboardingSkippedAt: null,
+  };
+}
+
+export class PrismaPreferencesRepository implements PreferencesRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async getForUser(userId: string): Promise<UserPreferences> {
+    try {
+      const [profile, follows] = await Promise.all([
+        this.prisma.profile.findUnique({
+          where: { userId },
+          select: {
+            activeSportSlug: true,
+            onboardingCompletedAt: true,
+            onboardingSkippedAt: true,
+          },
+        }),
+        this.prisma.sportFollow.findMany({
+          where: { userId },
+          orderBy: { createdAt: "asc" },
+          select: { sportSlug: true },
+        }),
+      ]);
+
+      if (!profile && follows.length === 0) {
+        return emptyPrefs(userId);
+      }
+
+      return {
+        userId,
+        sports: follows.map((row) => row.sportSlug),
+        activeSport: profile?.activeSportSlug ?? null,
+        onboardingCompletedAt: profile?.onboardingCompletedAt ?? null,
+        onboardingSkippedAt: profile?.onboardingSkippedAt ?? null,
+      };
+    } catch (error) {
+      throw new PreferencesPersistenceError("Failed to load preferences", {
+        cause: error,
+      });
+    }
+  }
+
+  async updateForUser(
+    userId: string,
+    input: UpdateUserPreferencesInput,
+  ): Promise<UserPreferences> {
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        if (input.sports !== undefined) {
+          await tx.sportFollow.deleteMany({ where: { userId } });
+          if (input.sports.length > 0) {
+            await tx.sportFollow.createMany({
+              data: input.sports.map((sportSlug) => ({ userId, sportSlug })),
+              skipDuplicates: true,
+            });
+          }
+        }
+
+        const profileData: {
+          activeSportSlug?: string | null;
+          onboardingCompletedAt?: Date | null;
+          onboardingSkippedAt?: Date | null;
+        } = {};
+
+        if (input.activeSport !== undefined) {
+          profileData.activeSportSlug = input.activeSport;
+        }
+        if (input.onboardingCompletedAt !== undefined) {
+          profileData.onboardingCompletedAt = input.onboardingCompletedAt;
+        }
+        if (input.onboardingSkippedAt !== undefined) {
+          profileData.onboardingSkippedAt = input.onboardingSkippedAt;
+        }
+
+        if (Object.keys(profileData).length > 0) {
+          await tx.profile.updateMany({
+            where: { userId },
+            data: profileData,
+          });
+        }
+      });
+
+      return this.getForUser(userId);
+    } catch (error) {
+      if (error instanceof PreferencesPersistenceError) throw error;
+      throw new PreferencesPersistenceError("Failed to update preferences", {
+        cause: error,
+      });
+    }
+  }
+}

--- a/src/modules/preferences/routes/preferences.routes.ts
+++ b/src/modules/preferences/routes/preferences.routes.ts
@@ -1,0 +1,26 @@
+import { Router } from "express";
+
+import { createPreferencesController } from "../controllers/preferences.controller";
+
+export function createPreferencesRoutes(
+  controller: ReturnType<typeof createPreferencesController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.get("/api/me/preferences", options.requireAuth, (req, res) => {
+    void controller.get(req, res);
+  });
+
+  router.put("/api/me/preferences", options.requireAuth, (req, res) => {
+    void controller.update(req, res);
+  });
+
+  return router;
+}

--- a/src/modules/preferences/services/preferences.service.test.ts
+++ b/src/modules/preferences/services/preferences.service.test.ts
@@ -1,0 +1,55 @@
+import {
+  assertSportSlugs,
+  GetPreferences,
+  UpdatePreferences,
+} from "./preferences.service";
+import { InMemoryPreferencesRepository } from "../repositories/in-memory-preferences.repository";
+
+describe("preferences service", () => {
+  test("normalizes and dedupes sport slugs", () => {
+    expect(assertSportSlugs(["Padel", "padel", " golf "])).toEqual([
+      "padel",
+      "golf",
+    ]);
+  });
+
+  test("get returns empty defaults", async () => {
+    const repo = new InMemoryPreferencesRepository();
+    const result = await new GetPreferences(repo).execute({ userId: "u1" });
+    expect(result).toEqual({
+      sports: [],
+      activeSport: null,
+      onboardingCompletedAt: null,
+      onboardingSkippedAt: null,
+    });
+  });
+
+  test("update persists sports, active sport, and onboarding flags", async () => {
+    const repo = new InMemoryPreferencesRepository();
+    const update = new UpdatePreferences(repo);
+
+    const saved = await update.execute({
+      userId: "u1",
+      sports: ["padel", "golf"],
+      activeSport: "padel",
+      completeOnboarding: true,
+    });
+
+    expect(saved.sports).toEqual(["padel", "golf"]);
+    expect(saved.activeSport).toBe("padel");
+    expect(saved.onboardingCompletedAt).toEqual(expect.any(String));
+    expect(saved.onboardingSkippedAt).toBeNull();
+
+    const loaded = await new GetPreferences(repo).execute({ userId: "u1" });
+    expect(loaded).toEqual(saved);
+  });
+
+  test("skip onboarding sets skipped timestamp", async () => {
+    const repo = new InMemoryPreferencesRepository();
+    const saved = await new UpdatePreferences(repo).execute({
+      userId: "u1",
+      skipOnboarding: true,
+    });
+    expect(saved.onboardingSkippedAt).toEqual(expect.any(String));
+  });
+});

--- a/src/modules/preferences/services/preferences.service.ts
+++ b/src/modules/preferences/services/preferences.service.ts
@@ -1,0 +1,137 @@
+import { DomainError } from "../../../lib/domain-error";
+import {
+  PreferencesRepository,
+  UserPreferences,
+} from "../repositories/preferences.repository";
+
+const SPORT_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const MAX_SPORTS = 20;
+
+export type PublicPreferences = {
+  sports: string[];
+  activeSport: string | null;
+  onboardingCompletedAt: string | null;
+  onboardingSkippedAt: string | null;
+};
+
+export function toPublicPreferences(
+  prefs: UserPreferences,
+): PublicPreferences {
+  return {
+    sports: [...prefs.sports],
+    activeSport: prefs.activeSport,
+    onboardingCompletedAt: prefs.onboardingCompletedAt?.toISOString() ?? null,
+    onboardingSkippedAt: prefs.onboardingSkippedAt?.toISOString() ?? null,
+  };
+}
+
+export function normalizeSportSlug(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+export function assertSportSlug(raw: string): string {
+  const slug = normalizeSportSlug(raw);
+  if (!slug || !SPORT_SLUG_PATTERN.test(slug) || slug.length > 64) {
+    throw new DomainError(`Invalid sport slug: ${raw}`);
+  }
+  return slug;
+}
+
+export function assertSportSlugs(raw: string[]): string[] {
+  if (raw.length > MAX_SPORTS) {
+    throw new DomainError(`Select at most ${MAX_SPORTS} sports`);
+  }
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of raw) {
+    const slug = assertSportSlug(item);
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(slug);
+  }
+  return out;
+}
+
+export class GetPreferences {
+  constructor(private readonly preferences: PreferencesRepository) {}
+
+  async execute(input: { userId: string }): Promise<PublicPreferences> {
+    const userId = input.userId.trim();
+    if (!userId) throw new DomainError("userId is required");
+    return toPublicPreferences(await this.preferences.getForUser(userId));
+  }
+}
+
+export type UpdatePreferencesInput = {
+  userId: string;
+  sports?: string[];
+  activeSport?: string | null;
+  completeOnboarding?: boolean;
+  skipOnboarding?: boolean;
+};
+
+export class UpdatePreferences {
+  constructor(private readonly preferences: PreferencesRepository) {}
+
+  async execute(input: UpdatePreferencesInput): Promise<PublicPreferences> {
+    const userId = input.userId.trim();
+    if (!userId) throw new DomainError("userId is required");
+
+    const patch: Parameters<PreferencesRepository["updateForUser"]>[1] = {};
+
+    if (input.sports !== undefined) {
+      patch.sports = assertSportSlugs(input.sports);
+    }
+
+    if (input.activeSport !== undefined) {
+      patch.activeSport =
+        input.activeSport === null || input.activeSport === ""
+          ? null
+          : assertSportSlug(input.activeSport);
+    }
+
+    if (input.completeOnboarding === true) {
+      patch.onboardingCompletedAt = new Date();
+    }
+
+    if (input.skipOnboarding === true) {
+      patch.onboardingSkippedAt = new Date();
+    }
+
+    if (
+      patch.sports === undefined &&
+      patch.activeSport === undefined &&
+      patch.onboardingCompletedAt === undefined &&
+      patch.onboardingSkippedAt === undefined
+    ) {
+      throw new DomainError("No preference fields to update");
+    }
+
+    // Keep activeSport inside the followed set when both are provided.
+    if (
+      patch.sports !== undefined &&
+      patch.activeSport &&
+      !patch.sports.includes(patch.activeSport)
+    ) {
+      patch.sports = [...patch.sports, patch.activeSport];
+    }
+
+    if (
+      patch.sports !== undefined &&
+      patch.activeSport === undefined
+    ) {
+      const current = await this.preferences.getForUser(userId);
+      if (
+        current.activeSport &&
+        !patch.sports.includes(current.activeSport)
+      ) {
+        patch.activeSport =
+          patch.sports.length === 1 ? patch.sports[0]! : null;
+      }
+    }
+
+    return toPublicPreferences(
+      await this.preferences.updateForUser(userId, patch),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds onboarding preferences and friend/user search APIs for the League Sports mobile/web clients.

### Preferences (`/api/me/preferences`)
- **GET** — returns the current user's sports follows, active sport, and onboarding timestamps
- **PUT** — updates sports list, active sport, and complete/skip onboarding flags
- Prisma schema + migration for `Profile` onboarding fields and `SportFollow`
- New `preferences` module (controller, routes, service, Prisma + in-memory repos, tests)

### User search (`/api/users/search`)
- **GET** `?q=` (or `query`) — authenticated handle/name search with friendship relationship (`none` | `friend` | `incoming` | `outgoing`)
- Extends friends profile lookup with `search()`, wires `SearchUsers` into friends routes

### Also
- Removes accidental `PLACEHOLDER` file from the branch

## Test plan
- [ ] Run preferences unit tests (`preferences.service.test.ts`)
- [ ] Run preferences + user search HTTP tests (`preferences.http.test.ts`)
- [ ] Apply migration and smoke-test GET/PUT `/api/me/preferences`
- [ ] Smoke-test GET `/api/users/search?q=...` with an authenticated session