### PR TITLE
feat: custom training plans + enrollments

### DIFF
--- a/prisma/migrations/20260906083000_training_enrollment/migration.sql
+++ b/prisma/migrations/20260906083000_training_enrollment/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "TrainingEnrollmentStatus" AS ENUM ('active', 'completed');
+
+-- CreateTable
+CREATE TABLE "TrainingEnrollment" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "planId" TEXT NOT NULL,
+    "status" "TrainingEnrollmentStatus" NOT NULL DEFAULT 'active',
+    "completedStepIds" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "percentComplete" INTEGER NOT NULL DEFAULT 0,
+    "currentStepIndex" INTEGER NOT NULL DEFAULT 0,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "TrainingEnrollment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TrainingEnrollment_userId_idx" ON "TrainingEnrollment"("userId");
+
+-- CreateIndex
+CREATE INDEX "TrainingEnrollment_userId_planId_status_idx" ON "TrainingEnrollment"("userId", "planId", "status");
+
+-- At most one active enrollment per user+plan. Completed history may repeat.
+CREATE UNIQUE INDEX "TrainingEnrollment_userId_planId_active_key" ON "TrainingEnrollment"("userId", "planId") WHERE "status" = 'active';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -144,6 +144,30 @@ model BadgeAward {
   @@index([userId])
 }
 
+// Curated training plans live in code (src/modules/training/catalog), not this table.
+// This model is session-owned enrollment + progress only. No User FK — same as
+// Friendship / BadgeAward / CommunityMember.
+enum TrainingEnrollmentStatus {
+  active
+  completed
+}
+
+model TrainingEnrollment {
+  id               String                    @id @default(uuid())
+  userId           String
+  planId           String
+  status           TrainingEnrollmentStatus  @default(active)
+  completedStepIds String[]
+  percentComplete  Int                       @default(0)
+  currentStepIndex Int                       @default(0)
+  startedAt        DateTime                  @default(now())
+  updatedAt        DateTime                  @updatedAt
+  completedAt      DateTime?
+
+  @@index([userId])
+  @@index([userId, planId, status])
+}
+
 
 enum MatchRuleset {
   golden_point

--- a/src/app.ts
+++ b/src/app.ts
@@ -31,6 +31,10 @@ import {
   PreferencesRepository,
 } from "./modules/preferences";
 import {
+  createTrainingModule,
+  TrainingEnrollmentRepository,
+} from "./modules/training";
+import {
   createVenueModule,
   VenueRepository,
 } from "./modules/venue";
@@ -45,6 +49,7 @@ export type CreateAppDependencies = {
   badgeAwardRepository?: BadgeAwardRepository;
   preferencesRepository?: PreferencesRepository;
   communityRepository?: CommunityRepository;
+  trainingEnrollmentRepository?: TrainingEnrollmentRepository;
 };
 
 export async function createApp(
@@ -120,6 +125,12 @@ export async function createApp(
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
+  const training = createTrainingModule({
+    prisma,
+    trainingEnrollmentRepository: dependencies.trainingEnrollmentRepository,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
@@ -129,6 +140,7 @@ export async function createApp(
   app.use(preferences.router);
   app.use(badges.router);
   app.use(communities.router);
+  app.use(training.router);
 
   app.use(
     (

--- a/src/modules/training/catalog/padel-plans.ts
+++ b/src/modules/training/catalog/padel-plans.ts
@@ -1,0 +1,45 @@
+import { TrainingPlanDefinition } from "../entities/training-plan";
+
+/**
+ * Curated padel library — code, not the database.
+ * `accuracy-focus` matches the /athletes “Accuracy Focus” mock
+ * (Warm-up 10, Target Practice 20, Precision Drills 15, Cool-down 5).
+ */
+export const PADEL_PLAN_DEFINITIONS: readonly TrainingPlanDefinition[] = [
+  {
+    id: "accuracy-focus",
+    title: "Accuracy Focus",
+    sport: "padel",
+    focus: "accuracy",
+    steps: [
+      { id: "warm-up", name: "Warm-up", durationMinutes: 10 },
+      { id: "target-practice", name: "Target Practice", durationMinutes: 20 },
+      { id: "precision-drills", name: "Precision Drills", durationMinutes: 15 },
+      { id: "cool-down", name: "Cool-down", durationMinutes: 5 },
+    ],
+  },
+  {
+    id: "consistency-builder",
+    title: "Consistency Builder",
+    sport: "padel",
+    focus: "consistency",
+    steps: [
+      { id: "warm-up-rallies", name: "Warm-up rallies", durationMinutes: 10 },
+      { id: "cross-court", name: "Cross-court rallies", durationMinutes: 15 },
+      { id: "down-the-line", name: "Down-the-line control", durationMinutes: 15 },
+      { id: "cool-down", name: "Cool-down", durationMinutes: 5 },
+    ],
+  },
+  {
+    id: "match-intensity",
+    title: "Match Intensity",
+    sport: "padel",
+    focus: "intensity",
+    steps: [
+      { id: "dynamic-warm-up", name: "Dynamic warm-up", durationMinutes: 8 },
+      { id: "serve-return", name: "Serve and return", durationMinutes: 15 },
+      { id: "point-play", name: "Point play", durationMinutes: 20 },
+      { id: "cool-down", name: "Cool-down", durationMinutes: 7 },
+    ],
+  },
+];

--- a/src/modules/training/catalog/training-catalog.test.ts
+++ b/src/modules/training/catalog/training-catalog.test.ts
@@ -1,0 +1,31 @@
+import { TrainingCatalog } from "./training-catalog";
+
+describe(TrainingCatalog, () => {
+  const catalog = TrainingCatalog.padel();
+
+  test("ships three padel plans including Accuracy Focus from /athletes", () => {
+    const plans = catalog.list();
+    expect(plans).toHaveLength(3);
+    expect(plans.every((plan) => plan.sport.value === "padel")).toBe(true);
+
+    const accuracy = catalog.require("accuracy-focus").toSnapshot();
+    expect(accuracy).toEqual({
+      id: "accuracy-focus",
+      title: "Accuracy Focus",
+      sport: "padel",
+      focus: "accuracy",
+      totalDurationMinutes: 50,
+      steps: [
+        { id: "warm-up", name: "Warm-up", durationMinutes: 10 },
+        { id: "target-practice", name: "Target Practice", durationMinutes: 20 },
+        { id: "precision-drills", name: "Precision Drills", durationMinutes: 15 },
+        { id: "cool-down", name: "Cool-down", durationMinutes: 5 },
+      ],
+    });
+  });
+
+  test("lookup is case-insensitive and unknown ids miss", () => {
+    expect(catalog.get("Accuracy-Focus")?.id.value).toBe("accuracy-focus");
+    expect(catalog.get("missing")).toBeNull();
+  });
+});

--- a/src/modules/training/catalog/training-catalog.ts
+++ b/src/modules/training/catalog/training-catalog.ts
@@ -1,0 +1,42 @@
+import { TrainingPlan } from "../entities/training-plan";
+import { TrainingPlanId } from "../entities/training-plan-id";
+import { TrainingPlanNotFoundError } from "../entities/training-plan-not-found-error";
+import { PADEL_PLAN_DEFINITIONS } from "./padel-plans";
+
+export class TrainingCatalog {
+  private readonly byId: Map<string, TrainingPlan>;
+
+  constructor(plans: readonly TrainingPlan[]) {
+    this.byId = new Map(plans.map((plan) => [plan.id.value, plan]));
+  }
+
+  static padel(): TrainingCatalog {
+    return new TrainingCatalog(
+      PADEL_PLAN_DEFINITIONS.map((definition) =>
+        TrainingPlan.fromDefinition(definition),
+      ),
+    );
+  }
+
+  list(): TrainingPlan[] {
+    return [...this.byId.values()];
+  }
+
+  get(rawId: unknown): TrainingPlan | null {
+    let id: TrainingPlanId;
+    try {
+      id = TrainingPlanId.from(rawId);
+    } catch {
+      return null;
+    }
+    return this.byId.get(id.value) ?? null;
+  }
+
+  require(rawId: unknown): TrainingPlan {
+    const plan = this.get(rawId);
+    if (!plan) {
+      throw new TrainingPlanNotFoundError();
+    }
+    return plan;
+  }
+}

--- a/src/modules/training/controllers/training.controller.ts
+++ b/src/modules/training/controllers/training.controller.ts
@@ -1,0 +1,117 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { TrainingEnrollmentCompletedError } from "../entities/training-enrollment-completed-error";
+import { TrainingEnrollmentNotFoundError } from "../entities/training-enrollment-not-found-error";
+import { TrainingEnrollmentPersistenceError } from "../entities/training-enrollment-persistence-error";
+import { TrainingPlanNotFoundError } from "../entities/training-plan-not-found-error";
+import {
+  AdvanceEnrollment,
+  CreateEnrollment,
+  ListTrainingPlans,
+} from "../services/training.service";
+
+const enrollBodySchema = z.object({
+  planId: z.string(),
+});
+
+const enrollmentIdParamSchema = z.object({
+  id: z.string(),
+});
+
+const advanceBodySchema = z.object({
+  completedStepIds: z.array(z.string()).optional(),
+  percentComplete: z.number().optional(),
+});
+
+export function createTrainingController(deps: {
+  listTrainingPlans: ListTrainingPlans;
+  createEnrollment: CreateEnrollment;
+  advanceEnrollment: AdvanceEnrollment;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async list(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const result = await deps.listTrainingPlans.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTrainingError(res, error);
+      }
+    },
+
+    async enroll(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const body = z.parse(enrollBodySchema, req.body ?? {});
+        const result = await deps.createEnrollment.execute({
+          userId,
+          planId: body.planId,
+        });
+        return res.status(result.resumed ? 200 : 201).json(result);
+      } catch (error) {
+        return sendTrainingError(res, error);
+      }
+    },
+
+    async advance(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(enrollmentIdParamSchema, req.params);
+        const body = z.parse(advanceBodySchema, req.body ?? {});
+        const result = await deps.advanceEnrollment.execute({
+          userId,
+          enrollmentId: id,
+          completedStepIds: body.completedStepIds,
+          percentComplete: body.percentComplete,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTrainingError(res, error);
+      }
+    },
+  };
+}
+
+function sendTrainingError(res: Response, error: unknown) {
+  if (error instanceof TrainingPlanNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof TrainingEnrollmentNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof TrainingEnrollmentCompletedError) {
+    return res.status(409).json({ error: error.message });
+  }
+
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid training payload" });
+  }
+
+  if (error instanceof TrainingEnrollmentPersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/training/controllers/training.http.test.ts
+++ b/src/modules/training/controllers/training.http.test.ts
@@ -1,0 +1,278 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+import jwt from "jsonwebtoken";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { InMemoryTrainingEnrollmentRepository } from "../repositories/in-memory-training-enrollment.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+describe("training HTTP", () => {
+  const config = makeConfig();
+  let enrollments: InMemoryTrainingEnrollmentRepository;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  beforeEach(async () => {
+    enrollments = new InMemoryTrainingEnrollmentRepository();
+    app = await createApp(config, {
+      venueRepository: new InMemoryVenueRepository(),
+      friendshipRepository: new InMemoryFriendshipRepository(),
+      friendProfileLookup: new InMemoryFriendProfileLookup(),
+      trainingEnrollmentRepository: enrollments,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  function cookie(userId: string) {
+    return `token=${jwt.sign({ userId }, config.JWT_SECRET)}`;
+  }
+
+  test("guests get 401 on every training route", async () => {
+    const list = await fetch(`${server.url}/api/me/training/plans`);
+    expect(list.status).toBe(401);
+
+    const enroll = await fetch(`${server.url}/api/me/training/enrollments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ planId: "accuracy-focus" }),
+    });
+    expect(enroll.status).toBe(401);
+
+    const advance = await fetch(
+      `${server.url}/api/me/training/enrollments/any`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ percentComplete: 50 }),
+      },
+    );
+    expect(advance.status).toBe(401);
+  });
+
+  test("list catalog, start, resume, advance, complete, and re-enroll", async () => {
+    const listed = await fetch(`${server.url}/api/me/training/plans`, {
+      headers: { Cookie: cookie("user-a") },
+    });
+    expect(listed.status).toBe(200);
+    const listedBody = (await listed.json()) as {
+      plans: Array<{ id: string; title: string }>;
+      enrollments: unknown[];
+    };
+    expect(listedBody.plans.map((plan) => plan.id)).toEqual([
+      "accuracy-focus",
+      "consistency-builder",
+      "match-intensity",
+    ]);
+    expect(listedBody.plans[0]).toMatchObject({
+      title: "Accuracy Focus",
+      sport: "padel",
+      focus: "accuracy",
+    });
+    expect(listedBody.enrollments).toEqual([]);
+
+    const created = await fetch(`${server.url}/api/me/training/enrollments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({ planId: "accuracy-focus" }),
+    });
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as {
+      resumed: boolean;
+      enrollment: { id: string; status: string; percentComplete: number };
+    };
+    expect(createdBody.resumed).toBe(false);
+    expect(createdBody.enrollment).toMatchObject({
+      planId: "accuracy-focus",
+      status: "active",
+      percentComplete: 0,
+    });
+
+    const resumed = await fetch(`${server.url}/api/me/training/enrollments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({ planId: "accuracy-focus" }),
+    });
+    expect(resumed.status).toBe(200);
+    const resumedBody = (await resumed.json()) as {
+      resumed: boolean;
+      enrollment: { id: string };
+    };
+    expect(resumedBody.resumed).toBe(true);
+    expect(resumedBody.enrollment.id).toBe(createdBody.enrollment.id);
+
+    const advanced = await fetch(
+      `${server.url}/api/me/training/enrollments/${createdBody.enrollment.id}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({
+          completedStepIds: ["warm-up", "target-practice"],
+        }),
+      },
+    );
+    expect(advanced.status).toBe(200);
+    expect(await advanced.json()).toMatchObject({
+      enrollment: {
+        id: createdBody.enrollment.id,
+        completedStepIds: ["warm-up", "target-practice"],
+        percentComplete: 50,
+        currentStepIndex: 2,
+        status: "active",
+      },
+    });
+
+    const finished = await fetch(
+      `${server.url}/api/me/training/enrollments/${createdBody.enrollment.id}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({ percentComplete: 100 }),
+      },
+    );
+    expect(finished.status).toBe(200);
+    expect(await finished.json()).toMatchObject({
+      enrollment: { status: "completed", percentComplete: 100 },
+    });
+
+    const again = await fetch(`${server.url}/api/me/training/enrollments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({ planId: "accuracy-focus" }),
+    });
+    expect(again.status).toBe(201);
+    const againBody = (await again.json()) as {
+      resumed: boolean;
+      enrollment: { id: string; status: string };
+    };
+    expect(againBody.resumed).toBe(false);
+    expect(againBody.enrollment.id).not.toBe(createdBody.enrollment.id);
+    expect(againBody.enrollment.status).toBe("active");
+
+    const history = await fetch(`${server.url}/api/me/training/plans`, {
+      headers: { Cookie: cookie("user-a") },
+    });
+    const historyBody = (await history.json()) as {
+      enrollments: Array<{ id: string; status: string }>;
+    };
+    expect(historyBody.enrollments).toHaveLength(2);
+    expect(historyBody.enrollments[0]).toMatchObject({
+      id: againBody.enrollment.id,
+      status: "active",
+    });
+    expect(historyBody.enrollments[1]).toMatchObject({
+      id: createdBody.enrollment.id,
+      status: "completed",
+    });
+  });
+
+  test("unknown plan, foreign enrollment, and invalid payload map to HTTP errors", async () => {
+    const missingPlan = await fetch(
+      `${server.url}/api/me/training/enrollments`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({ planId: "not-a-plan" }),
+      },
+    );
+    expect(missingPlan.status).toBe(404);
+    expect(await missingPlan.json()).toEqual({
+      error: "Training plan not found",
+    });
+
+    const created = await fetch(`${server.url}/api/me/training/enrollments`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({ planId: "match-intensity" }),
+    });
+    const { enrollment } = (await created.json()) as {
+      enrollment: { id: string };
+    };
+
+    const foreign = await fetch(
+      `${server.url}/api/me/training/enrollments/${enrollment.id}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-b"),
+        },
+        body: JSON.stringify({ percentComplete: 50 }),
+      },
+    );
+    expect(foreign.status).toBe(404);
+
+    const invalid = await fetch(
+      `${server.url}/api/me/training/enrollments/${enrollment.id}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(invalid.status).toBe(400);
+  });
+});

--- a/src/modules/training/entities/completed-step-ids.ts
+++ b/src/modules/training/entities/completed-step-ids.ts
@@ -1,0 +1,80 @@
+import { DomainError } from "../../../lib/domain-error";
+import { PercentComplete } from "./percent-complete";
+import { TrainingPlan } from "./training-plan";
+import { TrainingStepId } from "./training-step-id";
+
+export class CompletedStepIds {
+  private constructor(private readonly ids: string[]) {}
+
+  static empty(): CompletedStepIds {
+    return new CompletedStepIds([]);
+  }
+
+  static from(raw: unknown, plan: TrainingPlan): CompletedStepIds {
+    if (!Array.isArray(raw)) {
+      throw new DomainError("completedStepIds must be an array");
+    }
+
+    const unique: string[] = [];
+    for (const item of raw) {
+      const stepId = TrainingStepId.from(item);
+      if (!plan.hasStep(stepId)) {
+        throw new DomainError(
+          `stepId ${stepId.value} is not part of plan ${plan.id.value}`,
+        );
+      }
+      if (!unique.includes(stepId.value)) {
+        unique.push(stepId.value);
+      }
+    }
+
+    return new CompletedStepIds(orderByPlan(unique, plan));
+  }
+
+  static prefixForPercent(
+    percent: PercentComplete,
+    plan: TrainingPlan,
+  ): CompletedStepIds {
+    const count = Math.round((percent.value / 100) * plan.stepCount);
+    const ids = plan.steps.slice(0, count).map((step) => step.id.value);
+    return new CompletedStepIds(ids);
+  }
+
+  get values(): readonly string[] {
+    return this.ids;
+  }
+
+  get count(): number {
+    return this.ids.length;
+  }
+
+  includes(stepId: string): boolean {
+    return this.ids.includes(stepId);
+  }
+
+  union(other: CompletedStepIds, plan: TrainingPlan): CompletedStepIds {
+    return new CompletedStepIds(
+      orderByPlan([...new Set([...this.ids, ...other.ids])], plan),
+    );
+  }
+
+  toPercent(plan: TrainingPlan): PercentComplete {
+    return PercentComplete.fromCompletedRatio(this.ids.length, plan.stepCount);
+  }
+
+  currentStepIndex(plan: TrainingPlan): number {
+    const next = plan.steps.findIndex((step) => !this.ids.includes(step.id.value));
+    return next === -1 ? plan.stepCount : next;
+  }
+
+  isComplete(plan: TrainingPlan): boolean {
+    return plan.steps.every((step) => this.ids.includes(step.id.value));
+  }
+}
+
+function orderByPlan(ids: string[], plan: TrainingPlan): string[] {
+  const allowed = new Set(ids);
+  return plan.steps
+    .filter((step) => allowed.has(step.id.value))
+    .map((step) => step.id.value);
+}

--- a/src/modules/training/entities/duration-minutes.ts
+++ b/src/modules/training/entities/duration-minutes.ts
@@ -1,0 +1,20 @@
+import { DomainError } from "../../../lib/domain-error";
+
+const MIN = 1;
+const MAX = 180;
+
+export class DurationMinutes {
+  private constructor(readonly value: number) {}
+
+  static from(raw: unknown): DurationMinutes {
+    if (typeof raw !== "number" || !Number.isInteger(raw)) {
+      throw new DomainError("durationMinutes must be a whole number");
+    }
+    if (raw < MIN || raw > MAX) {
+      throw new DomainError(
+        `durationMinutes must be between ${MIN} and ${MAX}`,
+      );
+    }
+    return new DurationMinutes(raw);
+  }
+}

--- a/src/modules/training/entities/enrollment-status.ts
+++ b/src/modules/training/entities/enrollment-status.ts
@@ -1,0 +1,28 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export type EnrollmentStatusValue = "active" | "completed";
+
+export class EnrollmentStatus {
+  static readonly ACTIVE = new EnrollmentStatus("active");
+  static readonly COMPLETED = new EnrollmentStatus("completed");
+
+  private constructor(readonly value: EnrollmentStatusValue) {}
+
+  static from(raw: unknown): EnrollmentStatus {
+    if (raw === "active") return EnrollmentStatus.ACTIVE;
+    if (raw === "completed") return EnrollmentStatus.COMPLETED;
+    throw new DomainError("status must be active or completed");
+  }
+
+  get isActive(): boolean {
+    return this.value === "active";
+  }
+
+  get isCompleted(): boolean {
+    return this.value === "completed";
+  }
+
+  equals(other: EnrollmentStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/training/entities/percent-complete.ts
+++ b/src/modules/training/entities/percent-complete.ts
@@ -1,0 +1,40 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export class PercentComplete {
+  static readonly ZERO = new PercentComplete(0);
+  static readonly HUNDRED = new PercentComplete(100);
+
+  private constructor(readonly value: number) {}
+
+  static from(raw: unknown): PercentComplete {
+    if (typeof raw !== "number" || !Number.isFinite(raw)) {
+      throw new DomainError("percentComplete must be a number");
+    }
+    if (!Number.isInteger(raw)) {
+      throw new DomainError("percentComplete must be a whole number");
+    }
+    if (raw < 0 || raw > 100) {
+      throw new DomainError("percentComplete must be between 0 and 100");
+    }
+    return new PercentComplete(raw);
+  }
+
+  static fromCompletedRatio(
+    completedCount: number,
+    stepCount: number,
+  ): PercentComplete {
+    if (stepCount <= 0) {
+      throw new DomainError("stepCount must be positive");
+    }
+    const ratio = Math.max(0, Math.min(completedCount, stepCount)) / stepCount;
+    return new PercentComplete(Math.round(ratio * 100));
+  }
+
+  get isComplete(): boolean {
+    return this.value === 100;
+  }
+
+  isLessThan(other: PercentComplete): boolean {
+    return this.value < other.value;
+  }
+}

--- a/src/modules/training/entities/training-enrollment-completed-error.ts
+++ b/src/modules/training/entities/training-enrollment-completed-error.ts
@@ -1,0 +1,6 @@
+export class TrainingEnrollmentCompletedError extends Error {
+  constructor() {
+    super("Training enrollment is already completed");
+    this.name = "TrainingEnrollmentCompletedError";
+  }
+}

--- a/src/modules/training/entities/training-enrollment-not-found-error.ts
+++ b/src/modules/training/entities/training-enrollment-not-found-error.ts
@@ -1,0 +1,6 @@
+export class TrainingEnrollmentNotFoundError extends Error {
+  constructor() {
+    super("Training enrollment not found");
+    this.name = "TrainingEnrollmentNotFoundError";
+  }
+}

--- a/src/modules/training/entities/training-enrollment-persistence-error.ts
+++ b/src/modules/training/entities/training-enrollment-persistence-error.ts
@@ -1,0 +1,9 @@
+export class TrainingEnrollmentPersistenceError extends Error {
+  constructor(
+    message = "Unable to save training enrollment",
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "TrainingEnrollmentPersistenceError";
+  }
+}

--- a/src/modules/training/entities/training-enrollment.test.ts
+++ b/src/modules/training/entities/training-enrollment.test.ts
@@ -1,0 +1,192 @@
+import { DomainError } from "../../../lib/domain-error";
+import { TrainingCatalog } from "../catalog/training-catalog";
+import { EnrollmentStatus } from "./enrollment-status";
+import { PercentComplete } from "./percent-complete";
+import { TrainingEnrollment } from "./training-enrollment";
+import { TrainingEnrollmentCompletedError } from "./training-enrollment-completed-error";
+import { TrainingFocus } from "./training-focus";
+import { TrainingPlan } from "./training-plan";
+import { TrainingPlanId } from "./training-plan-id";
+import { TrainingSport } from "./training-sport";
+
+function accuracyPlan() {
+  return TrainingCatalog.padel().require("accuracy-focus");
+}
+
+describe("training value objects", () => {
+  test("plan id and step id require kebab-case slugs", () => {
+    expect(TrainingPlanId.from("Accuracy-Focus").value).toBe("accuracy-focus");
+    expect(() => TrainingPlanId.from("")).toThrow(DomainError);
+    expect(() => TrainingPlanId.from("Accuracy Focus")).toThrow(DomainError);
+  });
+
+  test("sport is padel-only and focus is optional", () => {
+    expect(TrainingSport.from("Padel").value).toBe("padel");
+    expect(() => TrainingSport.from("golf")).toThrow(DomainError);
+    expect(TrainingFocus.from("Accuracy")?.value).toBe("accuracy");
+    expect(TrainingFocus.from(null)).toBeNull();
+    expect(TrainingFocus.from("  ")).toBeNull();
+    expect(() => TrainingFocus.from("footwork")).toThrow(DomainError);
+  });
+
+  test("percent is a whole number 0-100 and derives from completed ratio", () => {
+    expect(PercentComplete.from(50).value).toBe(50);
+    expect(PercentComplete.fromCompletedRatio(2, 4).value).toBe(50);
+    expect(PercentComplete.fromCompletedRatio(4, 4).isComplete).toBe(true);
+    expect(() => PercentComplete.from(101)).toThrow(DomainError);
+    expect(() => PercentComplete.from(12.5)).toThrow(DomainError);
+    expect(() => PercentComplete.from(-1)).toThrow(DomainError);
+  });
+
+  test("status is active or completed", () => {
+    expect(EnrollmentStatus.from("active").isActive).toBe(true);
+    expect(EnrollmentStatus.from("completed").isCompleted).toBe(true);
+    expect(() => EnrollmentStatus.from("paused")).toThrow(DomainError);
+  });
+});
+
+describe(TrainingPlan, () => {
+  test("rejects empty or duplicate steps", () => {
+    expect(() =>
+      TrainingPlan.fromDefinition({
+        id: "empty",
+        title: "Empty",
+        sport: "padel",
+        steps: [],
+      }),
+    ).toThrow(DomainError);
+
+    expect(() =>
+      TrainingPlan.fromDefinition({
+        id: "dupes",
+        title: "Dupes",
+        sport: "padel",
+        steps: [
+          { id: "warm-up", name: "A", durationMinutes: 10 },
+          { id: "warm-up", name: "B", durationMinutes: 10 },
+        ],
+      }),
+    ).toThrow(DomainError);
+  });
+});
+
+describe(TrainingEnrollment, () => {
+  test("start is empty progress on the given plan", () => {
+    const plan = accuracyPlan();
+    const enrollment = TrainingEnrollment.start("user-a", plan);
+    const snapshot = enrollment.toSnapshot();
+
+    expect(enrollment.id).toBeTruthy();
+    expect(snapshot).toMatchObject({
+      userId: "user-a",
+      planId: "accuracy-focus",
+      status: "active",
+      completedStepIds: [],
+      percentComplete: 0,
+      currentStepIndex: 0,
+      completedAt: null,
+    });
+  });
+
+  test("completed steps union, derive percent, and point at the next step", () => {
+    const plan = accuracyPlan();
+    const enrollment = TrainingEnrollment.start("user-a", plan);
+
+    enrollment.advanceByCompletedSteps(["warm-up"], plan);
+    expect(enrollment.toSnapshot()).toMatchObject({
+      completedStepIds: ["warm-up"],
+      percentComplete: 25,
+      currentStepIndex: 1,
+      status: "active",
+    });
+
+    enrollment.advanceByCompletedSteps(["warm-up", "target-practice"], plan);
+    expect(enrollment.toSnapshot()).toMatchObject({
+      completedStepIds: ["warm-up", "target-practice"],
+      percentComplete: 50,
+      currentStepIndex: 2,
+    });
+  });
+
+  test("unknown step ids are domain errors", () => {
+    const plan = accuracyPlan();
+    const enrollment = TrainingEnrollment.start("user-a", plan);
+    expect(() =>
+      enrollment.advanceByCompletedSteps(["not-a-step"], plan),
+    ).toThrow(DomainError);
+  });
+
+  test("percent advance materializes a prefix of steps", () => {
+    const plan = accuracyPlan();
+    const enrollment = TrainingEnrollment.start("user-a", plan);
+
+    enrollment.advanceByPercent(50, plan);
+    expect(enrollment.toSnapshot()).toMatchObject({
+      completedStepIds: ["warm-up", "target-practice"],
+      percentComplete: 50,
+      currentStepIndex: 2,
+      status: "active",
+    });
+  });
+
+  test("percent cannot decrease on an active enrollment", () => {
+    const plan = accuracyPlan();
+    const enrollment = TrainingEnrollment.start("user-a", plan);
+    enrollment.advanceByPercent(50, plan);
+    expect(() => enrollment.advanceByPercent(25, plan)).toThrow(DomainError);
+  });
+
+  test("all steps or 100% marks the enrollment completed", () => {
+    const plan = accuracyPlan();
+    const bySteps = TrainingEnrollment.start("user-a", plan);
+    bySteps.advanceByCompletedSteps(
+      ["warm-up", "target-practice", "precision-drills", "cool-down"],
+      plan,
+    );
+    expect(bySteps.toSnapshot()).toMatchObject({
+      status: "completed",
+      percentComplete: 100,
+      currentStepIndex: 4,
+    });
+    expect(bySteps.completedAt).toBeInstanceOf(Date);
+
+    const byPercent = TrainingEnrollment.start("user-a", plan);
+    byPercent.advanceByPercent(100, plan);
+    expect(byPercent.toSnapshot()).toMatchObject({
+      status: "completed",
+      completedStepIds: [
+        "warm-up",
+        "target-practice",
+        "precision-drills",
+        "cool-down",
+      ],
+      percentComplete: 100,
+    });
+  });
+
+  test("completing again is a no-op; regressing a completed enrollment errors", () => {
+    const plan = accuracyPlan();
+    const enrollment = TrainingEnrollment.start("user-a", plan);
+    enrollment.advanceByPercent(100, plan);
+    const before = enrollment.toSnapshot();
+
+    enrollment.advanceByPercent(100, plan);
+    enrollment.advanceByCompletedSteps(
+      ["warm-up", "target-practice", "precision-drills", "cool-down"],
+      plan,
+    );
+    expect(enrollment.toSnapshot()).toEqual(before);
+
+    expect(() => enrollment.advanceByPercent(50, plan)).toThrow(
+      TrainingEnrollmentCompletedError,
+    );
+  });
+
+  test("rehydrate + snapshot round-trips progress", () => {
+    const plan = accuracyPlan();
+    const created = TrainingEnrollment.start("user-a", plan);
+    created.advanceByCompletedSteps(["warm-up", "target-practice"], plan);
+    const restored = TrainingEnrollment.fromSnapshot(created.toSnapshot(), plan);
+    expect(restored.toSnapshot()).toEqual(created.toSnapshot());
+  });
+});

--- a/src/modules/training/entities/training-enrollment.ts
+++ b/src/modules/training/entities/training-enrollment.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { CompletedStepIds } from "./completed-step-ids";
+import { EnrollmentStatus } from "./enrollment-status";
+import { PercentComplete } from "./percent-complete";
+import { TrainingEnrollmentCompletedError } from "./training-enrollment-completed-error";
+import { TrainingPlan } from "./training-plan";
+import { TrainingPlanId } from "./training-plan-id";
+
+export type TrainingEnrollmentSnapshot = {
+  id: string;
+  userId: string;
+  planId: string;
+  status: "active" | "completed";
+  completedStepIds: string[];
+  percentComplete: number;
+  currentStepIndex: number;
+  startedAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+};
+
+export class TrainingEnrollment {
+  private constructor(
+    readonly id: string,
+    readonly userId: string,
+    readonly planId: TrainingPlanId,
+    readonly startedAt: Date,
+    private statusValue: EnrollmentStatus,
+    private completedStepIdsValue: CompletedStepIds,
+    private percentCompleteValue: PercentComplete,
+    private currentStepIndexValue: number,
+    private updatedAtValue: Date,
+    private completedAtValue: Date | null,
+  ) {}
+
+  static start(userId: string, plan: TrainingPlan): TrainingEnrollment {
+    const now = new Date();
+    return new TrainingEnrollment(
+      randomUUID(),
+      requiredTrimmed(userId, "userId"),
+      plan.id,
+      now,
+      EnrollmentStatus.ACTIVE,
+      CompletedStepIds.empty(),
+      PercentComplete.ZERO,
+      0,
+      now,
+      null,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    userId: string;
+    planId: TrainingPlanId;
+    status: EnrollmentStatus;
+    completedStepIds: CompletedStepIds;
+    percentComplete: PercentComplete;
+    currentStepIndex: number;
+    startedAt: Date;
+    updatedAt: Date;
+    completedAt: Date | null;
+  }): TrainingEnrollment {
+    return new TrainingEnrollment(
+      props.id,
+      props.userId,
+      props.planId,
+      props.startedAt,
+      props.status,
+      props.completedStepIds,
+      props.percentComplete,
+      props.currentStepIndex,
+      props.updatedAt,
+      props.completedAt,
+    );
+  }
+
+  static fromSnapshot(
+    snapshot: TrainingEnrollmentSnapshot,
+    plan: TrainingPlan,
+  ): TrainingEnrollment {
+    if (snapshot.planId !== plan.id.value) {
+      throw new DomainError("enrollment planId does not match catalog plan");
+    }
+
+    return TrainingEnrollment.rehydrate({
+      id: snapshot.id,
+      userId: snapshot.userId,
+      planId: TrainingPlanId.from(snapshot.planId),
+      status: EnrollmentStatus.from(snapshot.status),
+      completedStepIds: CompletedStepIds.from(snapshot.completedStepIds, plan),
+      percentComplete: PercentComplete.from(snapshot.percentComplete),
+      currentStepIndex: snapshot.currentStepIndex,
+      startedAt: new Date(snapshot.startedAt),
+      updatedAt: new Date(snapshot.updatedAt),
+      completedAt: snapshot.completedAt ? new Date(snapshot.completedAt) : null,
+    });
+  }
+
+  get status(): EnrollmentStatus {
+    return this.statusValue;
+  }
+
+  get completedStepIds(): readonly string[] {
+    return this.completedStepIdsValue.values;
+  }
+
+  get percentComplete(): number {
+    return this.percentCompleteValue.value;
+  }
+
+  get currentStepIndex(): number {
+    return this.currentStepIndexValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  get completedAt(): Date | null {
+    return this.completedAtValue;
+  }
+
+  get isCompleted(): boolean {
+    return this.statusValue.isCompleted;
+  }
+
+  belongsTo(userId: string): boolean {
+    return this.userId === userId.trim();
+  }
+
+  advanceByCompletedSteps(rawIds: unknown, plan: TrainingPlan): void {
+    this.assertPlan(plan);
+    const incoming = CompletedStepIds.from(rawIds, plan);
+    this.applyProgress(this.completedStepIdsValue.union(incoming, plan), plan);
+  }
+
+  advanceByPercent(rawPercent: unknown, plan: TrainingPlan): void {
+    this.assertPlan(plan);
+    const percent = PercentComplete.from(rawPercent);
+    if (percent.isLessThan(this.percentCompleteValue)) {
+      if (this.statusValue.isCompleted) {
+        throw new TrainingEnrollmentCompletedError();
+      }
+      throw new DomainError("percentComplete cannot decrease");
+    }
+    const incoming = CompletedStepIds.prefixForPercent(percent, plan);
+    this.applyProgress(this.completedStepIdsValue.union(incoming, plan), plan);
+  }
+
+  toSnapshot(): TrainingEnrollmentSnapshot {
+    return {
+      id: this.id,
+      userId: this.userId,
+      planId: this.planId.value,
+      status: this.statusValue.value,
+      completedStepIds: [...this.completedStepIdsValue.values],
+      percentComplete: this.percentCompleteValue.value,
+      currentStepIndex: this.currentStepIndexValue,
+      startedAt: this.startedAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+      completedAt: this.completedAtValue
+        ? this.completedAtValue.toISOString()
+        : null,
+    };
+  }
+
+  private applyProgress(completed: CompletedStepIds, plan: TrainingPlan): void {
+    const percent = completed.toPercent(plan);
+    const currentStepIndex = completed.currentStepIndex(plan);
+    const done = completed.isComplete(plan) || percent.isComplete;
+
+    if (this.statusValue.isCompleted) {
+      if (done) {
+        return;
+      }
+      throw new TrainingEnrollmentCompletedError();
+    }
+
+    const unchanged =
+      this.listsEqual(this.completedStepIdsValue.values, completed.values) &&
+      this.percentCompleteValue.value === percent.value &&
+      this.currentStepIndexValue === currentStepIndex;
+    if (unchanged) {
+      return;
+    }
+
+    this.completedStepIdsValue = completed;
+    this.percentCompleteValue = done ? PercentComplete.HUNDRED : percent;
+    this.currentStepIndexValue = done ? plan.stepCount : currentStepIndex;
+    this.updatedAtValue = new Date();
+
+    if (done) {
+      this.statusValue = EnrollmentStatus.COMPLETED;
+      this.completedAtValue = this.updatedAtValue;
+    }
+  }
+
+  private assertPlan(plan: TrainingPlan): void {
+    if (!this.planId.equals(plan.id)) {
+      throw new DomainError("enrollment planId does not match catalog plan");
+    }
+  }
+
+  private listsEqual(left: readonly string[], right: readonly string[]): boolean {
+    if (left.length !== right.length) return false;
+    return left.every((id, index) => id === right[index]);
+  }
+}

--- a/src/modules/training/entities/training-focus.ts
+++ b/src/modules/training/entities/training-focus.ts
@@ -1,0 +1,35 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const TRAINING_FOCUSES = [
+  "accuracy",
+  "consistency",
+  "intensity",
+] as const;
+export type TrainingFocusValue = (typeof TRAINING_FOCUSES)[number];
+
+export class TrainingFocus {
+  static readonly ACCURACY = new TrainingFocus("accuracy");
+  static readonly CONSISTENCY = new TrainingFocus("consistency");
+  static readonly INTENSITY = new TrainingFocus("intensity");
+
+  private constructor(readonly value: TrainingFocusValue) {}
+
+  static from(raw: unknown): TrainingFocus | null {
+    if (raw == null) return null;
+    if (typeof raw !== "string") {
+      throw new DomainError("focus must be accuracy, consistency, or intensity");
+    }
+
+    const focus = raw.trim().toLowerCase();
+    if (focus.length === 0) return null;
+    if (focus === "accuracy") return TrainingFocus.ACCURACY;
+    if (focus === "consistency") return TrainingFocus.CONSISTENCY;
+    if (focus === "intensity") return TrainingFocus.INTENSITY;
+
+    throw new DomainError("focus must be accuracy, consistency, or intensity");
+  }
+
+  equals(other: TrainingFocus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/training/entities/training-plan-id.ts
+++ b/src/modules/training/entities/training-plan-id.ts
@@ -1,0 +1,23 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const MAX_LENGTH = 80;
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export class TrainingPlanId {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): TrainingPlanId {
+    const id = requiredTrimmed(raw, "planId").toLowerCase();
+    if (id.length > MAX_LENGTH) {
+      throw new DomainError(`planId must be at most ${MAX_LENGTH} characters`);
+    }
+    if (!SLUG.test(id)) {
+      throw new DomainError("planId must be a kebab-case slug");
+    }
+    return new TrainingPlanId(id);
+  }
+
+  equals(other: TrainingPlanId): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/training/entities/training-plan-not-found-error.ts
+++ b/src/modules/training/entities/training-plan-not-found-error.ts
@@ -1,0 +1,6 @@
+export class TrainingPlanNotFoundError extends Error {
+  constructor() {
+    super("Training plan not found");
+    this.name = "TrainingPlanNotFoundError";
+  }
+}

--- a/src/modules/training/entities/training-plan-title.ts
+++ b/src/modules/training/entities/training-plan-title.ts
@@ -1,0 +1,15 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const MAX_LENGTH = 80;
+
+export class TrainingPlanTitle {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): TrainingPlanTitle {
+    const title = requiredTrimmed(raw, "title");
+    if (title.length > MAX_LENGTH) {
+      throw new DomainError(`title must be at most ${MAX_LENGTH} characters`);
+    }
+    return new TrainingPlanTitle(title);
+  }
+}

--- a/src/modules/training/entities/training-plan.ts
+++ b/src/modules/training/entities/training-plan.ts
@@ -1,0 +1,96 @@
+import { DomainError } from "../../../lib/domain-error";
+import { TrainingFocus, TrainingFocusValue } from "./training-focus";
+import { TrainingPlanId } from "./training-plan-id";
+import { TrainingPlanTitle } from "./training-plan-title";
+import { TrainingSport, TrainingSportValue } from "./training-sport";
+import { TrainingStep, TrainingStepSnapshot } from "./training-step";
+import { TrainingStepId } from "./training-step-id";
+
+export type TrainingPlanDefinition = {
+  id: string;
+  title: string;
+  sport: TrainingSportValue;
+  focus?: TrainingFocusValue | null;
+  steps: Array<{
+    id: string;
+    name: string;
+    durationMinutes: number;
+  }>;
+};
+
+export type TrainingPlanSnapshot = {
+  id: string;
+  title: string;
+  sport: TrainingSportValue;
+  focus: TrainingFocusValue | null;
+  steps: TrainingStepSnapshot[];
+  totalDurationMinutes: number;
+};
+
+export class TrainingPlan {
+  private constructor(
+    readonly id: TrainingPlanId,
+    readonly title: TrainingPlanTitle,
+    readonly sport: TrainingSport,
+    readonly focus: TrainingFocus | null,
+    private readonly stepsValue: TrainingStep[],
+  ) {}
+
+  static fromDefinition(definition: TrainingPlanDefinition): TrainingPlan {
+    const steps = definition.steps.map((step) => TrainingStep.from(step));
+    if (steps.length === 0) {
+      throw new DomainError("plan must have at least one step");
+    }
+
+    const seen = new Set<string>();
+    for (const step of steps) {
+      if (seen.has(step.id.value)) {
+        throw new DomainError("plan step ids must be unique");
+      }
+      seen.add(step.id.value);
+    }
+
+    return new TrainingPlan(
+      TrainingPlanId.from(definition.id),
+      TrainingPlanTitle.from(definition.title),
+      TrainingSport.from(definition.sport),
+      TrainingFocus.from(definition.focus),
+      steps,
+    );
+  }
+
+  get steps(): readonly TrainingStep[] {
+    return this.stepsValue;
+  }
+
+  get stepCount(): number {
+    return this.stepsValue.length;
+  }
+
+  get totalDurationMinutes(): number {
+    return this.stepsValue.reduce(
+      (sum, step) => sum + step.durationMinutes.value,
+      0,
+    );
+  }
+
+  stepById(rawId: string): TrainingStep | null {
+    const id = rawId.trim().toLowerCase();
+    return this.stepsValue.find((step) => step.id.value === id) ?? null;
+  }
+
+  hasStep(stepId: TrainingStepId): boolean {
+    return this.stepsValue.some((step) => step.id.equals(stepId));
+  }
+
+  toSnapshot(): TrainingPlanSnapshot {
+    return {
+      id: this.id.value,
+      title: this.title.value,
+      sport: this.sport.value,
+      focus: this.focus?.value ?? null,
+      steps: this.stepsValue.map((step) => step.toSnapshot()),
+      totalDurationMinutes: this.totalDurationMinutes,
+    };
+  }
+}

--- a/src/modules/training/entities/training-sport.ts
+++ b/src/modules/training/entities/training-sport.ts
@@ -1,0 +1,25 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const TRAINING_SPORTS = ["padel"] as const;
+export type TrainingSportValue = (typeof TRAINING_SPORTS)[number];
+
+export class TrainingSport {
+  static readonly PADEL = new TrainingSport("padel");
+
+  private constructor(readonly value: TrainingSportValue) {}
+
+  static from(raw: unknown): TrainingSport {
+    if (typeof raw !== "string") {
+      throw new DomainError("sport must be padel");
+    }
+
+    const sport = raw.trim().toLowerCase();
+    if (sport === "padel") return TrainingSport.PADEL;
+
+    throw new DomainError("sport must be padel");
+  }
+
+  equals(other: TrainingSport): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/training/entities/training-step-id.ts
+++ b/src/modules/training/entities/training-step-id.ts
@@ -1,0 +1,23 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const MAX_LENGTH = 80;
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export class TrainingStepId {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): TrainingStepId {
+    const id = requiredTrimmed(raw, "stepId").toLowerCase();
+    if (id.length > MAX_LENGTH) {
+      throw new DomainError(`stepId must be at most ${MAX_LENGTH} characters`);
+    }
+    if (!SLUG.test(id)) {
+      throw new DomainError("stepId must be a kebab-case slug");
+    }
+    return new TrainingStepId(id);
+  }
+
+  equals(other: TrainingStepId): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/training/entities/training-step.ts
+++ b/src/modules/training/entities/training-step.ts
@@ -1,0 +1,45 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { DurationMinutes } from "./duration-minutes";
+import { TrainingStepId } from "./training-step-id";
+
+const MAX_NAME_LENGTH = 80;
+
+export type TrainingStepSnapshot = {
+  id: string;
+  name: string;
+  durationMinutes: number;
+};
+
+export class TrainingStep {
+  private constructor(
+    readonly id: TrainingStepId,
+    readonly name: string,
+    readonly durationMinutes: DurationMinutes,
+  ) {}
+
+  static from(props: {
+    id: unknown;
+    name: unknown;
+    durationMinutes: unknown;
+  }): TrainingStep {
+    const name = requiredTrimmed(props.name, "step name");
+    if (name.length > MAX_NAME_LENGTH) {
+      throw new DomainError(
+        `step name must be at most ${MAX_NAME_LENGTH} characters`,
+      );
+    }
+    return new TrainingStep(
+      TrainingStepId.from(props.id),
+      name,
+      DurationMinutes.from(props.durationMinutes),
+    );
+  }
+
+  toSnapshot(): TrainingStepSnapshot {
+    return {
+      id: this.id.value,
+      name: this.name,
+      durationMinutes: this.durationMinutes.value,
+    };
+  }
+}

--- a/src/modules/training/index.ts
+++ b/src/modules/training/index.ts
@@ -1,0 +1,92 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { TrainingCatalog } from "./catalog/training-catalog";
+import { createTrainingController } from "./controllers/training.controller";
+import { PrismaTrainingEnrollmentRepository } from "./repositories/prisma-training-enrollment.repository";
+import { TrainingEnrollmentRepository } from "./repositories/training-enrollment.repository";
+import { createTrainingRoutes } from "./routes/training.routes";
+import {
+  AdvanceEnrollment,
+  CreateEnrollment,
+  ListTrainingPlans,
+} from "./services/training.service";
+
+export type CreateTrainingModuleParams = {
+  prisma: PrismaClient;
+  trainingEnrollmentRepository?: TrainingEnrollmentRepository;
+  catalog?: TrainingCatalog;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type TrainingModule = {
+  router: Router;
+  trainingEnrollmentRepository: TrainingEnrollmentRepository;
+};
+
+export function createTrainingModule({
+  prisma,
+  trainingEnrollmentRepository: repositoryOverride,
+  catalog: catalogOverride,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreateTrainingModuleParams): TrainingModule {
+  const catalog = catalogOverride ?? TrainingCatalog.padel();
+  const trainingEnrollmentRepository =
+    repositoryOverride ??
+    new PrismaTrainingEnrollmentRepository(prisma, catalog);
+
+  const controller = createTrainingController({
+    listTrainingPlans: new ListTrainingPlans(
+      trainingEnrollmentRepository,
+      catalog,
+    ),
+    createEnrollment: new CreateEnrollment(
+      trainingEnrollmentRepository,
+      catalog,
+    ),
+    advanceEnrollment: new AdvanceEnrollment(
+      trainingEnrollmentRepository,
+      catalog,
+    ),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createTrainingRoutes(controller, { requireAuth }),
+    trainingEnrollmentRepository,
+  };
+}
+
+export { createTrainingController } from "./controllers/training.controller";
+export { TrainingCatalog } from "./catalog/training-catalog";
+export { PADEL_PLAN_DEFINITIONS } from "./catalog/padel-plans";
+export { InMemoryTrainingEnrollmentRepository } from "./repositories/in-memory-training-enrollment.repository";
+export { PrismaTrainingEnrollmentRepository } from "./repositories/prisma-training-enrollment.repository";
+export type { TrainingEnrollmentRepository } from "./repositories/training-enrollment.repository";
+export { TrainingEnrollment } from "./entities/training-enrollment";
+export { TrainingPlan } from "./entities/training-plan";
+export { TrainingPlanId } from "./entities/training-plan-id";
+export { TrainingSport, TRAINING_SPORTS } from "./entities/training-sport";
+export { TrainingFocus, TRAINING_FOCUSES } from "./entities/training-focus";
+export { EnrollmentStatus } from "./entities/enrollment-status";
+export { PercentComplete } from "./entities/percent-complete";
+export { TrainingEnrollmentPersistenceError } from "./entities/training-enrollment-persistence-error";
+export { TrainingEnrollmentNotFoundError } from "./entities/training-enrollment-not-found-error";
+export { TrainingEnrollmentCompletedError } from "./entities/training-enrollment-completed-error";
+export { TrainingPlanNotFoundError } from "./entities/training-plan-not-found-error";
+export {
+  AdvanceEnrollment,
+  CreateEnrollment,
+  ListTrainingPlans,
+} from "./services/training.service";
+export type {
+  PublicEnrollment,
+  PublicTrainingPlan,
+} from "./services/training.service";

--- a/src/modules/training/repositories/in-memory-training-enrollment.repository.ts
+++ b/src/modules/training/repositories/in-memory-training-enrollment.repository.ts
@@ -1,0 +1,75 @@
+import { TrainingCatalog } from "../catalog/training-catalog";
+import { TrainingEnrollment } from "../entities/training-enrollment";
+import { TrainingEnrollmentPersistenceError } from "../entities/training-enrollment-persistence-error";
+import { TrainingPlanId } from "../entities/training-plan-id";
+import { TrainingEnrollmentRepository } from "./training-enrollment.repository";
+
+export class InMemoryTrainingEnrollmentRepository
+  implements TrainingEnrollmentRepository
+{
+  private readonly byId = new Map<string, TrainingEnrollment>();
+
+  constructor(private readonly catalog: TrainingCatalog = TrainingCatalog.padel()) {}
+
+  async findById(id: string): Promise<TrainingEnrollment | null> {
+    return clone(this.byId.get(id) ?? null, this.catalog);
+  }
+
+  async findActiveByUserAndPlan(
+    userId: string,
+    planId: TrainingPlanId,
+  ): Promise<TrainingEnrollment | null> {
+    const match = [...this.byId.values()].find(
+      (enrollment) =>
+        enrollment.belongsTo(userId) &&
+        enrollment.planId.equals(planId) &&
+        enrollment.status.isActive,
+    );
+    return clone(match ?? null, this.catalog);
+  }
+
+  async create(enrollment: TrainingEnrollment): Promise<TrainingEnrollment> {
+    const stored = clone(enrollment, this.catalog)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored, this.catalog)!;
+  }
+
+  async persist(enrollment: TrainingEnrollment): Promise<TrainingEnrollment> {
+    if (!this.byId.has(enrollment.id)) {
+      throw new TrainingEnrollmentPersistenceError(
+        "Unable to save training enrollment",
+      );
+    }
+    const stored = clone(enrollment, this.catalog)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored, this.catalog)!;
+  }
+
+  async listForUser(userId: string): Promise<TrainingEnrollment[]> {
+    return [...this.byId.values()]
+      .filter((enrollment) => enrollment.belongsTo(userId))
+      .sort(compareEnrollments)
+      .map((enrollment) => clone(enrollment, this.catalog)!);
+  }
+}
+
+function compareEnrollments(a: TrainingEnrollment, b: TrainingEnrollment): number {
+  if (a.status.isActive !== b.status.isActive) {
+    return a.status.isActive ? -1 : 1;
+  }
+  return b.updatedAt.getTime() - a.updatedAt.getTime();
+}
+
+function clone(
+  enrollment: TrainingEnrollment | null,
+  catalog: TrainingCatalog,
+): TrainingEnrollment | null {
+  if (!enrollment) return null;
+  const plan = catalog.get(enrollment.planId.value);
+  if (!plan) {
+    throw new TrainingEnrollmentPersistenceError(
+      "Unable to load training enrollment",
+    );
+  }
+  return TrainingEnrollment.fromSnapshot(enrollment.toSnapshot(), plan);
+}

--- a/src/modules/training/repositories/prisma-training-enrollment.repository.ts
+++ b/src/modules/training/repositories/prisma-training-enrollment.repository.ts
@@ -1,0 +1,165 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { TrainingCatalog } from "../catalog/training-catalog";
+import { CompletedStepIds } from "../entities/completed-step-ids";
+import { EnrollmentStatus } from "../entities/enrollment-status";
+import { PercentComplete } from "../entities/percent-complete";
+import { TrainingEnrollment } from "../entities/training-enrollment";
+import { TrainingEnrollmentPersistenceError } from "../entities/training-enrollment-persistence-error";
+import { TrainingPlanId } from "../entities/training-plan-id";
+import { TrainingEnrollmentRepository } from "./training-enrollment.repository";
+
+type EnrollmentRow = {
+  id: string;
+  userId: string;
+  planId: string;
+  status: "active" | "completed";
+  completedStepIds: string[];
+  percentComplete: number;
+  currentStepIndex: number;
+  startedAt: Date;
+  updatedAt: Date;
+  completedAt: Date | null;
+};
+
+function toDomain(
+  row: EnrollmentRow,
+  catalog: TrainingCatalog,
+): TrainingEnrollment {
+  const plan = catalog.get(row.planId);
+  if (!plan) {
+    throw new TrainingEnrollmentPersistenceError(
+      `Unknown catalog plan ${row.planId}`,
+    );
+  }
+
+  return TrainingEnrollment.rehydrate({
+    id: row.id,
+    userId: row.userId,
+    planId: TrainingPlanId.from(row.planId),
+    status: EnrollmentStatus.from(row.status),
+    completedStepIds: CompletedStepIds.from(row.completedStepIds, plan),
+    percentComplete: PercentComplete.from(row.percentComplete),
+    currentStepIndex: row.currentStepIndex,
+    startedAt: row.startedAt,
+    updatedAt: row.updatedAt,
+    completedAt: row.completedAt,
+  });
+}
+
+export class PrismaTrainingEnrollmentRepository
+  implements TrainingEnrollmentRepository
+{
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly catalog: TrainingCatalog = TrainingCatalog.padel(),
+  ) {}
+
+  async findById(id: string): Promise<TrainingEnrollment | null> {
+    try {
+      const row = await this.prisma.trainingEnrollment.findUnique({
+        where: { id },
+      });
+      return row ? toDomain(row, this.catalog) : null;
+    } catch (error) {
+      if (error instanceof TrainingEnrollmentPersistenceError) throw error;
+      throw new TrainingEnrollmentPersistenceError(
+        "Failed to load training enrollment",
+        { cause: error },
+      );
+    }
+  }
+
+  async findActiveByUserAndPlan(
+    userId: string,
+    planId: TrainingPlanId,
+  ): Promise<TrainingEnrollment | null> {
+    try {
+      const row = await this.prisma.trainingEnrollment.findFirst({
+        where: {
+          userId,
+          planId: planId.value,
+          status: "active",
+        },
+      });
+      return row ? toDomain(row, this.catalog) : null;
+    } catch (error) {
+      if (error instanceof TrainingEnrollmentPersistenceError) throw error;
+      throw new TrainingEnrollmentPersistenceError(
+        "Failed to load training enrollment",
+        { cause: error },
+      );
+    }
+  }
+
+  async create(enrollment: TrainingEnrollment): Promise<TrainingEnrollment> {
+    const snapshot = enrollment.toSnapshot();
+    try {
+      const row = await this.prisma.trainingEnrollment.create({
+        data: {
+          id: snapshot.id,
+          userId: snapshot.userId,
+          planId: snapshot.planId,
+          status: snapshot.status,
+          completedStepIds: snapshot.completedStepIds,
+          percentComplete: snapshot.percentComplete,
+          currentStepIndex: snapshot.currentStepIndex,
+          startedAt: enrollment.startedAt,
+          updatedAt: enrollment.updatedAt,
+          completedAt: enrollment.completedAt,
+        },
+      });
+      return toDomain(row, this.catalog);
+    } catch (error) {
+      throw new TrainingEnrollmentPersistenceError(
+        "Failed to create training enrollment",
+        { cause: error },
+      );
+    }
+  }
+
+  async persist(enrollment: TrainingEnrollment): Promise<TrainingEnrollment> {
+    const snapshot = enrollment.toSnapshot();
+    try {
+      const row = await this.prisma.trainingEnrollment.update({
+        where: { id: snapshot.id },
+        data: {
+          status: snapshot.status,
+          completedStepIds: snapshot.completedStepIds,
+          percentComplete: snapshot.percentComplete,
+          currentStepIndex: snapshot.currentStepIndex,
+          updatedAt: enrollment.updatedAt,
+          completedAt: enrollment.completedAt,
+        },
+      });
+      return toDomain(row, this.catalog);
+    } catch (error) {
+      throw new TrainingEnrollmentPersistenceError(
+        "Failed to save training enrollment",
+        { cause: error },
+      );
+    }
+  }
+
+  async listForUser(userId: string): Promise<TrainingEnrollment[]> {
+    try {
+      const rows = await this.prisma.trainingEnrollment.findMany({
+        where: { userId },
+        orderBy: [{ status: "asc" }, { updatedAt: "desc" }],
+      });
+      return rows
+        .map((row) => toDomain(row, this.catalog))
+        .sort((a, b) => {
+          if (a.status.isActive !== b.status.isActive) {
+            return a.status.isActive ? -1 : 1;
+          }
+          return b.updatedAt.getTime() - a.updatedAt.getTime();
+        });
+    } catch (error) {
+      if (error instanceof TrainingEnrollmentPersistenceError) throw error;
+      throw new TrainingEnrollmentPersistenceError(
+        "Failed to list training enrollments",
+        { cause: error },
+      );
+    }
+  }
+}

--- a/src/modules/training/repositories/training-enrollment.repository.ts
+++ b/src/modules/training/repositories/training-enrollment.repository.ts
@@ -1,0 +1,13 @@
+import { TrainingEnrollment } from "../entities/training-enrollment";
+import { TrainingPlanId } from "../entities/training-plan-id";
+
+export interface TrainingEnrollmentRepository {
+  findById(id: string): Promise<TrainingEnrollment | null>;
+  findActiveByUserAndPlan(
+    userId: string,
+    planId: TrainingPlanId,
+  ): Promise<TrainingEnrollment | null>;
+  create(enrollment: TrainingEnrollment): Promise<TrainingEnrollment>;
+  persist(enrollment: TrainingEnrollment): Promise<TrainingEnrollment>;
+  listForUser(userId: string): Promise<TrainingEnrollment[]>;
+}

--- a/src/modules/training/routes/training.routes.ts
+++ b/src/modules/training/routes/training.routes.ts
@@ -1,0 +1,38 @@
+import { Router } from "express";
+
+import { createTrainingController } from "../controllers/training.controller";
+
+export function createTrainingRoutes(
+  controller: ReturnType<typeof createTrainingController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.get("/api/me/training/plans", options.requireAuth, (req, res) => {
+    void controller.list(req, res);
+  });
+
+  router.post(
+    "/api/me/training/enrollments",
+    options.requireAuth,
+    (req, res) => {
+      void controller.enroll(req, res);
+    },
+  );
+
+  router.patch(
+    "/api/me/training/enrollments/:id",
+    options.requireAuth,
+    (req, res) => {
+      void controller.advance(req, res);
+    },
+  );
+
+  return router;
+}

--- a/src/modules/training/services/training.service.test.ts
+++ b/src/modules/training/services/training.service.test.ts
@@ -1,0 +1,200 @@
+import { DomainError } from "../../../lib/domain-error";
+import { TrainingCatalog } from "../catalog/training-catalog";
+import { InMemoryTrainingEnrollmentRepository } from "../repositories/in-memory-training-enrollment.repository";
+import {
+  AdvanceEnrollment,
+  CreateEnrollment,
+  ListTrainingPlans,
+  TrainingEnrollmentCompletedError,
+  TrainingEnrollmentNotFoundError,
+  TrainingPlanNotFoundError,
+} from "./training.service";
+
+describe("training services", () => {
+  function setup() {
+    const catalog = TrainingCatalog.padel();
+    const enrollments = new InMemoryTrainingEnrollmentRepository(catalog);
+    return {
+      catalog,
+      enrollments,
+      list: new ListTrainingPlans(enrollments, catalog),
+      create: new CreateEnrollment(enrollments, catalog),
+      advance: new AdvanceEnrollment(enrollments, catalog),
+    };
+  }
+
+  test("list returns the curated catalog and empty enrollments", async () => {
+    const { list } = setup();
+    const result = await list.execute({ userId: "user-a" });
+
+    expect(result.plans.map((plan) => plan.id)).toEqual([
+      "accuracy-focus",
+      "consistency-builder",
+      "match-intensity",
+    ]);
+    expect(result.plans[0]).toMatchObject({
+      title: "Accuracy Focus",
+      sport: "padel",
+      focus: "accuracy",
+      totalDurationMinutes: 50,
+    });
+    expect(result.enrollments).toEqual([]);
+  });
+
+  test("create starts a plan and resumes the active enrollment", async () => {
+    const { create, list } = setup();
+    const started = await create.execute({
+      userId: "user-a",
+      planId: "accuracy-focus",
+    });
+    expect(started.resumed).toBe(false);
+    expect(started.enrollment).toMatchObject({
+      planId: "accuracy-focus",
+      status: "active",
+      percentComplete: 0,
+      currentStepIndex: 0,
+    });
+
+    const resumed = await create.execute({
+      userId: "user-a",
+      planId: "  Accuracy-Focus  ",
+    });
+    expect(resumed.resumed).toBe(true);
+    expect(resumed.enrollment.id).toBe(started.enrollment.id);
+
+    const listed = await list.execute({ userId: "user-a" });
+    expect(listed.enrollments).toHaveLength(1);
+    expect(listed.enrollments[0]?.id).toBe(started.enrollment.id);
+  });
+
+  test("unknown planId is a not-found error", async () => {
+    const { create } = setup();
+    await expect(
+      create.execute({ userId: "user-a", planId: "missing-plan" }),
+    ).rejects.toBeInstanceOf(TrainingPlanNotFoundError);
+  });
+
+  test("advance by steps then percent, and complete at 100%", async () => {
+    const { create, advance } = setup();
+    const started = await create.execute({
+      userId: "user-a",
+      planId: "accuracy-focus",
+    });
+
+    const stepped = await advance.execute({
+      userId: "user-a",
+      enrollmentId: started.enrollment.id,
+      completedStepIds: ["warm-up"],
+    });
+    expect(stepped.enrollment).toMatchObject({
+      completedStepIds: ["warm-up"],
+      percentComplete: 25,
+      currentStepIndex: 1,
+      status: "active",
+    });
+
+    const percented = await advance.execute({
+      userId: "user-a",
+      enrollmentId: started.enrollment.id,
+      percentComplete: 50,
+    });
+    expect(percented.enrollment).toMatchObject({
+      completedStepIds: ["warm-up", "target-practice"],
+      percentComplete: 50,
+      currentStepIndex: 2,
+    });
+
+    const done = await advance.execute({
+      userId: "user-a",
+      enrollmentId: started.enrollment.id,
+      percentComplete: 100,
+    });
+    expect(done.enrollment).toMatchObject({
+      status: "completed",
+      percentComplete: 100,
+      currentStepIndex: 4,
+    });
+    expect(done.enrollment.completedAt).toEqual(expect.any(String));
+  });
+
+  test("re-enroll after complete creates a new active enrollment", async () => {
+    const { create, advance, list } = setup();
+    const first = await create.execute({
+      userId: "user-a",
+      planId: "accuracy-focus",
+    });
+    await advance.execute({
+      userId: "user-a",
+      enrollmentId: first.enrollment.id,
+      percentComplete: 100,
+    });
+
+    const second = await create.execute({
+      userId: "user-a",
+      planId: "accuracy-focus",
+    });
+    expect(second.resumed).toBe(false);
+    expect(second.enrollment.id).not.toBe(first.enrollment.id);
+    expect(second.enrollment.status).toBe("active");
+    expect(second.enrollment.percentComplete).toBe(0);
+
+    const listed = await list.execute({ userId: "user-a" });
+    expect(listed.enrollments).toHaveLength(2);
+    expect(listed.enrollments[0]?.status).toBe("active");
+    expect(listed.enrollments[1]?.status).toBe("completed");
+    expect(listed.enrollments[1]?.id).toBe(first.enrollment.id);
+  });
+
+  test("advance rejects missing payload, foreign enrollments, and completed regress", async () => {
+    const { create, advance } = setup();
+    const started = await create.execute({
+      userId: "user-a",
+      planId: "consistency-builder",
+    });
+
+    await expect(
+      advance.execute({
+        userId: "user-a",
+        enrollmentId: started.enrollment.id,
+      }),
+    ).rejects.toBeInstanceOf(DomainError);
+
+    await expect(
+      advance.execute({
+        userId: "user-a",
+        enrollmentId: started.enrollment.id,
+        completedStepIds: ["warm-up-rallies"],
+        percentComplete: 50,
+      }),
+    ).rejects.toBeInstanceOf(DomainError);
+
+    await expect(
+      advance.execute({
+        userId: "user-b",
+        enrollmentId: started.enrollment.id,
+        percentComplete: 50,
+      }),
+    ).rejects.toBeInstanceOf(TrainingEnrollmentNotFoundError);
+
+    await expect(
+      advance.execute({
+        userId: "user-a",
+        enrollmentId: "missing",
+        percentComplete: 50,
+      }),
+    ).rejects.toBeInstanceOf(TrainingEnrollmentNotFoundError);
+
+    await advance.execute({
+      userId: "user-a",
+      enrollmentId: started.enrollment.id,
+      percentComplete: 100,
+    });
+    await expect(
+      advance.execute({
+        userId: "user-a",
+        enrollmentId: started.enrollment.id,
+        percentComplete: 50,
+      }),
+    ).rejects.toBeInstanceOf(TrainingEnrollmentCompletedError);
+  });
+});

--- a/src/modules/training/services/training.service.ts
+++ b/src/modules/training/services/training.service.ts
@@ -1,0 +1,142 @@
+import { DomainError } from "../../../lib/domain-error";
+import { TrainingCatalog } from "../catalog/training-catalog";
+import { TrainingEnrollment } from "../entities/training-enrollment";
+import { TrainingEnrollmentCompletedError } from "../entities/training-enrollment-completed-error";
+import { TrainingEnrollmentNotFoundError } from "../entities/training-enrollment-not-found-error";
+import { TrainingPlan } from "../entities/training-plan";
+import { TrainingPlanNotFoundError } from "../entities/training-plan-not-found-error";
+import { TrainingEnrollmentRepository } from "../repositories/training-enrollment.repository";
+
+export type PublicTrainingPlan = {
+  id: string;
+  title: string;
+  sport: "padel";
+  focus: "accuracy" | "consistency" | "intensity" | null;
+  steps: Array<{
+    id: string;
+    name: string;
+    durationMinutes: number;
+  }>;
+  totalDurationMinutes: number;
+};
+
+export type PublicEnrollment = {
+  id: string;
+  planId: string;
+  status: "active" | "completed";
+  completedStepIds: string[];
+  percentComplete: number;
+  currentStepIndex: number;
+  startedAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+};
+
+function toPublicPlan(plan: TrainingPlan): PublicTrainingPlan {
+  return plan.toSnapshot();
+}
+
+function toPublicEnrollment(enrollment: TrainingEnrollment): PublicEnrollment {
+  return enrollment.toSnapshot();
+}
+
+function requireUserId(userId: string): string {
+  const id = userId.trim();
+  if (!id) throw new DomainError("userId is required");
+  return id;
+}
+
+export class ListTrainingPlans {
+  constructor(
+    private readonly enrollments: TrainingEnrollmentRepository,
+    private readonly catalog: TrainingCatalog,
+  ) {}
+
+  async execute(input: { userId: string }): Promise<{
+    plans: PublicTrainingPlan[];
+    enrollments: PublicEnrollment[];
+  }> {
+    const userId = requireUserId(input.userId);
+    const rows = await this.enrollments.listForUser(userId);
+    return {
+      plans: this.catalog.list().map(toPublicPlan),
+      enrollments: rows.map(toPublicEnrollment),
+    };
+  }
+}
+
+export class CreateEnrollment {
+  constructor(
+    private readonly enrollments: TrainingEnrollmentRepository,
+    private readonly catalog: TrainingCatalog,
+  ) {}
+
+  async execute(input: { userId: string; planId: unknown }): Promise<{
+    enrollment: PublicEnrollment;
+    resumed: boolean;
+  }> {
+    const userId = requireUserId(input.userId);
+    const plan = this.catalog.get(input.planId);
+    if (!plan) throw new TrainingPlanNotFoundError();
+
+    const active = await this.enrollments.findActiveByUserAndPlan(
+      userId,
+      plan.id,
+    );
+    if (active) {
+      return { enrollment: toPublicEnrollment(active), resumed: true };
+    }
+
+    const created = await this.enrollments.create(
+      TrainingEnrollment.start(userId, plan),
+    );
+    return { enrollment: toPublicEnrollment(created), resumed: false };
+  }
+}
+
+export class AdvanceEnrollment {
+  constructor(
+    private readonly enrollments: TrainingEnrollmentRepository,
+    private readonly catalog: TrainingCatalog,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    enrollmentId: string;
+    completedStepIds?: unknown;
+    percentComplete?: unknown;
+  }): Promise<{ enrollment: PublicEnrollment }> {
+    const userId = requireUserId(input.userId);
+    const enrollmentId = input.enrollmentId.trim();
+    if (!enrollmentId) throw new DomainError("enrollment id is required");
+
+    const hasSteps = input.completedStepIds !== undefined;
+    const hasPercent = input.percentComplete !== undefined;
+    if (hasSteps === hasPercent) {
+      throw new DomainError(
+        "provide completedStepIds or percentComplete, not both",
+      );
+    }
+
+    const enrollment = await this.enrollments.findById(enrollmentId);
+    if (!enrollment || !enrollment.belongsTo(userId)) {
+      throw new TrainingEnrollmentNotFoundError();
+    }
+
+    const plan = this.catalog.get(enrollment.planId.value);
+    if (!plan) throw new TrainingPlanNotFoundError();
+
+    if (hasSteps) {
+      enrollment.advanceByCompletedSteps(input.completedStepIds, plan);
+    } else {
+      enrollment.advanceByPercent(input.percentComplete, plan);
+    }
+
+    const saved = await this.enrollments.persist(enrollment);
+    return { enrollment: toPublicEnrollment(saved) };
+  }
+}
+
+export { TrainingEnrollmentCompletedError } from "../entities/training-enrollment-completed-error";
+export { TrainingEnrollmentNotFoundError } from "../entities/training-enrollment-not-found-error";
+export { TrainingPlanNotFoundError } from "../entities/training-plan-not-found-error";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the backend half of Custom Training for [leaguesports/landing-page#112](https://github.com/leaguesports/landing-page/issues/112) (parent: landing-page #59). Athletes can start curated padel plans, persist progress, and complete them. No plan builder, reminders, hardware, or non-padel plans.

## Catalog vs enrollment (required split)

| Concern | Where it lives | Why |
| --- | --- | --- |
| **Plan catalog** | Code — `src/modules/training/catalog/` | Curated, padel-first, versioned with the API. Not a CMS/DB table in v1. |
| **Enrollment + progress** | Postgres `TrainingEnrollment` | Session-owned start/resume/complete. Survives refresh. |

The frontend may also hardcode the same three plan ids (`accuracy-focus`, `consistency-builder`, `match-intensity`) for hub cards, but **progress must come from this API**. `GET /api/me/training/plans` already returns both the catalog and the caller’s enrollments so the hub does not need a second source of truth.

`accuracy-focus` matches the `/athletes` mock: Warm-up 10, Target Practice 20, Precision Drills 15, Cool-down 5 (50 min, focus `accuracy`).

## Domain (Venue / Match / communities #26 bar)

`TrainingEnrollment` is the aggregate under `src/modules/training/entities/`. VOs: `TrainingPlanId`, `TrainingSport` (padel), `TrainingFocus`, `TrainingStep` / `TrainingStepId`, `DurationMinutes`, `PercentComplete`, `CompletedStepIds`, `EnrollmentStatus`. The catalog is a read-only `TrainingCatalog` of `TrainingPlan` entities (code constants + VOs), not persisted.

`TrainingEnrollment.start` is the only create path. `advanceByCompletedSteps` unions step ids (monotonic). `advanceByPercent` materializes a prefix of steps (monotonic; cannot decrease). Completing **all steps or 100%** marks the enrollment `completed` and sets `completedAt`. Completing again is a no-op; regressing a completed enrollment is a domain error → HTTP 409.

`TrainingEnrollmentRepository` loads/saves the aggregate via rehydrate + snapshot. Application commands/queries: `CreateEnrollment`, `AdvanceEnrollment`, `ListTrainingPlans`. Zod stays thin at the controller.

Entity rules are unit-tested without HTTP.

## Idempotency

**Resume the active enrollment.** `POST /api/me/training/enrollments` with a `planId` that already has an **active** enrollment for that user returns the existing row (`200`, `resumed: true`). After the plan is **completed**, the same `POST` creates a **new** enrollment (`201`, `resumed: false`). Completed history stays in the list.

At most one active enrollment per user+plan (partial unique index in the migration).

## API contract

Cookie session, `credentials: include`, same JWT `token` cookie as friends/badges/communities. **All three routes require auth.** Guests get **401**.

| Method | Path | Success |
| --- | --- | --- |
| `GET` | `/api/me/training/plans` | `{ plans, enrollments }` |
| `POST` | `/api/me/training/enrollments` | **201** new / **200** resume `{ enrollment, resumed }` |
| `PATCH` | `/api/me/training/enrollments/:id` | `{ enrollment }` |

### Catalog plan

```ts
{
  id: string                    // kebab slug, e.g. "accuracy-focus"
  title: string
  sport: "padel"
  focus: "accuracy" | "consistency" | "intensity" | null
  steps: Array<{
    id: string                  // kebab slug, scoped to the plan
    name: string
    durationMinutes: number
  }>
  totalDurationMinutes: number
}
```

### Enrollment

```ts
{
  id: string
  planId: string
  status: "active" | "completed"
  completedStepIds: string[]    // ordered by the plan
  percentComplete: number       // 0–100, derived from completed / stepCount
  currentStepIndex: number      // first incomplete step, or steps.length when done
  startedAt: string             // ISO
  updatedAt: string
  completedAt: string | null
}
```

### Start body

```json
{ "planId": "accuracy-focus" }
```

### Advance body — exactly one of

```json
{ "completedStepIds": ["warm-up", "target-practice"] }
```

```json
{ "percentComplete": 50 }
```

- **Steps:** union with existing (never drops a completed step). Percent is `round(completed / total * 100)`.
- **Percent:** completes the first `round(percent/100 * stepCount)` steps (prefix), unioned with existing. Sending a lower percent on an active enrollment is **400**. Sending `< 100` on a completed enrollment is **409**.
- Both or neither → **400** `provide completedStepIds or percentComplete, not both`.
- Unknown step ids → **400**.
- `percentComplete: 100` or all step ids → `status: "completed"`.

Enrollments list is **active first**, then completed by `updatedAt` desc. A user who re-enrolls after complete will see one active + prior completed rows for the same `planId`.

### Errors

| Status | When |
| --- | --- |
| 401 | missing/invalid session |
| 400 | invalid body (`Invalid training payload` or domain message) |
| 404 | unknown `planId` (`Training plan not found`), unknown/foreign enrollment (`Training enrollment not found`) |
| 409 | regress a completed enrollment (`Training enrollment is already completed`) |
| 503 | persistence failure |

## Frontend notes

- Hub empty state: `GET /api/me/training/plans` with `enrollments.length === 0` → CTA “Start Accuracy Focus” → `POST` `{ planId: "accuracy-focus" }`.
- Active card: first enrollment with `status: "active"` (or match `planId`). Show `percentComplete` and `steps[currentStepIndex]`.
- Mark a drill done: `PATCH` with `completedStepIds` including the new id (server unions). Or jump with `percentComplete`.
- Completed history: `status: "completed"` rows stay in `enrollments`. Restart is another `POST` of the same `planId`.
- Guests hitting any route get **401** — send them through login with `returnTo` back to the hub / `/athletes` CTA.
- Deploy needs `prisma migrate deploy` (`20260906083000_training_enrollment`).

Out of scope (v1): plan builder UI, push reminders, Trackman/Autodarts, clubs-linked training, non-padel plans.

## Tests

Entity tests cover start / step union / percent prefix / complete / no-op complete / snapshot round-trip without HTTP. Service + HTTP cover resume-active, re-enroll-after-complete, guest 401, foreign enrollment 404. Full suite: **162 passing** (24 new).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e163ce88-b021-4b84-b624-e16369a329b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e163ce88-b021-4b84-b624-e16369a329b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

