### PR TITLE
fix: resume raced training enroll and skip drifted rows

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -147,6 +147,8 @@ model BadgeAward {
 // Curated training plans live in code (src/modules/training/catalog), not this table.
 // This model is session-owned enrollment + progress only. No User FK — same as
 // Friendship / BadgeAward / CommunityMember.
+// Partial unique (userId, planId) WHERE status = active is in
+// 20260906083000_training_enrollment — keep that SQL as source of truth.
 enum TrainingEnrollmentStatus {
   active
   completed

--- a/src/modules/training/entities/training-enrollment-active-conflict-error.ts
+++ b/src/modules/training/entities/training-enrollment-active-conflict-error.ts
@@ -1,0 +1,8 @@
+import { TrainingEnrollment } from "./training-enrollment";
+
+export class TrainingEnrollmentActiveConflictError extends Error {
+  constructor(readonly existing?: TrainingEnrollment) {
+    super("Active training enrollment already exists");
+    this.name = "TrainingEnrollmentActiveConflictError";
+  }
+}

--- a/src/modules/training/index.ts
+++ b/src/modules/training/index.ts
@@ -77,6 +77,7 @@ export { TrainingSport, TRAINING_SPORTS } from "./entities/training-sport";
 export { TrainingFocus, TRAINING_FOCUSES } from "./entities/training-focus";
 export { EnrollmentStatus } from "./entities/enrollment-status";
 export { PercentComplete } from "./entities/percent-complete";
+export { TrainingEnrollmentActiveConflictError } from "./entities/training-enrollment-active-conflict-error";
 export { TrainingEnrollmentPersistenceError } from "./entities/training-enrollment-persistence-error";
 export { TrainingEnrollmentNotFoundError } from "./entities/training-enrollment-not-found-error";
 export { TrainingEnrollmentCompletedError } from "./entities/training-enrollment-completed-error";

--- a/src/modules/training/repositories/in-memory-training-enrollment.repository.ts
+++ b/src/modules/training/repositories/in-memory-training-enrollment.repository.ts
@@ -1,18 +1,28 @@
 import { TrainingCatalog } from "../catalog/training-catalog";
 import { TrainingEnrollment } from "../entities/training-enrollment";
+import type { TrainingEnrollmentSnapshot } from "../entities/training-enrollment";
+import { TrainingEnrollmentActiveConflictError } from "../entities/training-enrollment-active-conflict-error";
 import { TrainingEnrollmentPersistenceError } from "../entities/training-enrollment-persistence-error";
 import { TrainingPlanId } from "../entities/training-plan-id";
-import { TrainingEnrollmentRepository } from "./training-enrollment.repository";
+import {
+  enrollmentListLimit,
+  TrainingEnrollmentRepository,
+} from "./training-enrollment.repository";
 
 export class InMemoryTrainingEnrollmentRepository
   implements TrainingEnrollmentRepository
 {
-  private readonly byId = new Map<string, TrainingEnrollment>();
+  private readonly byId = new Map<string, TrainingEnrollmentSnapshot>();
 
   constructor(private readonly catalog: TrainingCatalog = TrainingCatalog.padel()) {}
 
+  /** Test helper: insert a row without hydrating against the catalog. */
+  seedSnapshot(snapshot: TrainingEnrollmentSnapshot): void {
+    this.byId.set(snapshot.id, snapshot);
+  }
+
   async findById(id: string): Promise<TrainingEnrollment | null> {
-    return clone(this.byId.get(id) ?? null, this.catalog);
+    return hydrate(this.byId.get(id) ?? null, this.catalog);
   }
 
   async findActiveByUserAndPlan(
@@ -20,18 +30,31 @@ export class InMemoryTrainingEnrollmentRepository
     planId: TrainingPlanId,
   ): Promise<TrainingEnrollment | null> {
     const match = [...this.byId.values()].find(
-      (enrollment) =>
-        enrollment.belongsTo(userId) &&
-        enrollment.planId.equals(planId) &&
-        enrollment.status.isActive,
+      (snapshot) =>
+        snapshot.userId === userId.trim() &&
+        snapshot.planId === planId.value &&
+        snapshot.status === "active",
     );
-    return clone(match ?? null, this.catalog);
+    return hydrate(match ?? null, this.catalog);
   }
 
   async create(enrollment: TrainingEnrollment): Promise<TrainingEnrollment> {
-    const stored = clone(enrollment, this.catalog)!;
+    const existing = [...this.byId.values()].find(
+      (snapshot) =>
+        snapshot.userId === enrollment.userId &&
+        snapshot.planId === enrollment.planId.value &&
+        snapshot.status === "active" &&
+        snapshot.id !== enrollment.id,
+    );
+    if (existing) {
+      throw new TrainingEnrollmentActiveConflictError(
+        hydrate(existing, this.catalog) ?? undefined,
+      );
+    }
+
+    const stored = enrollment.toSnapshot();
     this.byId.set(stored.id, stored);
-    return clone(stored, this.catalog)!;
+    return hydrate(stored, this.catalog)!;
   }
 
   async persist(enrollment: TrainingEnrollment): Promise<TrainingEnrollment> {
@@ -40,36 +63,64 @@ export class InMemoryTrainingEnrollmentRepository
         "Unable to save training enrollment",
       );
     }
-    const stored = clone(enrollment, this.catalog)!;
+    const stored = enrollment.toSnapshot();
     this.byId.set(stored.id, stored);
-    return clone(stored, this.catalog)!;
+    return hydrate(stored, this.catalog)!;
   }
 
-  async listForUser(userId: string): Promise<TrainingEnrollment[]> {
+  async listForUser(
+    userId: string,
+    options: { limit?: number } = {},
+  ): Promise<TrainingEnrollment[]> {
+    const limit = enrollmentListLimit(options.limit);
     return [...this.byId.values()]
-      .filter((enrollment) => enrollment.belongsTo(userId))
-      .sort(compareEnrollments)
-      .map((enrollment) => clone(enrollment, this.catalog)!);
+      .filter((snapshot) => snapshot.userId === userId.trim())
+      .sort(compareSnapshots)
+      .slice(0, limit)
+      .flatMap((snapshot) => {
+        const enrollment = tryHydrate(snapshot, this.catalog);
+        return enrollment ? [enrollment] : [];
+      });
   }
 }
 
-function compareEnrollments(a: TrainingEnrollment, b: TrainingEnrollment): number {
-  if (a.status.isActive !== b.status.isActive) {
-    return a.status.isActive ? -1 : 1;
+function compareSnapshots(
+  a: TrainingEnrollmentSnapshot,
+  b: TrainingEnrollmentSnapshot,
+): number {
+  if (a.status !== b.status) {
+    return a.status === "active" ? -1 : 1;
   }
-  return b.updatedAt.getTime() - a.updatedAt.getTime();
+  return Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
 }
 
-function clone(
-  enrollment: TrainingEnrollment | null,
+function hydrate(
+  snapshot: TrainingEnrollmentSnapshot | null,
   catalog: TrainingCatalog,
 ): TrainingEnrollment | null {
-  if (!enrollment) return null;
-  const plan = catalog.get(enrollment.planId.value);
+  if (!snapshot) return null;
+  const plan = catalog.get(snapshot.planId);
   if (!plan) {
     throw new TrainingEnrollmentPersistenceError(
       "Unable to load training enrollment",
     );
   }
-  return TrainingEnrollment.fromSnapshot(enrollment.toSnapshot(), plan);
+  return TrainingEnrollment.fromSnapshot(snapshot, plan);
+}
+
+function tryHydrate(
+  snapshot: TrainingEnrollmentSnapshot,
+  catalog: TrainingCatalog,
+): TrainingEnrollment | null {
+  try {
+    return hydrate(snapshot, catalog);
+  } catch (error) {
+    console.warn(
+      "Skipping unreadable training enrollment",
+      snapshot.id,
+      snapshot.planId,
+      error,
+    );
+    return null;
+  }
 }

--- a/src/modules/training/repositories/prisma-training-enrollment.repository.ts
+++ b/src/modules/training/repositories/prisma-training-enrollment.repository.ts
@@ -4,9 +4,20 @@ import { CompletedStepIds } from "../entities/completed-step-ids";
 import { EnrollmentStatus } from "../entities/enrollment-status";
 import { PercentComplete } from "../entities/percent-complete";
 import { TrainingEnrollment } from "../entities/training-enrollment";
+import { TrainingEnrollmentActiveConflictError } from "../entities/training-enrollment-active-conflict-error";
 import { TrainingEnrollmentPersistenceError } from "../entities/training-enrollment-persistence-error";
 import { TrainingPlanId } from "../entities/training-plan-id";
-import { TrainingEnrollmentRepository } from "./training-enrollment.repository";
+import {
+  enrollmentListLimit,
+  TrainingEnrollmentRepository,
+} from "./training-enrollment.repository";
+
+function prismaErrorCode(error: unknown): string {
+  if (error && typeof error === "object" && "code" in error) {
+    return String((error as { code?: unknown }).code);
+  }
+  return "";
+}
 
 type EnrollmentRow = {
   id: string;
@@ -44,6 +55,23 @@ function toDomain(
     updatedAt: row.updatedAt,
     completedAt: row.completedAt,
   });
+}
+
+function tryToDomain(
+  row: EnrollmentRow,
+  catalog: TrainingCatalog,
+): TrainingEnrollment | null {
+  try {
+    return toDomain(row, catalog);
+  } catch (error) {
+    console.warn(
+      "Skipping unreadable training enrollment",
+      row.id,
+      row.planId,
+      error,
+    );
+    return null;
+  }
 }
 
 export class PrismaTrainingEnrollmentRepository
@@ -110,6 +138,13 @@ export class PrismaTrainingEnrollmentRepository
       });
       return toDomain(row, this.catalog);
     } catch (error) {
+      if (prismaErrorCode(error) === "P2002") {
+        const existing = await this.findActiveByUserAndPlan(
+          snapshot.userId,
+          TrainingPlanId.from(snapshot.planId),
+        );
+        throw new TrainingEnrollmentActiveConflictError(existing ?? undefined);
+      }
       throw new TrainingEnrollmentPersistenceError(
         "Failed to create training enrollment",
         { cause: error },
@@ -140,22 +175,22 @@ export class PrismaTrainingEnrollmentRepository
     }
   }
 
-  async listForUser(userId: string): Promise<TrainingEnrollment[]> {
+  async listForUser(
+    userId: string,
+    options: { limit?: number } = {},
+  ): Promise<TrainingEnrollment[]> {
+    const limit = enrollmentListLimit(options.limit);
     try {
       const rows = await this.prisma.trainingEnrollment.findMany({
         where: { userId },
         orderBy: [{ status: "asc" }, { updatedAt: "desc" }],
+        take: limit,
       });
-      return rows
-        .map((row) => toDomain(row, this.catalog))
-        .sort((a, b) => {
-          if (a.status.isActive !== b.status.isActive) {
-            return a.status.isActive ? -1 : 1;
-          }
-          return b.updatedAt.getTime() - a.updatedAt.getTime();
-        });
+      return rows.flatMap((row) => {
+        const enrollment = tryToDomain(row, this.catalog);
+        return enrollment ? [enrollment] : [];
+      });
     } catch (error) {
-      if (error instanceof TrainingEnrollmentPersistenceError) throw error;
       throw new TrainingEnrollmentPersistenceError(
         "Failed to list training enrollments",
         { cause: error },

--- a/src/modules/training/repositories/training-enrollment.repository.ts
+++ b/src/modules/training/repositories/training-enrollment.repository.ts
@@ -1,6 +1,14 @@
 import { TrainingEnrollment } from "../entities/training-enrollment";
 import { TrainingPlanId } from "../entities/training-plan-id";
 
+export const TRAINING_ENROLLMENT_LIST_LIMIT = 50;
+export const TRAINING_ENROLLMENT_LIST_MAX = 100;
+
+export function enrollmentListLimit(raw?: number): number {
+  if (raw == null || Number.isNaN(raw)) return TRAINING_ENROLLMENT_LIST_LIMIT;
+  return Math.min(Math.max(Math.trunc(raw), 1), TRAINING_ENROLLMENT_LIST_MAX);
+}
+
 export interface TrainingEnrollmentRepository {
   findById(id: string): Promise<TrainingEnrollment | null>;
   findActiveByUserAndPlan(
@@ -9,5 +17,8 @@ export interface TrainingEnrollmentRepository {
   ): Promise<TrainingEnrollment | null>;
   create(enrollment: TrainingEnrollment): Promise<TrainingEnrollment>;
   persist(enrollment: TrainingEnrollment): Promise<TrainingEnrollment>;
-  listForUser(userId: string): Promise<TrainingEnrollment[]>;
+  listForUser(
+    userId: string,
+    options?: { limit?: number },
+  ): Promise<TrainingEnrollment[]>;
 }

--- a/src/modules/training/services/training.service.test.ts
+++ b/src/modules/training/services/training.service.test.ts
@@ -1,6 +1,9 @@
 import { DomainError } from "../../../lib/domain-error";
 import { TrainingCatalog } from "../catalog/training-catalog";
+import { TrainingEnrollment } from "../entities/training-enrollment";
+import { TrainingEnrollmentActiveConflictError } from "../entities/training-enrollment-active-conflict-error";
 import { InMemoryTrainingEnrollmentRepository } from "../repositories/in-memory-training-enrollment.repository";
+import { TrainingPlanId } from "../entities/training-plan-id";
 import {
   AdvanceEnrollment,
   CreateEnrollment,
@@ -9,6 +12,21 @@ import {
   TrainingEnrollmentNotFoundError,
   TrainingPlanNotFoundError,
 } from "./training.service";
+
+class RaceyEnrollmentRepository extends InMemoryTrainingEnrollmentRepository {
+  missActiveOnce = false;
+
+  override async findActiveByUserAndPlan(
+    userId: string,
+    planId: TrainingPlanId,
+  ) {
+    if (this.missActiveOnce) {
+      this.missActiveOnce = false;
+      return null;
+    }
+    return super.findActiveByUserAndPlan(userId, planId);
+  }
+}
 
 describe("training services", () => {
   function setup() {
@@ -196,5 +214,109 @@ describe("training services", () => {
         percentComplete: 50,
       }),
     ).rejects.toBeInstanceOf(TrainingEnrollmentCompletedError);
+  });
+
+  test("create treats a unique-active race as resume", async () => {
+    const catalog = TrainingCatalog.padel();
+    const enrollments = new RaceyEnrollmentRepository(catalog);
+    const create = new CreateEnrollment(enrollments, catalog);
+    const first = await create.execute({
+      userId: "user-a",
+      planId: "accuracy-focus",
+    });
+
+    enrollments.missActiveOnce = true;
+    const raced = await create.execute({
+      userId: "user-a",
+      planId: "accuracy-focus",
+    });
+    expect(raced.resumed).toBe(true);
+    expect(raced.enrollment.id).toBe(first.enrollment.id);
+
+    const colliding = TrainingEnrollment.start(
+      "user-a",
+      catalog.require("accuracy-focus"),
+    );
+    await expect(enrollments.create(colliding)).rejects.toBeInstanceOf(
+      TrainingEnrollmentActiveConflictError,
+    );
+  });
+
+  test("list skips drifted enrollments and still returns the catalog", async () => {
+    const { enrollments, list, create } = setup();
+    await create.execute({ userId: "user-a", planId: "accuracy-focus" });
+    enrollments.seedSnapshot({
+      id: "retired-1",
+      userId: "user-a",
+      planId: "retired-plan",
+      status: "completed",
+      completedStepIds: ["old-step"],
+      percentComplete: 100,
+      currentStepIndex: 1,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+      completedAt: "2026-01-02T00:00:00.000Z",
+    });
+    enrollments.seedSnapshot({
+      id: "stale-step",
+      userId: "user-a",
+      planId: "accuracy-focus",
+      status: "completed",
+      completedStepIds: ["removed-drill"],
+      percentComplete: 100,
+      currentStepIndex: 1,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-03T00:00:00.000Z",
+      completedAt: "2026-01-03T00:00:00.000Z",
+    });
+
+    const listed = await list.execute({ userId: "user-a" });
+    expect(listed.plans.map((plan) => plan.id)).toContain("accuracy-focus");
+    expect(listed.enrollments.map((row) => row.id)).toEqual(
+      expect.not.arrayContaining(["retired-1", "stale-step"]),
+    );
+    expect(listed.enrollments).toHaveLength(1);
+    expect(listed.enrollments[0]?.planId).toBe("accuracy-focus");
+  });
+
+  test("list caps enrollments at 50 with active first", async () => {
+    const { enrollments, list } = setup();
+    const now = Date.parse("2026-01-01T00:00:00.000Z");
+    for (let i = 0; i < 60; i += 1) {
+      enrollments.seedSnapshot({
+        id: `done-${i}`,
+        userId: "user-a",
+        planId: "accuracy-focus",
+        status: "completed",
+        completedStepIds: [
+          "warm-up",
+          "target-practice",
+          "precision-drills",
+          "cool-down",
+        ],
+        percentComplete: 100,
+        currentStepIndex: 4,
+        startedAt: new Date(now + i).toISOString(),
+        updatedAt: new Date(now + i).toISOString(),
+        completedAt: new Date(now + i).toISOString(),
+      });
+    }
+    enrollments.seedSnapshot({
+      id: "active-now",
+      userId: "user-a",
+      planId: "consistency-builder",
+      status: "active",
+      completedStepIds: [],
+      percentComplete: 0,
+      currentStepIndex: 0,
+      startedAt: new Date(now + 1000).toISOString(),
+      updatedAt: new Date(now + 1000).toISOString(),
+      completedAt: null,
+    });
+
+    const listed = await list.execute({ userId: "user-a" });
+    expect(listed.enrollments).toHaveLength(50);
+    expect(listed.enrollments[0]?.id).toBe("active-now");
+    expect(listed.enrollments.every((row) => row.id !== "done-0")).toBe(true);
   });
 });

--- a/src/modules/training/services/training.service.ts
+++ b/src/modules/training/services/training.service.ts
@@ -1,6 +1,7 @@
 import { DomainError } from "../../../lib/domain-error";
 import { TrainingCatalog } from "../catalog/training-catalog";
 import { TrainingEnrollment } from "../entities/training-enrollment";
+import { TrainingEnrollmentActiveConflictError } from "../entities/training-enrollment-active-conflict-error";
 import { TrainingEnrollmentCompletedError } from "../entities/training-enrollment-completed-error";
 import { TrainingEnrollmentNotFoundError } from "../entities/training-enrollment-not-found-error";
 import { TrainingPlan } from "../entities/training-plan";
@@ -87,10 +88,22 @@ export class CreateEnrollment {
       return { enrollment: toPublicEnrollment(active), resumed: true };
     }
 
-    const created = await this.enrollments.create(
-      TrainingEnrollment.start(userId, plan),
-    );
-    return { enrollment: toPublicEnrollment(created), resumed: false };
+    try {
+      const created = await this.enrollments.create(
+        TrainingEnrollment.start(userId, plan),
+      );
+      return { enrollment: toPublicEnrollment(created), resumed: false };
+    } catch (error) {
+      if (error instanceof TrainingEnrollmentActiveConflictError) {
+        const active =
+          error.existing ??
+          (await this.enrollments.findActiveByUserAndPlan(userId, plan.id));
+        if (active) {
+          return { enrollment: toPublicEnrollment(active), resumed: true };
+        }
+      }
+      throw error;
+    }
   }
 }
 
@@ -137,6 +150,7 @@ export class AdvanceEnrollment {
   }
 }
 
+export { TrainingEnrollmentActiveConflictError } from "../entities/training-enrollment-active-conflict-error";
 export { TrainingEnrollmentCompletedError } from "../entities/training-enrollment-completed-error";
 export { TrainingEnrollmentNotFoundError } from "../entities/training-enrollment-not-found-error";
 export { TrainingPlanNotFoundError } from "../entities/training-plan-not-found-error";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to [#27](https://github.com/leaguesports/league-sports-api/pull/27) review (landed after that PR merged). Public contract is unchanged.

## Concurrent enroll

`POST /api/me/training/enrollments` was check-then-insert. Two tabs / a retry could both miss the active row; the loser hit the partial unique index and became **503**, breaking the documented resume.

- Prisma `create` maps `P2002` to `TrainingEnrollmentActiveConflictError` and reloads the active row
- In-memory repo enforces the same one-active-per-user+plan rule
- `CreateEnrollment` catches the conflict and returns `{ enrollment, resumed: true }`

## List resilience

`GET /api/me/training/plans` rehydrated every enrollment against today’s catalog. A retired `planId` or renamed step id threw and **503’d the whole payload**, catalog included.

- Unreadable rows are skipped (warned) so the catalog still returns
- List is capped at 50 (active first), matching other `/api/me` lists

Schema comment notes that the active unique index lives in `20260906083000_training_enrollment` SQL (no new migration).

## Tests

Race resume, drifted-row skip, and the 50-row cap. Full suite: **165 passing**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e163ce88-b021-4b84-b624-e16369a329b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e163ce88-b021-4b84-b624-e16369a329b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

