### PR TITLE
feat: smart integrations connect/sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/providers/google/callback-url
 
 JWT_SECRET=
 
+# Integration tokens are encrypted at rest with a key derived from JWT_SECRET.
+# Never log or return the raw token. API responses only include credentialMasked.
+
 FRONTEND_URL=http://localhost:3001
 
 # Optional extra CORS origins (comma-separated)

--- a/prisma/migrations/20260906090000_integration_connection/migration.sql
+++ b/prisma/migrations/20260906090000_integration_connection/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "IntegrationConnectionStatus" AS ENUM ('connected', 'disconnected');
+
+-- CreateTable
+CREATE TABLE "IntegrationConnection" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "providerId" TEXT NOT NULL,
+    "status" "IntegrationConnectionStatus" NOT NULL DEFAULT 'disconnected',
+    "lastSyncedAt" TIMESTAMP(3),
+    "importedSessionCount" INTEGER NOT NULL DEFAULT 0,
+    "importedSessions" JSONB NOT NULL DEFAULT '[]',
+    "encryptedToken" TEXT,
+    "tokenHint" TEXT,
+    "connectedAt" TIMESTAMP(3),
+    "disconnectedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "IntegrationConnection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IntegrationConnection_userId_providerId_key" ON "IntegrationConnection"("userId", "providerId");
+
+-- CreateIndex
+CREATE INDEX "IntegrationConnection_userId_idx" ON "IntegrationConnection"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,6 +168,33 @@ model TrainingEnrollment {
   @@index([userId, planId, status])
 }
 
+// Session-owned provider connection + import history. Catalog (Trackman /
+// Autodarts / generic-import) lives in src/modules/integrations/catalog.
+// No User FK — same as Friendship / BadgeAward / TrainingEnrollment.
+enum IntegrationConnectionStatus {
+  connected
+  disconnected
+}
+
+model IntegrationConnection {
+  id                   String                      @id @default(uuid())
+  userId               String
+  providerId           String
+  status               IntegrationConnectionStatus @default(disconnected)
+  lastSyncedAt         DateTime?
+  importedSessionCount Int                         @default(0)
+  importedSessions     Json                        @default("[]")
+  encryptedToken       String?
+  tokenHint            String?
+  connectedAt          DateTime?
+  disconnectedAt       DateTime?
+  createdAt            DateTime                    @default(now())
+  updatedAt            DateTime                    @updatedAt
+
+  @@unique([userId, providerId])
+  @@index([userId])
+}
+
 
 enum MatchRuleset {
   golden_point

--- a/src/app.ts
+++ b/src/app.ts
@@ -35,6 +35,10 @@ import {
   TrainingEnrollmentRepository,
 } from "./modules/training";
 import {
+  createIntegrationsModule,
+  IntegrationConnectionRepository,
+} from "./modules/integrations";
+import {
   createVenueModule,
   VenueRepository,
 } from "./modules/venue";
@@ -50,6 +54,7 @@ export type CreateAppDependencies = {
   preferencesRepository?: PreferencesRepository;
   communityRepository?: CommunityRepository;
   trainingEnrollmentRepository?: TrainingEnrollmentRepository;
+  integrationConnectionRepository?: IntegrationConnectionRepository;
 };
 
 export async function createApp(
@@ -131,6 +136,14 @@ export async function createApp(
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
+  const integrations = createIntegrationsModule({
+    prisma,
+    tokenEncryptionKey: config.JWT_SECRET,
+    integrationConnectionRepository:
+      dependencies.integrationConnectionRepository,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
@@ -141,6 +154,7 @@ export async function createApp(
   app.use(badges.router);
   app.use(communities.router);
   app.use(training.router);
+  app.use(integrations.router);
 
   app.use(
     (

--- a/src/modules/integrations/catalog/provider-catalog.test.ts
+++ b/src/modules/integrations/catalog/provider-catalog.test.ts
@@ -1,0 +1,47 @@
+import { ProviderUnavailableError } from "../entities/provider-unavailable-error";
+import { ProviderCatalog } from "./provider-catalog";
+import {
+  AUTODARTS_PROVIDER_ID,
+  GENERIC_IMPORT_PROVIDER_ID,
+  TRACKMAN_PROVIDER_ID,
+} from "./providers";
+
+describe(ProviderCatalog, () => {
+  const catalog = ProviderCatalog.defaults();
+
+  test("ships generic-import as the live path and lists vendor shells as coming soon", () => {
+    const providers = catalog.list().map((provider) => provider.toSnapshot());
+    expect(providers.map((provider) => provider.id)).toEqual([
+      GENERIC_IMPORT_PROVIDER_ID,
+      TRACKMAN_PROVIDER_ID,
+      AUTODARTS_PROVIDER_ID,
+    ]);
+
+    expect(catalog.require(GENERIC_IMPORT_PROVIDER_ID).toSnapshot()).toMatchObject({
+      name: "Import session",
+      available: true,
+      comingSoon: false,
+    });
+    expect(catalog.require(TRACKMAN_PROVIDER_ID).toSnapshot()).toMatchObject({
+      available: false,
+      comingSoon: true,
+    });
+    expect(catalog.require(AUTODARTS_PROVIDER_ID).toSnapshot()).toMatchObject({
+      available: false,
+      comingSoon: true,
+    });
+  });
+
+  test("lookup is case-insensitive and unknown ids miss", () => {
+    expect(catalog.get("Generic-Import")?.id.value).toBe(
+      GENERIC_IMPORT_PROVIDER_ID,
+    );
+    expect(catalog.get("missing")).toBeNull();
+  });
+
+  test("coming-soon providers are not connectable", () => {
+    expect(() => catalog.require(TRACKMAN_PROVIDER_ID).assertConnectable()).toThrow(
+      ProviderUnavailableError,
+    );
+  });
+});

--- a/src/modules/integrations/catalog/provider-catalog.ts
+++ b/src/modules/integrations/catalog/provider-catalog.ts
@@ -1,0 +1,42 @@
+import { Provider } from "../entities/provider";
+import { ProviderId } from "../entities/provider-id";
+import { ProviderNotFoundError } from "../entities/provider-not-found-error";
+import { PROVIDER_DEFINITIONS } from "./providers";
+
+export class ProviderCatalog {
+  private readonly byId: Map<string, Provider>;
+
+  constructor(providers: readonly Provider[]) {
+    this.byId = new Map(providers.map((provider) => [provider.id.value, provider]));
+  }
+
+  static defaults(): ProviderCatalog {
+    return new ProviderCatalog(
+      PROVIDER_DEFINITIONS.map((definition) =>
+        Provider.fromDefinition(definition),
+      ),
+    );
+  }
+
+  list(): Provider[] {
+    return [...this.byId.values()];
+  }
+
+  get(rawId: unknown): Provider | null {
+    let id: ProviderId;
+    try {
+      id = ProviderId.from(rawId);
+    } catch {
+      return null;
+    }
+    return this.byId.get(id.value) ?? null;
+  }
+
+  require(rawId: unknown): Provider {
+    const provider = this.get(rawId);
+    if (!provider) {
+      throw new ProviderNotFoundError();
+    }
+    return provider;
+  }
+}

--- a/src/modules/integrations/catalog/providers.ts
+++ b/src/modules/integrations/catalog/providers.ts
@@ -1,0 +1,32 @@
+import { ProviderDefinition } from "../entities/provider";
+
+export const GENERIC_IMPORT_PROVIDER_ID = "generic-import";
+export const TRACKMAN_PROVIDER_ID = "trackman";
+export const AUTODARTS_PROVIDER_ID = "autodarts";
+
+export const PROVIDER_DEFINITIONS: readonly ProviderDefinition[] = [
+  {
+    id: GENERIC_IMPORT_PROVIDER_ID,
+    name: "Import session",
+    description:
+      "Paste a structured session so the athlete hub can record a real last sync without a vendor partnership.",
+    available: true,
+    comingSoon: false,
+  },
+  {
+    id: TRACKMAN_PROVIDER_ID,
+    name: "Trackman",
+    description:
+      "Range and launch-monitor sessions. Requires a Trackman partnership and vendor API keys.",
+    available: false,
+    comingSoon: true,
+  },
+  {
+    id: AUTODARTS_PROVIDER_ID,
+    name: "Autodarts",
+    description:
+      "Electronic dartboard sessions. Requires Autodarts API access that is not available in v1.",
+    available: false,
+    comingSoon: true,
+  },
+];

--- a/src/modules/integrations/controllers/integrations.controller.ts
+++ b/src/modules/integrations/controllers/integrations.controller.ts
@@ -1,0 +1,152 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { IntegrationNotConnectedError } from "../entities/integration-not-connected-error";
+import { IntegrationPersistenceError } from "../entities/integration-persistence-error";
+import { ProviderNotFoundError } from "../entities/provider-not-found-error";
+import { ProviderUnavailableError } from "../entities/provider-unavailable-error";
+import {
+  ConnectIntegration,
+  DisconnectIntegration,
+  ListIntegrations,
+  SyncIntegration,
+} from "../services/integrations.service";
+
+const providerParamSchema = z.object({
+  provider: z.string(),
+});
+
+const connectBodySchema = z.object({
+  token: z.string().optional(),
+});
+
+const importedSessionSchema = z.object({
+  sport: z.string(),
+  playedAt: z.string(),
+  title: z.string().optional(),
+  notes: z.string().optional(),
+  metrics: z.record(z.string(), z.union([z.string(), z.number()])).optional(),
+});
+
+const syncBodySchema = z.union([
+  importedSessionSchema,
+  z.object({ session: importedSessionSchema }),
+  z.object({ sessions: z.array(importedSessionSchema).min(1) }),
+]);
+
+export function createIntegrationsController(deps: {
+  listIntegrations: ListIntegrations;
+  connectIntegration: ConnectIntegration;
+  disconnectIntegration: DisconnectIntegration;
+  syncIntegration: SyncIntegration;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async list(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const result = await deps.listIntegrations.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendIntegrationsError(res, error);
+      }
+    },
+
+    async connect(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { provider } = z.parse(providerParamSchema, req.params);
+        const body = z.parse(connectBodySchema, req.body ?? {});
+        const result = await deps.connectIntegration.execute({
+          userId,
+          providerId: provider,
+          token: body.token,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendIntegrationsError(res, error);
+      }
+    },
+
+    async disconnect(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { provider } = z.parse(providerParamSchema, req.params);
+        const result = await deps.disconnectIntegration.execute({
+          userId,
+          providerId: provider,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendIntegrationsError(res, error);
+      }
+    },
+
+    async sync(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { provider } = z.parse(providerParamSchema, req.params);
+        const body = z.parse(syncBodySchema, req.body ?? {});
+        const result = await deps.syncIntegration.execute({
+          userId,
+          providerId: provider,
+          session: "session" in body ? body.session : undefined,
+          sessions: "sessions" in body ? body.sessions : undefined,
+          body:
+            "sport" in body && "playedAt" in body
+              ? body
+              : undefined,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendIntegrationsError(res, error);
+      }
+    },
+  };
+}
+
+function sendIntegrationsError(res: Response, error: unknown) {
+  if (error instanceof ProviderNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof ProviderUnavailableError) {
+    return res.status(409).json({ error: error.message });
+  }
+
+  if (error instanceof IntegrationNotConnectedError) {
+    return res.status(409).json({ error: error.message });
+  }
+
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid integrations payload" });
+  }
+
+  if (error instanceof IntegrationPersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/integrations/controllers/integrations.http.test.ts
+++ b/src/modules/integrations/controllers/integrations.http.test.ts
@@ -1,0 +1,304 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+import jwt from "jsonwebtoken";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { InMemoryIntegrationConnectionRepository } from "../repositories/in-memory-integration-connection.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+describe("integrations HTTP", () => {
+  const config = makeConfig();
+  let connections: InMemoryIntegrationConnectionRepository;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  beforeEach(async () => {
+    connections = new InMemoryIntegrationConnectionRepository();
+    app = await createApp(config, {
+      venueRepository: new InMemoryVenueRepository(),
+      friendshipRepository: new InMemoryFriendshipRepository(),
+      friendProfileLookup: new InMemoryFriendProfileLookup(),
+      integrationConnectionRepository: connections,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  function cookie(userId: string) {
+    return `token=${jwt.sign({ userId }, config.JWT_SECRET)}`;
+  }
+
+  test("guests get 401 on every integrations route", async () => {
+    const list = await fetch(`${server.url}/api/me/integrations`);
+    expect(list.status).toBe(401);
+
+    const connect = await fetch(
+      `${server.url}/api/me/integrations/generic-import/connect`,
+      { method: "POST", headers: { "Content-Type": "application/json" } },
+    );
+    expect(connect.status).toBe(401);
+
+    const disconnect = await fetch(
+      `${server.url}/api/me/integrations/generic-import`,
+      { method: "DELETE" },
+    );
+    expect(disconnect.status).toBe(401);
+
+    const sync = await fetch(
+      `${server.url}/api/me/integrations/generic-import/sync`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sport: "padel",
+          playedAt: "2026-09-06T10:00:00.000Z",
+        }),
+      },
+    );
+    expect(sync.status).toBe(401);
+  });
+
+  test("list, connect, sync, and disconnect generic-import", async () => {
+    const listed = await fetch(`${server.url}/api/me/integrations`, {
+      headers: { Cookie: cookie("user-a") },
+    });
+    expect(listed.status).toBe(200);
+    const listedBody = (await listed.json()) as {
+      providers: Array<{
+        id: string;
+        available: boolean;
+        comingSoon: boolean;
+        status: string;
+      }>;
+    };
+    expect(listedBody.providers.map((provider) => provider.id)).toEqual([
+      "generic-import",
+      "trackman",
+      "autodarts",
+    ]);
+    expect(listedBody.providers[0]).toMatchObject({
+      available: true,
+      comingSoon: false,
+      status: "disconnected",
+    });
+    expect(listedBody.providers[1]).toMatchObject({
+      id: "trackman",
+      available: false,
+      comingSoon: true,
+    });
+
+    const token = "hub-import-token-99";
+    const connected = await fetch(
+      `${server.url}/api/me/integrations/generic-import/connect`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({ token }),
+      },
+    );
+    expect(connected.status).toBe(200);
+    const connectedBody = await connected.json();
+    expect(connectedBody).toMatchObject({
+      provider: {
+        id: "generic-import",
+        status: "connected",
+        credentialMasked: "••••n-99",
+      },
+    });
+    expect(JSON.stringify(connectedBody)).not.toContain(token);
+
+    const synced = await fetch(
+      `${server.url}/api/me/integrations/generic-import/sync`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({
+          sport: "padel",
+          playedAt: "2026-09-06T10:00:00.000Z",
+          title: "Club night",
+        }),
+      },
+    );
+    expect(synced.status).toBe(200);
+    expect(await synced.json()).toMatchObject({
+      provider: {
+        status: "connected",
+        importedSessionCount: 1,
+        lastImportedSession: { sport: "padel", title: "Club night" },
+      },
+    });
+
+    const wrapped = await fetch(
+      `${server.url}/api/me/integrations/generic-import/sync`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({
+          sessions: [
+            {
+              sport: "golf",
+              playedAt: "2026-09-06T11:00:00.000Z",
+              title: "Range",
+            },
+          ],
+        }),
+      },
+    );
+    expect(wrapped.status).toBe(200);
+    expect(await wrapped.json()).toMatchObject({
+      provider: {
+        importedSessionCount: 2,
+        lastImportedSession: { title: "Range" },
+      },
+    });
+
+    const disconnected = await fetch(
+      `${server.url}/api/me/integrations/generic-import`,
+      {
+        method: "DELETE",
+        headers: { Cookie: cookie("user-a") },
+      },
+    );
+    expect(disconnected.status).toBe(200);
+    expect(await disconnected.json()).toMatchObject({
+      provider: {
+        status: "disconnected",
+        importedSessionCount: 2,
+        credentialMasked: null,
+      },
+    });
+  });
+
+  test("unknown provider, coming soon, and invalid payloads map to HTTP errors", async () => {
+    const missing = await fetch(
+      `${server.url}/api/me/integrations/not-a-provider/connect`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(missing.status).toBe(404);
+    expect(await missing.json()).toEqual({
+      error: "Integration provider not found",
+    });
+
+    const comingSoon = await fetch(
+      `${server.url}/api/me/integrations/trackman/connect`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({ token: "vendor-key" }),
+      },
+    );
+    expect(comingSoon.status).toBe(409);
+    expect(await comingSoon.json()).toEqual({
+      error: "trackman is not available yet",
+    });
+
+    const notConnected = await fetch(
+      `${server.url}/api/me/integrations/generic-import/sync`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({
+          sport: "padel",
+          playedAt: "2026-09-06T10:00:00.000Z",
+        }),
+      },
+    );
+    expect(notConnected.status).toBe(409);
+
+    const invalid = await fetch(
+      `${server.url}/api/me/integrations/generic-import/sync`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(invalid.status).toBe(400);
+  });
+
+  test("connections are scoped to the session user", async () => {
+    await fetch(`${server.url}/api/me/integrations/generic-import/connect`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({}),
+    });
+
+    const other = await fetch(`${server.url}/api/me/integrations`, {
+      headers: { Cookie: cookie("user-b") },
+    });
+    const otherBody = (await other.json()) as {
+      providers: Array<{ id: string; status: string }>;
+    };
+    expect(
+      otherBody.providers.find((provider) => provider.id === "generic-import")
+        ?.status,
+    ).toBe("disconnected");
+  });
+});

--- a/src/modules/integrations/entities/connection-status.ts
+++ b/src/modules/integrations/entities/connection-status.ts
@@ -1,0 +1,28 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export type ConnectionStatusValue = "connected" | "disconnected";
+
+export class ConnectionStatus {
+  static readonly CONNECTED = new ConnectionStatus("connected");
+  static readonly DISCONNECTED = new ConnectionStatus("disconnected");
+
+  private constructor(readonly value: ConnectionStatusValue) {}
+
+  static from(raw: unknown): ConnectionStatus {
+    if (raw === "connected") return ConnectionStatus.CONNECTED;
+    if (raw === "disconnected") return ConnectionStatus.DISCONNECTED;
+    throw new DomainError("status must be connected or disconnected");
+  }
+
+  get isConnected(): boolean {
+    return this.value === "connected";
+  }
+
+  get isDisconnected(): boolean {
+    return this.value === "disconnected";
+  }
+
+  equals(other: ConnectionStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/integrations/entities/imported-session-count.ts
+++ b/src/modules/integrations/entities/imported-session-count.ts
@@ -1,0 +1,29 @@
+import { DomainError } from "../../../lib/domain-error";
+
+const MAX = 10_000;
+
+export class ImportedSessionCount {
+  static readonly ZERO = new ImportedSessionCount(0);
+
+  private constructor(readonly value: number) {}
+
+  static from(raw: unknown): ImportedSessionCount {
+    if (typeof raw !== "number" || !Number.isFinite(raw)) {
+      throw new DomainError("importedSessionCount must be a number");
+    }
+    if (!Number.isInteger(raw)) {
+      throw new DomainError("importedSessionCount must be a whole number");
+    }
+    if (raw < 0 || raw > MAX) {
+      throw new DomainError(`importedSessionCount must be between 0 and ${MAX}`);
+    }
+    return new ImportedSessionCount(raw);
+  }
+
+  increment(by: number): ImportedSessionCount {
+    if (!Number.isInteger(by) || by < 1) {
+      throw new DomainError("import increment must be a positive whole number");
+    }
+    return ImportedSessionCount.from(this.value + by);
+  }
+}

--- a/src/modules/integrations/entities/imported-session.ts
+++ b/src/modules/integrations/entities/imported-session.ts
@@ -1,0 +1,134 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+export const IMPORTED_SESSION_SPORTS = ["padel", "golf", "other"] as const;
+export type ImportedSessionSport = (typeof IMPORTED_SESSION_SPORTS)[number];
+
+export type ImportedSessionSnapshot = {
+  id: string;
+  sport: ImportedSessionSport;
+  playedAt: string;
+  title: string | null;
+  notes: string | null;
+  metrics: Record<string, string | number>;
+};
+
+const MAX_TITLE = 80;
+const MAX_NOTES = 500;
+const MAX_METRIC_KEYS = 20;
+const MAX_METRIC_KEY = 40;
+
+export class ImportedSession {
+  private constructor(
+    readonly id: string,
+    readonly sport: ImportedSessionSport,
+    readonly playedAt: Date,
+    readonly title: string | null,
+    readonly notes: string | null,
+    readonly metrics: Readonly<Record<string, string | number>>,
+  ) {}
+
+  static from(raw: unknown): ImportedSession {
+    if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new DomainError("session must be an object");
+    }
+
+    const body = raw as Record<string, unknown>;
+    return new ImportedSession(
+      typeof body.id === "string" && body.id.trim()
+        ? body.id.trim()
+        : randomUUID(),
+      parseSport(body.sport),
+      parsePlayedAt(body.playedAt),
+      parseOptionalText(body.title, "title", MAX_TITLE),
+      parseOptionalText(body.notes, "notes", MAX_NOTES),
+      parseMetrics(body.metrics),
+    );
+  }
+
+  static fromSnapshot(snapshot: ImportedSessionSnapshot): ImportedSession {
+    return ImportedSession.from(snapshot);
+  }
+
+  toSnapshot(): ImportedSessionSnapshot {
+    return {
+      id: this.id,
+      sport: this.sport,
+      playedAt: this.playedAt.toISOString(),
+      title: this.title,
+      notes: this.notes,
+      metrics: { ...this.metrics },
+    };
+  }
+}
+
+function parseSport(raw: unknown): ImportedSessionSport {
+  const sport = requiredTrimmed(raw, "sport").toLowerCase();
+  if ((IMPORTED_SESSION_SPORTS as readonly string[]).includes(sport)) {
+    return sport as ImportedSessionSport;
+  }
+  throw new DomainError("sport must be padel, golf, or other");
+}
+
+function parsePlayedAt(raw: unknown): Date {
+  const value = requiredTrimmed(raw, "playedAt");
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new DomainError("playedAt must be a valid ISO date");
+  }
+  return date;
+}
+
+function parseOptionalText(
+  raw: unknown,
+  field: string,
+  max: number,
+): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") {
+    throw new DomainError(`${field} must be a string`);
+  }
+  const value = raw.trim();
+  if (value.length === 0) return null;
+  if (value.length > max) {
+    throw new DomainError(`${field} must be at most ${max} characters`);
+  }
+  return value;
+}
+
+function parseMetrics(raw: unknown): Record<string, string | number> {
+  if (raw == null) return {};
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new DomainError("metrics must be an object");
+  }
+
+  const entries = Object.entries(raw as Record<string, unknown>);
+  if (entries.length > MAX_METRIC_KEYS) {
+    throw new DomainError(`metrics may have at most ${MAX_METRIC_KEYS} keys`);
+  }
+
+  const metrics: Record<string, string | number> = {};
+  for (const [key, value] of entries) {
+    const name = key.trim();
+    if (!name || name.length > MAX_METRIC_KEY) {
+      throw new DomainError(
+        `metric keys must be 1-${MAX_METRIC_KEY} characters`,
+      );
+    }
+    if (typeof value === "number" && Number.isFinite(value)) {
+      metrics[name] = value;
+      continue;
+    }
+    if (typeof value === "string") {
+      const text = value.trim();
+      if (text.length === 0) {
+        throw new DomainError("metric values must not be blank");
+      }
+      metrics[name] = text;
+      continue;
+    }
+    throw new DomainError("metric values must be strings or numbers");
+  }
+  return metrics;
+}

--- a/src/modules/integrations/entities/integration-connection.test.ts
+++ b/src/modules/integrations/entities/integration-connection.test.ts
@@ -1,0 +1,201 @@
+import { DomainError } from "../../../lib/domain-error";
+import { ProviderId } from "./provider-id";
+import { ConnectionStatus } from "./connection-status";
+import { ImportedSession } from "./imported-session";
+import { ImportedSessionCount } from "./imported-session-count";
+import { IntegrationConnection } from "./integration-connection";
+import { IntegrationNotConnectedError } from "./integration-not-connected-error";
+import { Provider } from "./provider";
+import { StoredCredential } from "./stored-credential";
+
+function genericImportId() {
+  return ProviderId.from("generic-import");
+}
+
+function sampleSession(overrides: Record<string, unknown> = {}) {
+  return ImportedSession.from({
+    sport: "padel",
+    playedAt: "2026-09-06T10:00:00.000Z",
+    title: "Morning set",
+    notes: "Serve held",
+    metrics: { winners: 8 },
+    ...overrides,
+  });
+}
+
+function sampleCredential() {
+  return StoredCredential.fromEncrypted("iv.tag.cipher", "ab12");
+}
+
+describe("integration value objects", () => {
+  test("provider id is a kebab-case slug", () => {
+    expect(ProviderId.from("Generic-Import").value).toBe("generic-import");
+    expect(() => ProviderId.from("")).toThrow(DomainError);
+    expect(() => ProviderId.from("Generic Import")).toThrow(DomainError);
+  });
+
+  test("status is connected or disconnected", () => {
+    expect(ConnectionStatus.from("connected").isConnected).toBe(true);
+    expect(ConnectionStatus.from("disconnected").isDisconnected).toBe(true);
+    expect(() => ConnectionStatus.from("active")).toThrow(DomainError);
+  });
+
+  test("imported session count is a non-negative whole number", () => {
+    expect(ImportedSessionCount.from(0).increment(2).value).toBe(2);
+    expect(() => ImportedSessionCount.from(-1)).toThrow(DomainError);
+    expect(() => ImportedSessionCount.from(1.5)).toThrow(DomainError);
+  });
+
+  test("imported session requires sport and playedAt", () => {
+    const session = sampleSession();
+    expect(session.toSnapshot()).toMatchObject({
+      sport: "padel",
+      playedAt: "2026-09-06T10:00:00.000Z",
+      title: "Morning set",
+      notes: "Serve held",
+      metrics: { winners: 8 },
+    });
+    expect(() => ImportedSession.from({ sport: "padel" })).toThrow(DomainError);
+    expect(() =>
+      ImportedSession.from({
+        sport: "tennis",
+        playedAt: "2026-09-06T10:00:00.000Z",
+      }),
+    ).toThrow(DomainError);
+  });
+
+  test("stored credential never exposes the full secret", () => {
+    const credential = sampleCredential();
+    expect(credential.masked).toBe("••••ab12");
+    expect(credential.encryptedValue).toBe("iv.tag.cipher");
+  });
+
+  test("provider catalog rules reject available+comingSoon", () => {
+    expect(() =>
+      Provider.fromDefinition({
+        id: "broken",
+        name: "Broken",
+        description: "Nope",
+        available: true,
+        comingSoon: true,
+      }),
+    ).toThrow(DomainError);
+  });
+});
+
+describe(IntegrationConnection, () => {
+  test("open starts connected with zero imports", () => {
+    const connection = IntegrationConnection.open(
+      "user-a",
+      genericImportId(),
+      sampleCredential(),
+    );
+    const snapshot = connection.toSnapshot();
+
+    expect(connection.id).toBeTruthy();
+    expect(snapshot).toMatchObject({
+      userId: "user-a",
+      providerId: "generic-import",
+      status: "connected",
+      lastSyncedAt: null,
+      importedSessionCount: 0,
+      importedSessions: [],
+      tokenHint: "ab12",
+      disconnectedAt: null,
+    });
+    expect(snapshot.encryptedToken).toBe("iv.tag.cipher");
+    expect(snapshot.connectedAt).toEqual(expect.any(String));
+  });
+
+  test("import updates lastSyncedAt and the session count", () => {
+    const connection = IntegrationConnection.open(
+      "user-a",
+      genericImportId(),
+      null,
+    );
+
+    connection.importSessions([sampleSession()]);
+    expect(connection.toSnapshot()).toMatchObject({
+      status: "connected",
+      importedSessionCount: 1,
+    });
+    expect(connection.lastSyncedAt).toBeInstanceOf(Date);
+    expect(connection.importedSessions).toHaveLength(1);
+
+    connection.importSessions([
+      sampleSession({ sport: "golf", title: "Range" }),
+    ]);
+    expect(connection.importedSessionCount).toBe(2);
+    expect(connection.importedSessions.at(-1)?.toSnapshot().title).toBe("Range");
+  });
+
+  test("import on a disconnected connection is rejected", () => {
+    const connection = IntegrationConnection.open(
+      "user-a",
+      genericImportId(),
+      null,
+    );
+    connection.disconnect();
+    expect(() => connection.importSessions([sampleSession()])).toThrow(
+      IntegrationNotConnectedError,
+    );
+  });
+
+  test("disconnect clears the credential and keeps import history", () => {
+    const connection = IntegrationConnection.open(
+      "user-a",
+      genericImportId(),
+      sampleCredential(),
+    );
+    connection.importSessions([sampleSession()]);
+    connection.disconnect();
+
+    const snapshot = connection.toSnapshot();
+    expect(snapshot).toMatchObject({
+      status: "disconnected",
+      importedSessionCount: 1,
+      encryptedToken: null,
+      tokenHint: null,
+    });
+    expect(snapshot.lastSyncedAt).toEqual(expect.any(String));
+    expect(snapshot.disconnectedAt).toEqual(expect.any(String));
+  });
+
+  test("reconnect without a token keeps history and does not invent a credential", () => {
+    const connection = IntegrationConnection.open(
+      "user-a",
+      genericImportId(),
+      sampleCredential(),
+    );
+    connection.importSessions([sampleSession()]);
+    connection.disconnect();
+    connection.connect(null);
+
+    expect(connection.toSnapshot()).toMatchObject({
+      status: "connected",
+      importedSessionCount: 1,
+      encryptedToken: null,
+      tokenHint: null,
+    });
+  });
+
+  test("rehydrate + snapshot round-trips connection state", () => {
+    const created = IntegrationConnection.open(
+      "user-a",
+      genericImportId(),
+      sampleCredential(),
+    );
+    created.importSessions([sampleSession()]);
+    const restored = IntegrationConnection.fromSnapshot(created.toSnapshot());
+    expect(restored.toSnapshot()).toEqual(created.toSnapshot());
+  });
+
+  test("empty import list is a domain error", () => {
+    const connection = IntegrationConnection.open(
+      "user-a",
+      genericImportId(),
+      null,
+    );
+    expect(() => connection.importSessions([])).toThrow(DomainError);
+  });
+});

--- a/src/modules/integrations/entities/integration-connection.ts
+++ b/src/modules/integrations/entities/integration-connection.ts
@@ -1,0 +1,240 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { ConnectionStatus } from "./connection-status";
+import { ImportedSession } from "./imported-session";
+import { ImportedSessionCount } from "./imported-session-count";
+import { IntegrationNotConnectedError } from "./integration-not-connected-error";
+import { ProviderId } from "./provider-id";
+import { StoredCredential } from "./stored-credential";
+
+export const MAX_STORED_IMPORTED_SESSIONS = 50;
+
+export type IntegrationConnectionSnapshot = {
+  id: string;
+  userId: string;
+  providerId: string;
+  status: "connected" | "disconnected";
+  lastSyncedAt: string | null;
+  importedSessionCount: number;
+  importedSessions: ReturnType<ImportedSession["toSnapshot"]>[];
+  encryptedToken: string | null;
+  tokenHint: string | null;
+  connectedAt: string | null;
+  disconnectedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export class IntegrationConnection {
+  private constructor(
+    readonly id: string,
+    readonly userId: string,
+    readonly providerId: ProviderId,
+    readonly createdAt: Date,
+    private statusValue: ConnectionStatus,
+    private lastSyncedAtValue: Date | null,
+    private importedSessionCountValue: ImportedSessionCount,
+    private importedSessionsValue: ImportedSession[],
+    private credentialValue: StoredCredential | null,
+    private connectedAtValue: Date | null,
+    private disconnectedAtValue: Date | null,
+    private updatedAtValue: Date,
+  ) {}
+
+  static open(
+    userId: string,
+    providerId: ProviderId,
+    credential: StoredCredential | null,
+  ): IntegrationConnection {
+    const now = new Date();
+    return new IntegrationConnection(
+      randomUUID(),
+      requiredTrimmed(userId, "userId"),
+      providerId,
+      now,
+      ConnectionStatus.CONNECTED,
+      null,
+      ImportedSessionCount.ZERO,
+      [],
+      credential,
+      now,
+      null,
+      now,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    userId: string;
+    providerId: ProviderId;
+    status: ConnectionStatus;
+    lastSyncedAt: Date | null;
+    importedSessionCount: ImportedSessionCount;
+    importedSessions: ImportedSession[];
+    credential: StoredCredential | null;
+    connectedAt: Date | null;
+    disconnectedAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }): IntegrationConnection {
+    return new IntegrationConnection(
+      props.id,
+      props.userId,
+      props.providerId,
+      props.createdAt,
+      props.status,
+      props.lastSyncedAt,
+      props.importedSessionCount,
+      [...props.importedSessions],
+      props.credential,
+      props.connectedAt,
+      props.disconnectedAt,
+      props.updatedAt,
+    );
+  }
+
+  static fromSnapshot(
+    snapshot: IntegrationConnectionSnapshot,
+  ): IntegrationConnection {
+    return IntegrationConnection.rehydrate({
+      id: snapshot.id,
+      userId: snapshot.userId,
+      providerId: ProviderId.from(snapshot.providerId),
+      status: ConnectionStatus.from(snapshot.status),
+      lastSyncedAt: snapshot.lastSyncedAt
+        ? new Date(snapshot.lastSyncedAt)
+        : null,
+      importedSessionCount: ImportedSessionCount.from(
+        snapshot.importedSessionCount,
+      ),
+      importedSessions: snapshot.importedSessions.map((session) =>
+        ImportedSession.fromSnapshot(session),
+      ),
+      credential:
+        snapshot.encryptedToken && snapshot.tokenHint
+          ? StoredCredential.fromEncrypted(
+              snapshot.encryptedToken,
+              snapshot.tokenHint,
+            )
+          : null,
+      connectedAt: snapshot.connectedAt
+        ? new Date(snapshot.connectedAt)
+        : null,
+      disconnectedAt: snapshot.disconnectedAt
+        ? new Date(snapshot.disconnectedAt)
+        : null,
+      createdAt: new Date(snapshot.createdAt),
+      updatedAt: new Date(snapshot.updatedAt),
+    });
+  }
+
+  get status(): ConnectionStatus {
+    return this.statusValue;
+  }
+
+  get lastSyncedAt(): Date | null {
+    return this.lastSyncedAtValue;
+  }
+
+  get importedSessionCount(): number {
+    return this.importedSessionCountValue.value;
+  }
+
+  get importedSessions(): readonly ImportedSession[] {
+    return this.importedSessionsValue;
+  }
+
+  get credential(): StoredCredential | null {
+    return this.credentialValue;
+  }
+
+  get connectedAt(): Date | null {
+    return this.connectedAtValue;
+  }
+
+  get disconnectedAt(): Date | null {
+    return this.disconnectedAtValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  belongsTo(userId: string): boolean {
+    return this.userId === userId.trim();
+  }
+
+  connect(credential: StoredCredential | null): void {
+    const now = new Date();
+    if (this.statusValue.isConnected && !credential) {
+      return;
+    }
+
+    this.statusValue = ConnectionStatus.CONNECTED;
+    this.connectedAtValue = now;
+    this.disconnectedAtValue = null;
+    if (credential) {
+      this.credentialValue = credential;
+    }
+    this.updatedAtValue = now;
+  }
+
+  disconnect(): void {
+    if (this.statusValue.isDisconnected) {
+      return;
+    }
+
+    const now = new Date();
+    this.statusValue = ConnectionStatus.DISCONNECTED;
+    this.credentialValue = null;
+    this.disconnectedAtValue = now;
+    this.updatedAtValue = now;
+  }
+
+  importSessions(sessions: ImportedSession[]): void {
+    if (!this.statusValue.isConnected) {
+      throw new IntegrationNotConnectedError();
+    }
+    if (sessions.length === 0) {
+      throw new DomainError("at least one session is required");
+    }
+
+    const now = new Date();
+    this.importedSessionsValue = [
+      ...this.importedSessionsValue,
+      ...sessions,
+    ].slice(-MAX_STORED_IMPORTED_SESSIONS);
+    this.importedSessionCountValue = this.importedSessionCountValue.increment(
+      sessions.length,
+    );
+    this.lastSyncedAtValue = now;
+    this.updatedAtValue = now;
+  }
+
+  toSnapshot(): IntegrationConnectionSnapshot {
+    return {
+      id: this.id,
+      userId: this.userId,
+      providerId: this.providerId.value,
+      status: this.statusValue.value,
+      lastSyncedAt: this.lastSyncedAtValue
+        ? this.lastSyncedAtValue.toISOString()
+        : null,
+      importedSessionCount: this.importedSessionCountValue.value,
+      importedSessions: this.importedSessionsValue.map((session) =>
+        session.toSnapshot(),
+      ),
+      encryptedToken: this.credentialValue?.encryptedValue ?? null,
+      tokenHint: this.credentialValue?.hint ?? null,
+      connectedAt: this.connectedAtValue
+        ? this.connectedAtValue.toISOString()
+        : null,
+      disconnectedAt: this.disconnectedAtValue
+        ? this.disconnectedAtValue.toISOString()
+        : null,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+    };
+  }
+}

--- a/src/modules/integrations/entities/integration-not-connected-error.ts
+++ b/src/modules/integrations/entities/integration-not-connected-error.ts
@@ -1,0 +1,6 @@
+export class IntegrationNotConnectedError extends Error {
+  constructor() {
+    super("Integration is not connected");
+    this.name = "IntegrationNotConnectedError";
+  }
+}

--- a/src/modules/integrations/entities/integration-persistence-error.ts
+++ b/src/modules/integrations/entities/integration-persistence-error.ts
@@ -1,0 +1,9 @@
+export class IntegrationPersistenceError extends Error {
+  constructor(
+    message = "Unable to save integration connection",
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "IntegrationPersistenceError";
+  }
+}

--- a/src/modules/integrations/entities/provider-id.ts
+++ b/src/modules/integrations/entities/provider-id.ts
@@ -1,0 +1,23 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const MAX_LENGTH = 80;
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export class ProviderId {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): ProviderId {
+    const id = requiredTrimmed(raw, "providerId").toLowerCase();
+    if (id.length > MAX_LENGTH) {
+      throw new DomainError(`providerId must be at most ${MAX_LENGTH} characters`);
+    }
+    if (!SLUG.test(id)) {
+      throw new DomainError("providerId must be a kebab-case slug");
+    }
+    return new ProviderId(id);
+  }
+
+  equals(other: ProviderId): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/integrations/entities/provider-not-found-error.ts
+++ b/src/modules/integrations/entities/provider-not-found-error.ts
@@ -1,0 +1,6 @@
+export class ProviderNotFoundError extends Error {
+  constructor() {
+    super("Integration provider not found");
+    this.name = "ProviderNotFoundError";
+  }
+}

--- a/src/modules/integrations/entities/provider-unavailable-error.ts
+++ b/src/modules/integrations/entities/provider-unavailable-error.ts
@@ -1,0 +1,6 @@
+export class ProviderUnavailableError extends Error {
+  constructor(providerId = "this provider") {
+    super(`${providerId} is not available yet`);
+    this.name = "ProviderUnavailableError";
+  }
+}

--- a/src/modules/integrations/entities/provider.ts
+++ b/src/modules/integrations/entities/provider.ts
@@ -1,0 +1,64 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { ProviderId } from "./provider-id";
+import { ProviderUnavailableError } from "./provider-unavailable-error";
+
+export type ProviderDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  available: boolean;
+  comingSoon: boolean;
+};
+
+export type ProviderSnapshot = {
+  id: string;
+  name: string;
+  description: string;
+  available: boolean;
+  comingSoon: boolean;
+};
+
+export class Provider {
+  private constructor(
+    readonly id: ProviderId,
+    readonly name: string,
+    readonly description: string,
+    readonly available: boolean,
+    readonly comingSoon: boolean,
+  ) {}
+
+  static fromDefinition(definition: ProviderDefinition): Provider {
+    const name = requiredTrimmed(definition.name, "name");
+    const description = requiredTrimmed(definition.description, "description");
+    if (definition.available && definition.comingSoon) {
+      throw new DomainError("available providers cannot be marked comingSoon");
+    }
+    if (!definition.available && !definition.comingSoon) {
+      throw new DomainError("unavailable providers must be marked comingSoon");
+    }
+
+    return new Provider(
+      ProviderId.from(definition.id),
+      name,
+      description,
+      definition.available,
+      definition.comingSoon,
+    );
+  }
+
+  assertConnectable(): void {
+    if (!this.available) {
+      throw new ProviderUnavailableError(this.id.value);
+    }
+  }
+
+  toSnapshot(): ProviderSnapshot {
+    return {
+      id: this.id.value,
+      name: this.name,
+      description: this.description,
+      available: this.available,
+      comingSoon: this.comingSoon,
+    };
+  }
+}

--- a/src/modules/integrations/entities/stored-credential.ts
+++ b/src/modules/integrations/entities/stored-credential.ts
@@ -1,0 +1,29 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const MAX_ENCRYPTED = 4000;
+const MAX_HINT = 8;
+
+export class StoredCredential {
+  private constructor(
+    readonly encryptedValue: string,
+    readonly hint: string,
+  ) {}
+
+  static fromEncrypted(encryptedValue: unknown, hint: unknown): StoredCredential {
+    const encrypted = requiredTrimmed(encryptedValue, "encryptedToken");
+    if (encrypted.length > MAX_ENCRYPTED) {
+      throw new DomainError("encryptedToken is too long");
+    }
+
+    const tokenHint = requiredTrimmed(hint, "tokenHint");
+    if (tokenHint.length > MAX_HINT) {
+      throw new DomainError(`tokenHint must be at most ${MAX_HINT} characters`);
+    }
+
+    return new StoredCredential(encrypted, tokenHint);
+  }
+
+  get masked(): string {
+    return `••••${this.hint}`;
+  }
+}

--- a/src/modules/integrations/index.ts
+++ b/src/modules/integrations/index.ts
@@ -1,0 +1,108 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { ProviderCatalog } from "./catalog/provider-catalog";
+import { createIntegrationsController } from "./controllers/integrations.controller";
+import { IntegrationConnectionRepository } from "./repositories/integration-connection.repository";
+import { PrismaIntegrationConnectionRepository } from "./repositories/prisma-integration-connection.repository";
+import { createIntegrationsRoutes } from "./routes/integrations.routes";
+import {
+  ConnectIntegration,
+  DisconnectIntegration,
+  ListIntegrations,
+  SyncIntegration,
+} from "./services/integrations.service";
+import { TokenCipher } from "./services/token-cipher";
+
+export type CreateIntegrationsModuleParams = {
+  prisma: PrismaClient;
+  tokenEncryptionKey: string;
+  integrationConnectionRepository?: IntegrationConnectionRepository;
+  catalog?: ProviderCatalog;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type IntegrationsModule = {
+  router: Router;
+  integrationConnectionRepository: IntegrationConnectionRepository;
+};
+
+export function createIntegrationsModule({
+  prisma,
+  tokenEncryptionKey,
+  integrationConnectionRepository: repositoryOverride,
+  catalog: catalogOverride,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreateIntegrationsModuleParams): IntegrationsModule {
+  const catalog = catalogOverride ?? ProviderCatalog.defaults();
+  const integrationConnectionRepository =
+    repositoryOverride ?? new PrismaIntegrationConnectionRepository(prisma);
+  const cipher = new TokenCipher(tokenEncryptionKey);
+
+  const controller = createIntegrationsController({
+    listIntegrations: new ListIntegrations(
+      integrationConnectionRepository,
+      catalog,
+    ),
+    connectIntegration: new ConnectIntegration(
+      integrationConnectionRepository,
+      catalog,
+      cipher,
+    ),
+    disconnectIntegration: new DisconnectIntegration(
+      integrationConnectionRepository,
+      catalog,
+    ),
+    syncIntegration: new SyncIntegration(
+      integrationConnectionRepository,
+      catalog,
+    ),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createIntegrationsRoutes(controller, { requireAuth }),
+    integrationConnectionRepository,
+  };
+}
+
+export { createIntegrationsController } from "./controllers/integrations.controller";
+export { ProviderCatalog } from "./catalog/provider-catalog";
+export {
+  AUTODARTS_PROVIDER_ID,
+  GENERIC_IMPORT_PROVIDER_ID,
+  PROVIDER_DEFINITIONS,
+  TRACKMAN_PROVIDER_ID,
+} from "./catalog/providers";
+export { InMemoryIntegrationConnectionRepository } from "./repositories/in-memory-integration-connection.repository";
+export { PrismaIntegrationConnectionRepository } from "./repositories/prisma-integration-connection.repository";
+export type { IntegrationConnectionRepository } from "./repositories/integration-connection.repository";
+export { IntegrationConnection } from "./entities/integration-connection";
+export { Provider } from "./entities/provider";
+export { ProviderId } from "./entities/provider-id";
+export { ConnectionStatus } from "./entities/connection-status";
+export { ImportedSession } from "./entities/imported-session";
+export { ImportedSessionCount } from "./entities/imported-session-count";
+export { StoredCredential } from "./entities/stored-credential";
+export { IntegrationPersistenceError } from "./entities/integration-persistence-error";
+export { IntegrationNotConnectedError } from "./entities/integration-not-connected-error";
+export { ProviderNotFoundError } from "./entities/provider-not-found-error";
+export { ProviderUnavailableError } from "./entities/provider-unavailable-error";
+export {
+  ConnectIntegration,
+  DisconnectIntegration,
+  ListIntegrations,
+  SyncIntegration,
+} from "./services/integrations.service";
+export type {
+  PublicImportedSession,
+  PublicProvider,
+} from "./services/integrations.service";
+export { TokenCipher } from "./services/token-cipher";

--- a/src/modules/integrations/repositories/in-memory-integration-connection.repository.ts
+++ b/src/modules/integrations/repositories/in-memory-integration-connection.repository.ts
@@ -1,0 +1,56 @@
+import { IntegrationConnection } from "../entities/integration-connection";
+import { IntegrationPersistenceError } from "../entities/integration-persistence-error";
+import { ProviderId } from "../entities/provider-id";
+import { IntegrationConnectionRepository } from "./integration-connection.repository";
+
+export class InMemoryIntegrationConnectionRepository
+  implements IntegrationConnectionRepository
+{
+  private readonly byId = new Map<string, IntegrationConnection>();
+
+  async findByUserAndProvider(
+    userId: string,
+    providerId: ProviderId,
+  ): Promise<IntegrationConnection | null> {
+    const match = [...this.byId.values()].find(
+      (connection) =>
+        connection.belongsTo(userId) && connection.providerId.equals(providerId),
+    );
+    return clone(match ?? null);
+  }
+
+  async create(
+    connection: IntegrationConnection,
+  ): Promise<IntegrationConnection> {
+    const stored = clone(connection)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async persist(
+    connection: IntegrationConnection,
+  ): Promise<IntegrationConnection> {
+    if (!this.byId.has(connection.id)) {
+      throw new IntegrationPersistenceError(
+        "Unable to save integration connection",
+      );
+    }
+    const stored = clone(connection)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async listForUser(userId: string): Promise<IntegrationConnection[]> {
+    return [...this.byId.values()]
+      .filter((connection) => connection.belongsTo(userId))
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+      .map((connection) => clone(connection)!);
+  }
+}
+
+function clone(
+  connection: IntegrationConnection | null,
+): IntegrationConnection | null {
+  if (!connection) return null;
+  return IntegrationConnection.fromSnapshot(connection.toSnapshot());
+}

--- a/src/modules/integrations/repositories/integration-connection.repository.ts
+++ b/src/modules/integrations/repositories/integration-connection.repository.ts
@@ -1,0 +1,12 @@
+import { IntegrationConnection } from "../entities/integration-connection";
+import { ProviderId } from "../entities/provider-id";
+
+export interface IntegrationConnectionRepository {
+  findByUserAndProvider(
+    userId: string,
+    providerId: ProviderId,
+  ): Promise<IntegrationConnection | null>;
+  create(connection: IntegrationConnection): Promise<IntegrationConnection>;
+  persist(connection: IntegrationConnection): Promise<IntegrationConnection>;
+  listForUser(userId: string): Promise<IntegrationConnection[]>;
+}

--- a/src/modules/integrations/repositories/prisma-integration-connection.repository.ts
+++ b/src/modules/integrations/repositories/prisma-integration-connection.repository.ts
@@ -1,0 +1,160 @@
+import { Prisma, PrismaClient } from "../../../generated/prisma/client";
+import { ConnectionStatus } from "../entities/connection-status";
+import { ImportedSession } from "../entities/imported-session";
+import { ImportedSessionCount } from "../entities/imported-session-count";
+import { IntegrationConnection } from "../entities/integration-connection";
+import { IntegrationPersistenceError } from "../entities/integration-persistence-error";
+import { ProviderId } from "../entities/provider-id";
+import { StoredCredential } from "../entities/stored-credential";
+import { IntegrationConnectionRepository } from "./integration-connection.repository";
+
+type ConnectionRow = {
+  id: string;
+  userId: string;
+  providerId: string;
+  status: "connected" | "disconnected";
+  lastSyncedAt: Date | null;
+  importedSessionCount: number;
+  importedSessions: Prisma.JsonValue;
+  encryptedToken: string | null;
+  tokenHint: string | null;
+  connectedAt: Date | null;
+  disconnectedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function toDomain(row: ConnectionRow): IntegrationConnection {
+  return IntegrationConnection.rehydrate({
+    id: row.id,
+    userId: row.userId,
+    providerId: ProviderId.from(row.providerId),
+    status: ConnectionStatus.from(row.status),
+    lastSyncedAt: row.lastSyncedAt,
+    importedSessionCount: ImportedSessionCount.from(row.importedSessionCount),
+    importedSessions: parseImportedSessions(row.importedSessions),
+    credential:
+      row.encryptedToken && row.tokenHint
+        ? StoredCredential.fromEncrypted(row.encryptedToken, row.tokenHint)
+        : null,
+    connectedAt: row.connectedAt,
+    disconnectedAt: row.disconnectedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  });
+}
+
+function parseImportedSessions(raw: Prisma.JsonValue): ImportedSession[] {
+  if (!Array.isArray(raw)) {
+    throw new IntegrationPersistenceError("importedSessions must be an array");
+  }
+  return raw.map((item) => ImportedSession.from(item));
+}
+
+function toCreateData(connection: IntegrationConnection) {
+  const snapshot = connection.toSnapshot();
+  return {
+    id: snapshot.id,
+    userId: snapshot.userId,
+    providerId: snapshot.providerId,
+    status: snapshot.status,
+    lastSyncedAt: connection.lastSyncedAt,
+    importedSessionCount: snapshot.importedSessionCount,
+    importedSessions: snapshot.importedSessions as Prisma.InputJsonValue,
+    encryptedToken: snapshot.encryptedToken,
+    tokenHint: snapshot.tokenHint,
+    connectedAt: connection.connectedAt,
+    disconnectedAt: connection.disconnectedAt,
+    createdAt: connection.createdAt,
+    updatedAt: connection.updatedAt,
+  };
+}
+
+export class PrismaIntegrationConnectionRepository
+  implements IntegrationConnectionRepository
+{
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findByUserAndProvider(
+    userId: string,
+    providerId: ProviderId,
+  ): Promise<IntegrationConnection | null> {
+    try {
+      const row = await this.prisma.integrationConnection.findUnique({
+        where: {
+          userId_providerId: {
+            userId,
+            providerId: providerId.value,
+          },
+        },
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      if (error instanceof IntegrationPersistenceError) throw error;
+      throw new IntegrationPersistenceError(
+        "Failed to load integration connection",
+        { cause: error },
+      );
+    }
+  }
+
+  async create(
+    connection: IntegrationConnection,
+  ): Promise<IntegrationConnection> {
+    try {
+      const row = await this.prisma.integrationConnection.create({
+        data: toCreateData(connection),
+      });
+      return toDomain(row);
+    } catch (error) {
+      throw new IntegrationPersistenceError(
+        "Failed to create integration connection",
+        { cause: error },
+      );
+    }
+  }
+
+  async persist(
+    connection: IntegrationConnection,
+  ): Promise<IntegrationConnection> {
+    const snapshot = connection.toSnapshot();
+    try {
+      const row = await this.prisma.integrationConnection.update({
+        where: { id: snapshot.id },
+        data: {
+          status: snapshot.status,
+          lastSyncedAt: connection.lastSyncedAt,
+          importedSessionCount: snapshot.importedSessionCount,
+          importedSessions: snapshot.importedSessions as Prisma.InputJsonValue,
+          encryptedToken: snapshot.encryptedToken,
+          tokenHint: snapshot.tokenHint,
+          connectedAt: connection.connectedAt,
+          disconnectedAt: connection.disconnectedAt,
+          updatedAt: connection.updatedAt,
+        },
+      });
+      return toDomain(row);
+    } catch (error) {
+      throw new IntegrationPersistenceError(
+        "Failed to save integration connection",
+        { cause: error },
+      );
+    }
+  }
+
+  async listForUser(userId: string): Promise<IntegrationConnection[]> {
+    try {
+      const rows = await this.prisma.integrationConnection.findMany({
+        where: { userId },
+        orderBy: { updatedAt: "desc" },
+      });
+      return rows.map(toDomain);
+    } catch (error) {
+      if (error instanceof IntegrationPersistenceError) throw error;
+      throw new IntegrationPersistenceError(
+        "Failed to list integration connections",
+        { cause: error },
+      );
+    }
+  }
+}

--- a/src/modules/integrations/routes/integrations.routes.ts
+++ b/src/modules/integrations/routes/integrations.routes.ts
@@ -1,0 +1,46 @@
+import { Router } from "express";
+
+import { createIntegrationsController } from "../controllers/integrations.controller";
+
+export function createIntegrationsRoutes(
+  controller: ReturnType<typeof createIntegrationsController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.get("/api/me/integrations", options.requireAuth, (req, res) => {
+    void controller.list(req, res);
+  });
+
+  router.post(
+    "/api/me/integrations/:provider/connect",
+    options.requireAuth,
+    (req, res) => {
+      void controller.connect(req, res);
+    },
+  );
+
+  router.delete(
+    "/api/me/integrations/:provider",
+    options.requireAuth,
+    (req, res) => {
+      void controller.disconnect(req, res);
+    },
+  );
+
+  router.post(
+    "/api/me/integrations/:provider/sync",
+    options.requireAuth,
+    (req, res) => {
+      void controller.sync(req, res);
+    },
+  );
+
+  return router;
+}

--- a/src/modules/integrations/services/integrations.service.test.ts
+++ b/src/modules/integrations/services/integrations.service.test.ts
@@ -1,0 +1,230 @@
+import { DomainError } from "../../../lib/domain-error";
+import { ProviderCatalog } from "../catalog/provider-catalog";
+import {
+  AUTODARTS_PROVIDER_ID,
+  GENERIC_IMPORT_PROVIDER_ID,
+  TRACKMAN_PROVIDER_ID,
+} from "../catalog/providers";
+import { InMemoryIntegrationConnectionRepository } from "../repositories/in-memory-integration-connection.repository";
+import {
+  ConnectIntegration,
+  DisconnectIntegration,
+  IntegrationNotConnectedError,
+  ListIntegrations,
+  ProviderNotFoundError,
+  ProviderUnavailableError,
+  SyncIntegration,
+} from "./integrations.service";
+import { TokenCipher } from "./token-cipher";
+
+describe("integrations services", () => {
+  function setup() {
+    const catalog = ProviderCatalog.defaults();
+    const connections = new InMemoryIntegrationConnectionRepository();
+    const cipher = new TokenCipher("service-test-secret");
+    return {
+      catalog,
+      connections,
+      cipher,
+      list: new ListIntegrations(connections, catalog),
+      connect: new ConnectIntegration(connections, catalog, cipher),
+      disconnect: new DisconnectIntegration(connections, catalog),
+      sync: new SyncIntegration(connections, catalog),
+    };
+  }
+
+  const session = {
+    sport: "padel",
+    playedAt: "2026-09-06T10:00:00.000Z",
+    title: "Club night",
+  };
+
+  test("list returns the catalog with disconnected defaults", async () => {
+    const { list } = setup();
+    const result = await list.execute({ userId: "user-a" });
+
+    expect(result.providers.map((provider) => provider.id)).toEqual([
+      GENERIC_IMPORT_PROVIDER_ID,
+      TRACKMAN_PROVIDER_ID,
+      AUTODARTS_PROVIDER_ID,
+    ]);
+    expect(result.providers[0]).toMatchObject({
+      id: GENERIC_IMPORT_PROVIDER_ID,
+      available: true,
+      comingSoon: false,
+      status: "disconnected",
+      lastSyncedAt: null,
+      importedSessionCount: 0,
+      credentialMasked: null,
+      lastImportedSession: null,
+    });
+    expect(result.providers[1]).toMatchObject({
+      id: TRACKMAN_PROVIDER_ID,
+      available: false,
+      comingSoon: true,
+      status: "disconnected",
+    });
+  });
+
+  test("connect stores a masked credential and never returns the token", async () => {
+    const { connect, list } = setup();
+    const token = "super-secret-import-token";
+    const connected = await connect.execute({
+      userId: "user-a",
+      providerId: GENERIC_IMPORT_PROVIDER_ID,
+      token,
+    });
+
+    expect(connected.provider).toMatchObject({
+      id: GENERIC_IMPORT_PROVIDER_ID,
+      status: "connected",
+      credentialMasked: "••••oken",
+    });
+    expect(JSON.stringify(connected)).not.toContain(token);
+
+    const listed = await list.execute({ userId: "user-a" });
+    const generic = listed.providers.find(
+      (provider) => provider.id === GENERIC_IMPORT_PROVIDER_ID,
+    );
+    expect(generic?.status).toBe("connected");
+    expect(generic?.credentialMasked).toBe("••••oken");
+    expect(JSON.stringify(listed)).not.toContain(token);
+  });
+
+  test("connect is idempotent and can replace the stored token", async () => {
+    const { connect } = setup();
+    const first = await connect.execute({
+      userId: "user-a",
+      providerId: GENERIC_IMPORT_PROVIDER_ID,
+      token: "first-token",
+    });
+    const again = await connect.execute({
+      userId: "user-a",
+      providerId: GENERIC_IMPORT_PROVIDER_ID,
+    });
+    expect(again.provider.status).toBe("connected");
+    expect(again.provider.credentialMasked).toBe(first.provider.credentialMasked);
+
+    const rotated = await connect.execute({
+      userId: "user-a",
+      providerId: GENERIC_IMPORT_PROVIDER_ID,
+      token: "second-token",
+    });
+    expect(rotated.provider.credentialMasked).toBe("••••oken");
+    expect(JSON.stringify(rotated)).not.toContain("second-token");
+  });
+
+  test("sync accepts a structured session and updates lastSyncedAt", async () => {
+    const { connect, sync, list } = setup();
+    await connect.execute({
+      userId: "user-a",
+      providerId: GENERIC_IMPORT_PROVIDER_ID,
+    });
+
+    const synced = await sync.execute({
+      userId: "user-a",
+      providerId: GENERIC_IMPORT_PROVIDER_ID,
+      session,
+    });
+    expect(synced.provider).toMatchObject({
+      status: "connected",
+      importedSessionCount: 1,
+      lastImportedSession: {
+        sport: "padel",
+        title: "Club night",
+      },
+    });
+    expect(synced.provider.lastSyncedAt).toEqual(expect.any(String));
+
+    await sync.execute({
+      userId: "user-a",
+      providerId: GENERIC_IMPORT_PROVIDER_ID,
+      sessions: [
+        { ...session, sport: "golf", title: "Range" },
+        { ...session, sport: "other", title: "Gym" },
+      ],
+    });
+
+    const listed = await list.execute({ userId: "user-a" });
+    expect(listed.providers[0]).toMatchObject({
+      importedSessionCount: 3,
+      lastImportedSession: { title: "Gym" },
+    });
+  });
+
+  test("disconnect keeps import history and clears the credential", async () => {
+    const { connect, sync, disconnect } = setup();
+    await connect.execute({
+      userId: "user-a",
+      providerId: GENERIC_IMPORT_PROVIDER_ID,
+      token: "keep-secret",
+    });
+    await sync.execute({
+      userId: "user-a",
+      providerId: GENERIC_IMPORT_PROVIDER_ID,
+      session,
+    });
+
+    const disconnected = await disconnect.execute({
+      userId: "user-a",
+      providerId: GENERIC_IMPORT_PROVIDER_ID,
+    });
+    expect(disconnected.provider).toMatchObject({
+      status: "disconnected",
+      importedSessionCount: 1,
+      credentialMasked: null,
+    });
+    expect(disconnected.provider.lastSyncedAt).toEqual(expect.any(String));
+    expect(JSON.stringify(disconnected)).not.toContain("keep-secret");
+  });
+
+  test("sync requires a connected available provider", async () => {
+    const { sync, connect } = setup();
+
+    await expect(
+      sync.execute({
+        userId: "user-a",
+        providerId: GENERIC_IMPORT_PROVIDER_ID,
+        session,
+      }),
+    ).rejects.toBeInstanceOf(IntegrationNotConnectedError);
+
+    await connect.execute({
+      userId: "user-a",
+      providerId: GENERIC_IMPORT_PROVIDER_ID,
+    });
+    await expect(
+      sync.execute({
+        userId: "user-a",
+        providerId: GENERIC_IMPORT_PROVIDER_ID,
+      }),
+    ).rejects.toBeInstanceOf(DomainError);
+  });
+
+  test("unknown and coming-soon providers are rejected on connect/sync", async () => {
+    const { connect, sync } = setup();
+
+    await expect(
+      connect.execute({
+        userId: "user-a",
+        providerId: "not-a-provider",
+      }),
+    ).rejects.toBeInstanceOf(ProviderNotFoundError);
+
+    await expect(
+      connect.execute({
+        userId: "user-a",
+        providerId: TRACKMAN_PROVIDER_ID,
+        token: "vendor-key",
+      }),
+    ).rejects.toBeInstanceOf(ProviderUnavailableError);
+
+    await expect(
+      sync.execute({
+        userId: "user-a",
+        providerId: AUTODARTS_PROVIDER_ID,
+        session,
+      }),
+    ).rejects.toBeInstanceOf(ProviderUnavailableError);
+  });
+});

--- a/src/modules/integrations/services/integrations.service.ts
+++ b/src/modules/integrations/services/integrations.service.ts
@@ -1,0 +1,222 @@
+import { DomainError } from "../../../lib/domain-error";
+import { ProviderCatalog } from "../catalog/provider-catalog";
+import { IntegrationConnection } from "../entities/integration-connection";
+import { ImportedSession } from "../entities/imported-session";
+import { IntegrationNotConnectedError } from "../entities/integration-not-connected-error";
+import { Provider } from "../entities/provider";
+import { ProviderNotFoundError } from "../entities/provider-not-found-error";
+import { StoredCredential } from "../entities/stored-credential";
+import { IntegrationConnectionRepository } from "../repositories/integration-connection.repository";
+import { maskHint, TokenCipher } from "./token-cipher";
+
+export type PublicImportedSession = {
+  id: string;
+  sport: string;
+  playedAt: string;
+  title: string | null;
+};
+
+export type PublicProvider = {
+  id: string;
+  name: string;
+  description: string;
+  available: boolean;
+  comingSoon: boolean;
+  status: "connected" | "disconnected";
+  lastSyncedAt: string | null;
+  importedSessionCount: number;
+  connectedAt: string | null;
+  disconnectedAt: string | null;
+  credentialMasked: string | null;
+  lastImportedSession: PublicImportedSession | null;
+};
+
+function requireUserId(userId: string): string {
+  const id = userId.trim();
+  if (!id) throw new DomainError("userId is required");
+  return id;
+}
+
+function toPublicImportedSession(
+  session: ImportedSession,
+): PublicImportedSession {
+  const snapshot = session.toSnapshot();
+  return {
+    id: snapshot.id,
+    sport: snapshot.sport,
+    playedAt: snapshot.playedAt,
+    title: snapshot.title,
+  };
+}
+
+export function toPublicProvider(
+  provider: Provider,
+  connection: IntegrationConnection | null,
+): PublicProvider {
+  const last = connection?.importedSessions.at(-1) ?? null;
+  return {
+    ...provider.toSnapshot(),
+    status: connection?.status.value ?? "disconnected",
+    lastSyncedAt: connection?.lastSyncedAt
+      ? connection.lastSyncedAt.toISOString()
+      : null,
+    importedSessionCount: connection?.importedSessionCount ?? 0,
+    connectedAt: connection?.connectedAt
+      ? connection.connectedAt.toISOString()
+      : null,
+    disconnectedAt: connection?.disconnectedAt
+      ? connection.disconnectedAt.toISOString()
+      : null,
+    credentialMasked: maskHint(connection?.credential?.hint),
+    lastImportedSession: last ? toPublicImportedSession(last) : null,
+  };
+}
+
+function parseSessions(input: {
+  session?: unknown;
+  sessions?: unknown;
+  body?: unknown;
+}): ImportedSession[] {
+  if (Array.isArray(input.sessions)) {
+    return input.sessions.map((session) => ImportedSession.from(session));
+  }
+  if (input.session !== undefined) {
+    return [ImportedSession.from(input.session)];
+  }
+  if (input.body !== undefined) {
+    return [ImportedSession.from(input.body)];
+  }
+  throw new DomainError("provide session, sessions, or a session body");
+}
+
+export class ListIntegrations {
+  constructor(
+    private readonly connections: IntegrationConnectionRepository,
+    private readonly catalog: ProviderCatalog,
+  ) {}
+
+  async execute(input: { userId: string }): Promise<{
+    providers: PublicProvider[];
+  }> {
+    const userId = requireUserId(input.userId);
+    const rows = await this.connections.listForUser(userId);
+    const byProvider = new Map(
+      rows.map((connection) => [connection.providerId.value, connection]),
+    );
+
+    return {
+      providers: this.catalog.list().map((provider) =>
+        toPublicProvider(provider, byProvider.get(provider.id.value) ?? null),
+      ),
+    };
+  }
+}
+
+export class ConnectIntegration {
+  constructor(
+    private readonly connections: IntegrationConnectionRepository,
+    private readonly catalog: ProviderCatalog,
+    private readonly cipher: TokenCipher,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    providerId: unknown;
+    token?: unknown;
+  }): Promise<{ provider: PublicProvider }> {
+    const userId = requireUserId(input.userId);
+    const provider = this.catalog.require(input.providerId);
+    provider.assertConnectable();
+
+    const credential = toStoredCredential(this.cipher, input.token);
+    const existing = await this.connections.findByUserAndProvider(
+      userId,
+      provider.id,
+    );
+
+    if (existing) {
+      existing.connect(credential);
+      const saved = await this.connections.persist(existing);
+      return { provider: toPublicProvider(provider, saved) };
+    }
+
+    const created = await this.connections.create(
+      IntegrationConnection.open(userId, provider.id, credential),
+    );
+    return { provider: toPublicProvider(provider, created) };
+  }
+}
+
+export class DisconnectIntegration {
+  constructor(
+    private readonly connections: IntegrationConnectionRepository,
+    private readonly catalog: ProviderCatalog,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    providerId: unknown;
+  }): Promise<{ provider: PublicProvider }> {
+    const userId = requireUserId(input.userId);
+    const provider = this.catalog.require(input.providerId);
+    const existing = await this.connections.findByUserAndProvider(
+      userId,
+      provider.id,
+    );
+
+    if (!existing) {
+      return { provider: toPublicProvider(provider, null) };
+    }
+
+    existing.disconnect();
+    const saved = await this.connections.persist(existing);
+    return { provider: toPublicProvider(provider, saved) };
+  }
+}
+
+export class SyncIntegration {
+  constructor(
+    private readonly connections: IntegrationConnectionRepository,
+    private readonly catalog: ProviderCatalog,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    providerId: unknown;
+    session?: unknown;
+    sessions?: unknown;
+    body?: unknown;
+  }): Promise<{ provider: PublicProvider }> {
+    const userId = requireUserId(input.userId);
+    const provider = this.catalog.require(input.providerId);
+    provider.assertConnectable();
+
+    const existing = await this.connections.findByUserAndProvider(
+      userId,
+      provider.id,
+    );
+    if (!existing || !existing.status.isConnected) {
+      throw new IntegrationNotConnectedError();
+    }
+
+    existing.importSessions(parseSessions(input));
+    const saved = await this.connections.persist(existing);
+    return { provider: toPublicProvider(provider, saved) };
+  }
+}
+
+function toStoredCredential(
+  cipher: TokenCipher,
+  token: unknown,
+): StoredCredential | null {
+  if (token == null || token === "") return null;
+  const encrypted = cipher.encrypt(token);
+  return StoredCredential.fromEncrypted(
+    encrypted.encryptedValue,
+    encrypted.hint,
+  );
+}
+
+export { IntegrationNotConnectedError } from "../entities/integration-not-connected-error";
+export { ProviderNotFoundError } from "../entities/provider-not-found-error";
+export { ProviderUnavailableError } from "../entities/provider-unavailable-error";

--- a/src/modules/integrations/services/token-cipher.test.ts
+++ b/src/modules/integrations/services/token-cipher.test.ts
@@ -1,0 +1,33 @@
+import { DomainError } from "../../../lib/domain-error";
+import { hintFrom, maskHint, TokenCipher } from "./token-cipher";
+
+describe(TokenCipher, () => {
+  const cipher = new TokenCipher("test-encryption-secret");
+
+  test("encrypts a token and decrypts the ciphertext", () => {
+    const token = "import-token-secret-value";
+    const stored = cipher.encrypt(token);
+
+    expect(stored.encryptedValue).not.toContain(token);
+    expect(stored.hint).toBe("alue");
+    expect(cipher.decrypt(stored.encryptedValue)).toBe(token);
+  });
+
+  test("does not persist or hint the full secret", () => {
+    const stored = cipher.encrypt("abcd1234");
+    expect(stored.hint).toBe("1234");
+    expect(maskHint(stored.hint)).toBe("••••1234");
+    expect(stored.encryptedValue.includes("abcd1234")).toBe(false);
+  });
+
+  test("rejects blank tokens", () => {
+    expect(() => cipher.encrypt("   ")).toThrow(DomainError);
+  });
+});
+
+describe(hintFrom, () => {
+  test("uses the last four characters", () => {
+    expect(hintFrom("xy")).toBe("xy");
+    expect(hintFrom("token-99")).toBe("n-99");
+  });
+});

--- a/src/modules/integrations/services/token-cipher.ts
+++ b/src/modules/integrations/services/token-cipher.ts
@@ -1,0 +1,82 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes,
+} from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_BYTES = 12;
+const MAX_TOKEN_LENGTH = 512;
+
+export type EncryptedToken = {
+  encryptedValue: string;
+  hint: string;
+};
+
+export class TokenCipher {
+  constructor(private readonly secret: string) {
+    if (!secret.trim()) {
+      throw new DomainError("token encryption secret is required");
+    }
+  }
+
+  encrypt(rawToken: unknown): EncryptedToken {
+    const token = requiredTrimmed(rawToken, "token");
+    if (token.length > MAX_TOKEN_LENGTH) {
+      throw new DomainError(`token must be at most ${MAX_TOKEN_LENGTH} characters`);
+    }
+
+    const iv = randomBytes(IV_BYTES);
+    const cipher = createCipheriv(ALGORITHM, this.key(), iv);
+    const encrypted = Buffer.concat([
+      cipher.update(token, "utf8"),
+      cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+
+    return {
+      encryptedValue: [
+        iv.toString("base64url"),
+        tag.toString("base64url"),
+        encrypted.toString("base64url"),
+      ].join("."),
+      hint: hintFrom(token),
+    };
+  }
+
+  decrypt(encryptedValue: string): string {
+    const parts = encryptedValue.split(".");
+    if (parts.length !== 3) {
+      throw new DomainError("encryptedToken is malformed");
+    }
+
+    const [ivPart, tagPart, dataPart] = parts;
+    const iv = Buffer.from(ivPart, "base64url");
+    const tag = Buffer.from(tagPart, "base64url");
+    const data = Buffer.from(dataPart, "base64url");
+
+    const decipher = createDecipheriv(ALGORITHM, this.key(), iv);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(data), decipher.final()]).toString(
+      "utf8",
+    );
+  }
+
+  private key(): Buffer {
+    return createHash("sha256").update(this.secret).digest();
+  }
+}
+
+export function hintFrom(token: string): string {
+  const trimmed = token.trim();
+  if (trimmed.length <= 4) return trimmed;
+  return trimmed.slice(-4);
+}
+
+export function maskHint(hint: string | null | undefined): string | null {
+  if (!hint) return null;
+  return `••••${hint}`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the Smart Integrations API for the athlete hub ([leaguesports/landing-page#128](https://github.com/leaguesports/landing-page/issues/128), parent [landing-page#59](https://github.com/leaguesports/landing-page/issues/59)).

## Provider choice

**Live path: `generic-import`.** Trackman and Autodarts need vendor API keys / partnerships that are out of scope for v1. The catalog still lists them so the hub can render a real “coming soon” strip instead of a fake Active badge.

| id | available | comingSoon | Connect / sync |
| --- | --- | --- | --- |
| `generic-import` | `true` | `false` | Session user can connect, disconnect, and sync a structured session JSON |
| `trackman` | `false` | `true` | `409` on connect/sync |
| `autodarts` | `false` | `true` | `409` on connect/sync |

Tokens (optional on connect) are encrypted at rest with AES-256-GCM (key derived from `JWT_SECRET`). Responses never include the raw or ciphertext token — only `credentialMasked` (`••••` + last 4). Secrets are never logged.

## Frontend contract

All routes require the session cookie `token` (`credentials: "include"`). Guests get `401 { "error": "Unauthorized" }`.

### `GET /api/me/integrations`

```json
{
  "providers": [
    {
      "id": "generic-import",
      "name": "Import session",
      "description": "…",
      "available": true,
      "comingSoon": false,
      "status": "disconnected",
      "lastSyncedAt": null,
      "importedSessionCount": 0,
      "connectedAt": null,
      "disconnectedAt": null,
      "credentialMasked": null,
      "lastImportedSession": null
    }
  ]
}
```

`status` is `"connected" | "disconnected"`. `lastImportedSession` is `{ id, sport, playedAt, title }` or `null`.

### `POST /api/me/integrations/:provider/connect`

Body (all optional):

```json
{ "token": "optional-secret-or-label" }
```

Empty `{}` is a valid connect for `generic-import`. Returns `{ "provider": { …same PublicProvider… } }`.

### `DELETE /api/me/integrations/:provider`

Idempotent. Clears the stored credential, keeps `lastSyncedAt` + `importedSessionCount`. Returns `{ "provider": { … } }`.

### `POST /api/me/integrations/:provider/sync`

Accepts any of:

```json
{ "sport": "padel", "playedAt": "2026-09-06T10:00:00.000Z", "title": "Club night", "notes": "optional", "metrics": { "winners": 8 } }
```

```json
{ "session": { "sport": "padel", "playedAt": "2026-09-06T10:00:00.000Z" } }
```

```json
{ "sessions": [{ "sport": "golf", "playedAt": "2026-09-06T11:00:00.000Z", "title": "Range" }] }
```

`sport` is `"padel" | "golf" | "other"`. `playedAt` is an ISO datetime. Updates `lastSyncedAt` and increments `importedSessionCount`. Requires a connected `generic-import` (otherwise `409`).

### Errors

| Status | When |
| --- | --- |
| 400 | Invalid payload / domain validation |
| 401 | Missing session |
| 404 | Unknown `:provider` |
| 409 | Coming-soon provider, or sync while disconnected |
| 503 | Persistence failure |

## Domain bar

`IntegrationConnection` aggregate + VOs under `src/modules/integrations/entities/`. Commands/queries in `services/`. Thin Zod at the controller. Repository rehydrate + snapshot (Prisma + in-memory).

## Migration

`20260906090000_integration_connection` — `IntegrationConnection` table + `IntegrationConnectionStatus` enum (`connected` | `disconnected`). No User FK (same as training / badges / communities).

## Testing

Local: **193 passed** (35 suites), including **31 new** integrations tests (entity / catalog / cipher / service / HTTP). `yarn build` typecheck is clean.

## Out of scope

Full Trackman partnership, replacing scorecards with hardware scores, MyFitnessPal, push notifications.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14e26459-6173-4537-9e62-a2f4b8feab8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14e26459-6173-4537-9e62-a2f4b8feab8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

