### PR TITLE
Add fixture-scoped prediction pools (create/join/picks)

### DIFF
--- a/prisma/migrations/20260906120000_prediction_pool/migration.sql
+++ b/prisma/migrations/20260906120000_prediction_pool/migration.sql
@@ -1,0 +1,60 @@
+-- CreateEnum
+CREATE TYPE "PredictionPoolMemberRole" AS ENUM ('owner', 'member');
+
+-- CreateEnum
+CREATE TYPE "PredictionWinner" AS ENUM ('home', 'away', 'draw');
+
+-- CreateTable
+CREATE TABLE "PredictionPool" (
+    "id" TEXT NOT NULL,
+    "fixtureSlug" VARCHAR(80) NOT NULL,
+    "title" TEXT,
+    "inviteCode" VARCHAR(16) NOT NULL,
+    "createdByUserId" TEXT NOT NULL,
+    "kicksOffAt" TIMESTAMP(3),
+    "lockedAt" TIMESTAMP(3),
+    "resultHomeScore" INTEGER,
+    "resultAwayScore" INTEGER,
+    "resultWinner" "PredictionWinner",
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PredictionPool_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PredictionPoolEntry" (
+    "id" TEXT NOT NULL,
+    "poolId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "PredictionPoolMemberRole" NOT NULL DEFAULT 'member',
+    "tip" TEXT,
+    "homeScore" INTEGER,
+    "awayScore" INTEGER,
+    "winner" "PredictionWinner",
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PredictionPoolEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PredictionPool_inviteCode_key" ON "PredictionPool"("inviteCode");
+
+-- CreateIndex
+CREATE INDEX "PredictionPool_fixtureSlug_idx" ON "PredictionPool"("fixtureSlug");
+
+-- CreateIndex
+CREATE INDEX "PredictionPool_createdByUserId_idx" ON "PredictionPool"("createdByUserId");
+
+-- CreateIndex
+CREATE INDEX "PredictionPoolEntry_userId_idx" ON "PredictionPoolEntry"("userId");
+
+-- CreateIndex
+CREATE INDEX "PredictionPoolEntry_poolId_idx" ON "PredictionPoolEntry"("poolId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PredictionPoolEntry_poolId_userId_key" ON "PredictionPoolEntry"("poolId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "PredictionPoolEntry" ADD CONSTRAINT "PredictionPoolEntry_poolId_fkey" FOREIGN KEY ("poolId") REFERENCES "PredictionPool"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -195,6 +195,57 @@ model IntegrationConnection {
   @@index([userId])
 }
 
+// Fixture-scoped friends tip pool. No User FK — same as Friendship /
+// CommunityMember. Invite link is the share surface (WhatsApp). No money.
+enum PredictionPoolMemberRole {
+  owner
+  member
+}
+
+enum PredictionWinner {
+  home
+  away
+  draw
+}
+
+model PredictionPool {
+  id              String        @id @default(uuid())
+  fixtureSlug     String        @db.VarChar(80)
+  title           String?
+  inviteCode      String        @unique @db.VarChar(16)
+  createdByUserId String
+  kicksOffAt      DateTime?
+  lockedAt        DateTime?
+  resultHomeScore Int?
+  resultAwayScore Int?
+  resultWinner    PredictionWinner?
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @updatedAt
+  entries         PredictionPoolEntry[]
+
+  @@index([fixtureSlug])
+  @@index([createdByUserId])
+}
+
+model PredictionPoolEntry {
+  id        String                   @id @default(uuid())
+  poolId    String
+  userId    String
+  role      PredictionPoolMemberRole @default(member)
+  tip       String?
+  homeScore Int?
+  awayScore Int?
+  winner    PredictionWinner?
+  createdAt DateTime                 @default(now())
+  updatedAt DateTime                 @updatedAt
+
+  pool PredictionPool @relation(fields: [poolId], references: [id], onDelete: Cascade)
+
+  @@unique([poolId, userId])
+  @@index([userId])
+  @@index([poolId])
+}
+
 
 enum MatchRuleset {
   golden_point

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,6 +42,10 @@ import {
   createVenueModule,
   VenueRepository,
 } from "./modules/venue";
+import {
+  createPoolsModule,
+  PoolRepository,
+} from "./modules/pools";
 
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
@@ -55,6 +59,7 @@ export type CreateAppDependencies = {
   communityRepository?: CommunityRepository;
   trainingEnrollmentRepository?: TrainingEnrollmentRepository;
   integrationConnectionRepository?: IntegrationConnectionRepository;
+  poolRepository?: PoolRepository;
 };
 
 export async function createApp(
@@ -144,6 +149,13 @@ export async function createApp(
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
+  const pools = createPoolsModule({
+    prisma,
+    poolRepository: dependencies.poolRepository,
+    friendProfileLookup: friends.friendProfileLookup,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
@@ -155,6 +167,7 @@ export async function createApp(
   app.use(communities.router);
   app.use(training.router);
   app.use(integrations.router);
+  app.use(pools.router);
 
   app.use(
     (

--- a/src/modules/pools/controllers/pools.controller.ts
+++ b/src/modules/pools/controllers/pools.controller.ts
@@ -1,0 +1,186 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { PoolForbiddenError } from "../entities/pool-forbidden-error";
+import { PoolLockedError } from "../entities/pool-locked-error";
+import { PoolNotFoundError } from "../entities/pool-not-found-error";
+import { PoolPersistenceError } from "../entities/pool-persistence-error";
+import {
+  CreatePool,
+  GetPool,
+  GetPoolStandings,
+  JoinPool,
+  RecordPoolResult,
+  SubmitPoolPick,
+} from "../services/pools.service";
+
+const createBodySchema = z.object({
+  fixtureSlug: z.string(),
+  title: z.string().nullable().optional(),
+  kicksOffAt: z.string().nullable().optional(),
+});
+
+const idOrCodeParamSchema = z.object({
+  idOrCode: z.string(),
+});
+
+const pickBodySchema = z.object({
+  tip: z.string().nullable().optional(),
+  homeScore: z.number().nullable().optional(),
+  awayScore: z.number().nullable().optional(),
+  winner: z.string().nullable().optional(),
+});
+
+const resultBodySchema = z.object({
+  homeScore: z.number(),
+  awayScore: z.number(),
+  winner: z.string().nullable().optional(),
+});
+
+export function createPoolsController(deps: {
+  createPool: CreatePool;
+  getPool: GetPool;
+  joinPool: JoinPool;
+  submitPoolPick: SubmitPoolPick;
+  recordPoolResult: RecordPoolResult;
+  getPoolStandings: GetPoolStandings;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async create(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const body = z.parse(createBodySchema, req.body ?? {});
+        const result = await deps.createPool.execute({
+          userId,
+          fixtureSlug: body.fixtureSlug,
+          title: body.title,
+          kicksOffAt: body.kicksOffAt,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendPoolsError(res, error);
+      }
+    },
+
+    async get(req: Request, res: Response) {
+      try {
+        const { idOrCode } = z.parse(idOrCodeParamSchema, req.params);
+        const result = await deps.getPool.execute({
+          idOrCode,
+          userId: deps.tryGetSessionUserId(req),
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendPoolsError(res, error);
+      }
+    },
+
+    async join(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { idOrCode } = z.parse(idOrCodeParamSchema, req.params);
+        const result = await deps.joinPool.execute({
+          userId,
+          idOrCode,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendPoolsError(res, error);
+      }
+    },
+
+    async pick(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { idOrCode } = z.parse(idOrCodeParamSchema, req.params);
+        const body = z.parse(pickBodySchema, req.body ?? {});
+        const result = await deps.submitPoolPick.execute({
+          userId,
+          idOrCode,
+          tip: body.tip,
+          homeScore: body.homeScore,
+          awayScore: body.awayScore,
+          winner: body.winner,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendPoolsError(res, error);
+      }
+    },
+
+    async result(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { idOrCode } = z.parse(idOrCodeParamSchema, req.params);
+        const body = z.parse(resultBodySchema, req.body ?? {});
+        const result = await deps.recordPoolResult.execute({
+          userId,
+          idOrCode,
+          homeScore: body.homeScore,
+          awayScore: body.awayScore,
+          winner: body.winner,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendPoolsError(res, error);
+      }
+    },
+
+    async standings(req: Request, res: Response) {
+      try {
+        const { idOrCode } = z.parse(idOrCodeParamSchema, req.params);
+        const result = await deps.getPoolStandings.execute({ idOrCode });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendPoolsError(res, error);
+      }
+    },
+  };
+}
+
+function sendPoolsError(res: Response, error: unknown) {
+  if (error instanceof PoolNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof PoolLockedError) {
+    return res.status(409).json({ error: error.message });
+  }
+
+  if (error instanceof PoolForbiddenError) {
+    return res.status(403).json({ error: error.message });
+  }
+
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid prediction pool payload" });
+  }
+
+  if (error instanceof PoolPersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/pools/controllers/pools.http.test.ts
+++ b/src/modules/pools/controllers/pools.http.test.ts
@@ -1,0 +1,272 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+import jwt from "jsonwebtoken";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { FIXTURE_SLUG_MAX_LENGTH } from "../entities/fixture-slug";
+import { InMemoryPoolRepository } from "../repositories/in-memory-pool.repository";
+
+const SLUG = "springboks-vs-all-blacks-2026-09-06";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+describe("prediction pools HTTP", () => {
+  const config = makeConfig();
+  let pools: InMemoryPoolRepository;
+  let profiles: InMemoryFriendProfileLookup;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  beforeEach(async () => {
+    pools = new InMemoryPoolRepository();
+    profiles = new InMemoryFriendProfileLookup();
+    profiles.seed({
+      userId: "user-a",
+      displayName: "Alex",
+      handle: "alex",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-b",
+      displayName: "Blake",
+      handle: "blake",
+      avatarUrl: null,
+    });
+
+    app = await createApp(config, {
+      venueRepository: new InMemoryVenueRepository(),
+      friendshipRepository: new InMemoryFriendshipRepository(),
+      friendProfileLookup: profiles,
+      poolRepository: pools,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  function cookie(userId: string) {
+    return `token=${jwt.sign({ userId }, config.JWT_SECRET)}`;
+  }
+
+  test("create/join/picks require auth; get and standings are public", async () => {
+    const unauth = await fetch(`${server.url}/api/pools`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fixtureSlug: SLUG }),
+    });
+    expect(unauth.status).toBe(401);
+
+    const created = await fetch(`${server.url}/api/pools`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        fixtureSlug: SLUG,
+        title: "Boks tips",
+        userId: "someone-else",
+      }),
+    });
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as {
+      pool: {
+        id: string;
+        inviteCode: string;
+        fixtureSlug: string;
+        createdByUserId: string;
+        role: string;
+        memberCount: number;
+      };
+    };
+    expect(createdBody.pool).toMatchObject({
+      fixtureSlug: SLUG,
+      createdByUserId: "user-a",
+      role: "owner",
+      memberCount: 1,
+    });
+    expect(createdBody.pool.inviteCode).toMatch(/^[a-z0-9]{8}$/);
+
+    const guest = await fetch(
+      `${server.url}/api/pools/${createdBody.pool.inviteCode}`,
+    );
+    expect(guest.status).toBe(200);
+    const guestBody = (await guest.json()) as {
+      pool: { joined: boolean; role: string | null };
+    };
+    expect(guestBody.pool.joined).toBe(false);
+    expect(guestBody.pool.role).toBeNull();
+
+    const unauthJoin = await fetch(
+      `${server.url}/api/pools/${createdBody.pool.inviteCode}/join`,
+      { method: "POST" },
+    );
+    expect(unauthJoin.status).toBe(401);
+
+    const joined = await fetch(
+      `${server.url}/api/pools/${createdBody.pool.inviteCode}/join`,
+      {
+        method: "POST",
+        headers: { Cookie: cookie("user-b") },
+      },
+    );
+    expect(joined.status).toBe(200);
+    expect((await joined.json() as { pool: { memberCount: number } }).pool.memberCount).toBe(2);
+
+    const picked = await fetch(
+      `${server.url}/api/pools/${createdBody.pool.inviteCode}/picks`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-b"),
+        },
+        body: JSON.stringify({ homeScore: 27, awayScore: 20 }),
+      },
+    );
+    expect(picked.status).toBe(200);
+    const pickedBody = (await picked.json()) as {
+      pool: { myPick: { winner: string } };
+    };
+    expect(pickedBody.pool.myPick.winner).toBe("home");
+
+    const standings = await fetch(
+      `${server.url}/api/pools/${createdBody.pool.inviteCode}/standings`,
+    );
+    expect(standings.status).toBe(200);
+    const standingsBody = (await standings.json()) as {
+      result: null;
+      standings: Array<{ points: number; rank: number }>;
+    };
+    expect(standingsBody.result).toBeNull();
+    expect(standingsBody.standings).toHaveLength(2);
+    expect(
+      standingsBody.standings.every((row) => row.points === 0 && row.rank === 1),
+    ).toBe(true);
+  });
+
+  test("rejects invalid slugs and unknown invite codes", async () => {
+    const uppercase = await fetch(`${server.url}/api/pools`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({ fixtureSlug: "Springboks-vs-All-Blacks" }),
+    });
+    expect(uppercase.status).toBe(400);
+
+    const tooLong = await fetch(`${server.url}/api/pools`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        fixtureSlug: "a".repeat(FIXTURE_SLUG_MAX_LENGTH + 1),
+      }),
+    });
+    expect(tooLong.status).toBe(400);
+
+    const missing = await fetch(`${server.url}/api/pools/zzzzzzzz`);
+    expect(missing.status).toBe(404);
+  });
+
+  test("locks picks at kickoff and lets the owner record a result", async () => {
+    const created = await fetch(`${server.url}/api/pools`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        fixtureSlug: SLUG,
+        kicksOffAt: "2020-01-01T12:00:00.000Z",
+      }),
+    });
+    const createdBody = (await created.json()) as {
+      pool: { inviteCode: string };
+    };
+
+    const locked = await fetch(
+      `${server.url}/api/pools/${createdBody.pool.inviteCode}/picks`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-b"),
+        },
+        body: JSON.stringify({ winner: "home" }),
+      },
+    );
+    expect(locked.status).toBe(409);
+
+    const forbidden = await fetch(
+      `${server.url}/api/pools/${createdBody.pool.inviteCode}/result`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-b"),
+        },
+        body: JSON.stringify({ homeScore: 10, awayScore: 8 }),
+      },
+    );
+    expect(forbidden.status).toBe(403);
+
+    const recorded = await fetch(
+      `${server.url}/api/pools/${createdBody.pool.inviteCode}/result`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({ homeScore: 24, awayScore: 17 }),
+      },
+    );
+    expect(recorded.status).toBe(200);
+    const recordedBody = (await recorded.json()) as {
+      pool: { locked: boolean; result: { winner: string } };
+    };
+    expect(recordedBody.pool.locked).toBe(true);
+    expect(recordedBody.pool.result.winner).toBe("home");
+  });
+});

--- a/src/modules/pools/entities/fixture-slug.test.ts
+++ b/src/modules/pools/entities/fixture-slug.test.ts
@@ -1,0 +1,42 @@
+import { DomainError } from "../../../lib/domain-error";
+import { FIXTURE_SLUG_MAX_LENGTH, FixtureSlug } from "./fixture-slug";
+
+describe(FixtureSlug, () => {
+  test("accepts a landing fixture slug", () => {
+    expect(FixtureSlug.from("springboks-vs-all-blacks-2026-09-06").value).toBe(
+      "springboks-vs-all-blacks-2026-09-06",
+    );
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(FixtureSlug.from("  derby-2026-09-12  ").value).toBe(
+      "derby-2026-09-12",
+    );
+  });
+
+  test("rejects missing or blank values", () => {
+    expect(() => FixtureSlug.from(undefined)).toThrow(DomainError);
+    expect(() => FixtureSlug.from("")).toThrow(DomainError);
+    expect(() => FixtureSlug.from("   ")).toThrow(DomainError);
+  });
+
+  test("rejects uppercase, underscores, and other characters", () => {
+    expect(() => FixtureSlug.from("Springboks-vs-All-Blacks")).toThrow(
+      DomainError,
+    );
+    expect(() => FixtureSlug.from("springboks_vs_all_blacks")).toThrow(
+      DomainError,
+    );
+    expect(() => FixtureSlug.from("springboks vs all blacks")).toThrow(
+      DomainError,
+    );
+  });
+
+  test("rejects slugs longer than the max length", () => {
+    const tooLong = `${"a".repeat(FIXTURE_SLUG_MAX_LENGTH)}b`;
+    expect(() => FixtureSlug.from(tooLong)).toThrow(DomainError);
+    expect(
+      FixtureSlug.from("a".repeat(FIXTURE_SLUG_MAX_LENGTH)).value,
+    ).toHaveLength(FIXTURE_SLUG_MAX_LENGTH);
+  });
+});

--- a/src/modules/pools/entities/fixture-slug.ts
+++ b/src/modules/pools/entities/fixture-slug.ts
@@ -1,0 +1,30 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+export const FIXTURE_SLUG_MAX_LENGTH = 80;
+const FIXTURE_SLUG_PATTERN = /^[a-z0-9-]+$/;
+
+export class FixtureSlug {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): FixtureSlug {
+    const value = requiredTrimmed(raw, "fixtureSlug");
+
+    if (value.length > FIXTURE_SLUG_MAX_LENGTH) {
+      throw new DomainError(
+        `fixtureSlug must be at most ${FIXTURE_SLUG_MAX_LENGTH} characters`,
+      );
+    }
+
+    if (!FIXTURE_SLUG_PATTERN.test(value)) {
+      throw new DomainError(
+        "fixtureSlug must be lowercase letters, digits, and hyphens",
+      );
+    }
+
+    return new FixtureSlug(value);
+  }
+
+  equals(other: FixtureSlug): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/pools/entities/invite-code.ts
+++ b/src/modules/pools/entities/invite-code.ts
@@ -1,0 +1,43 @@
+import { randomBytes } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+export const INVITE_CODE_LENGTH = 8;
+export const INVITE_CODE_MAX_LENGTH = 16;
+const ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
+const INVITE_CODE_PATTERN = /^[a-z0-9]+$/;
+
+export class InviteCode {
+  private constructor(readonly value: string) {}
+
+  static generate(): InviteCode {
+    const bytes = randomBytes(INVITE_CODE_LENGTH);
+    let out = "";
+    for (let i = 0; i < INVITE_CODE_LENGTH; i++) {
+      out += ALPHABET[bytes[i]! % ALPHABET.length];
+    }
+    return new InviteCode(out);
+  }
+
+  static from(raw: unknown): InviteCode {
+    const value = requiredTrimmed(raw, "inviteCode").toLowerCase();
+    if (
+      value.length < INVITE_CODE_LENGTH ||
+      value.length > INVITE_CODE_MAX_LENGTH
+    ) {
+      throw new DomainError(
+        `inviteCode must be ${INVITE_CODE_LENGTH}–${INVITE_CODE_MAX_LENGTH} characters`,
+      );
+    }
+    if (!INVITE_CODE_PATTERN.test(value)) {
+      throw new DomainError(
+        "inviteCode must be lowercase letters and digits",
+      );
+    }
+    return new InviteCode(value);
+  }
+
+  equals(other: InviteCode): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/pools/entities/pool-entry.ts
+++ b/src/modules/pools/entities/pool-entry.ts
@@ -1,0 +1,145 @@
+import { randomUUID } from "node:crypto";
+
+import { requiredTrimmed } from "../../../lib/domain-error";
+import { PoolMemberRole } from "./pool-member-role";
+import { PredictionWinner } from "./prediction-winner";
+
+export const POOL_TIP_MAX_LENGTH = 140;
+
+export type PoolEntrySnapshot = {
+  id: string;
+  userId: string;
+  role: "owner" | "member";
+  tip: string | null;
+  homeScore: number | null;
+  awayScore: number | null;
+  winner: "home" | "away" | "draw" | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PoolPickInput = {
+  tip: string | null;
+  homeScore: number | null;
+  awayScore: number | null;
+  winner: PredictionWinner | null;
+};
+
+export class PoolEntry {
+  private constructor(
+    readonly id: string,
+    readonly userId: string,
+    readonly role: PoolMemberRole,
+    readonly createdAt: Date,
+    private tipValue: string | null,
+    private homeScoreValue: number | null,
+    private awayScoreValue: number | null,
+    private winnerValue: PredictionWinner | null,
+    private updatedAtValue: Date,
+  ) {}
+
+  static owner(userId: string, now = new Date()): PoolEntry {
+    const id = requiredTrimmed(userId, "userId");
+    return new PoolEntry(
+      randomUUID(),
+      id,
+      PoolMemberRole.OWNER,
+      now,
+      null,
+      null,
+      null,
+      null,
+      now,
+    );
+  }
+
+  static member(userId: string, now = new Date()): PoolEntry {
+    const id = requiredTrimmed(userId, "userId");
+    return new PoolEntry(
+      randomUUID(),
+      id,
+      PoolMemberRole.MEMBER,
+      now,
+      null,
+      null,
+      null,
+      null,
+      now,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    userId: string;
+    role: PoolMemberRole;
+    tip: string | null;
+    homeScore: number | null;
+    awayScore: number | null;
+    winner: PredictionWinner | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }): PoolEntry {
+    return new PoolEntry(
+      props.id,
+      props.userId,
+      props.role,
+      props.createdAt,
+      props.tip,
+      props.homeScore,
+      props.awayScore,
+      props.winner,
+      props.updatedAt,
+    );
+  }
+
+  get tip(): string | null {
+    return this.tipValue;
+  }
+
+  get homeScore(): number | null {
+    return this.homeScoreValue;
+  }
+
+  get awayScore(): number | null {
+    return this.awayScoreValue;
+  }
+
+  get winner(): PredictionWinner | null {
+    return this.winnerValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  get hasPick(): boolean {
+    return (
+      this.tipValue != null ||
+      this.homeScoreValue != null ||
+      this.awayScoreValue != null ||
+      this.winnerValue != null
+    );
+  }
+
+  applyPick(pick: PoolPickInput, now = new Date()): void {
+    this.tipValue = pick.tip;
+    this.homeScoreValue = pick.homeScore;
+    this.awayScoreValue = pick.awayScore;
+    this.winnerValue = pick.winner;
+    this.updatedAtValue = now;
+  }
+
+  toSnapshot(): PoolEntrySnapshot {
+    return {
+      id: this.id,
+      userId: this.userId,
+      role: this.role.value,
+      tip: this.tipValue,
+      homeScore: this.homeScoreValue,
+      awayScore: this.awayScoreValue,
+      winner: this.winnerValue?.value ?? null,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+    };
+  }
+}

--- a/src/modules/pools/entities/pool-forbidden-error.ts
+++ b/src/modules/pools/entities/pool-forbidden-error.ts
@@ -1,0 +1,6 @@
+export class PoolForbiddenError extends Error {
+  constructor(message = "Only the pool owner can record a result") {
+    super(message);
+    this.name = "PoolForbiddenError";
+  }
+}

--- a/src/modules/pools/entities/pool-locked-error.ts
+++ b/src/modules/pools/entities/pool-locked-error.ts
@@ -1,0 +1,6 @@
+export class PoolLockedError extends Error {
+  constructor(message = "Tips are locked for this pool") {
+    super(message);
+    this.name = "PoolLockedError";
+  }
+}

--- a/src/modules/pools/entities/pool-member-role.ts
+++ b/src/modules/pools/entities/pool-member-role.ts
@@ -1,0 +1,20 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export type PoolMemberRoleValue = "owner" | "member";
+
+export class PoolMemberRole {
+  static readonly OWNER = new PoolMemberRole("owner");
+  static readonly MEMBER = new PoolMemberRole("member");
+
+  private constructor(readonly value: PoolMemberRoleValue) {}
+
+  static from(raw: unknown): PoolMemberRole {
+    if (raw === "owner") return PoolMemberRole.OWNER;
+    if (raw === "member") return PoolMemberRole.MEMBER;
+    throw new DomainError("role must be owner or member");
+  }
+
+  get isOwner(): boolean {
+    return this.value === "owner";
+  }
+}

--- a/src/modules/pools/entities/pool-not-found-error.ts
+++ b/src/modules/pools/entities/pool-not-found-error.ts
@@ -1,0 +1,6 @@
+export class PoolNotFoundError extends Error {
+  constructor() {
+    super("Prediction pool not found");
+    this.name = "PoolNotFoundError";
+  }
+}

--- a/src/modules/pools/entities/pool-persistence-error.ts
+++ b/src/modules/pools/entities/pool-persistence-error.ts
@@ -1,0 +1,6 @@
+export class PoolPersistenceError extends Error {
+  constructor(message = "Unable to save prediction pool", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "PoolPersistenceError";
+  }
+}

--- a/src/modules/pools/entities/pool-title.ts
+++ b/src/modules/pools/entities/pool-title.ts
@@ -1,0 +1,23 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const POOL_TITLE_MAX_LENGTH = 80;
+
+export class PoolTitle {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): PoolTitle | null {
+    if (raw == null) return null;
+    if (typeof raw !== "string") {
+      throw new DomainError("title must be a string");
+    }
+
+    const title = raw.trim();
+    if (title.length === 0) return null;
+    if (title.length > POOL_TITLE_MAX_LENGTH) {
+      throw new DomainError(
+        `title must be at most ${POOL_TITLE_MAX_LENGTH} characters`,
+      );
+    }
+    return new PoolTitle(title);
+  }
+}

--- a/src/modules/pools/entities/prediction-pool.test.ts
+++ b/src/modules/pools/entities/prediction-pool.test.ts
@@ -1,0 +1,104 @@
+import { DomainError } from "../../../lib/domain-error";
+import { FixtureSlug } from "./fixture-slug";
+import { PoolForbiddenError } from "./pool-forbidden-error";
+import { PoolLockedError } from "./pool-locked-error";
+import { PoolTitle } from "./pool-title";
+import {
+  parsePoolPick,
+  parsePoolResult,
+  PredictionPool,
+} from "./prediction-pool";
+import { PredictionWinner } from "./prediction-winner";
+
+function createPool(overrides: { kicksOffAt?: Date | null } = {}) {
+  return PredictionPool.create({
+    fixtureSlug: FixtureSlug.from("springboks-vs-all-blacks-2026-09-06"),
+    title: PoolTitle.from("Boks tips"),
+    createdByUserId: "user-a",
+    kicksOffAt: overrides.kicksOffAt ?? null,
+  });
+}
+
+describe(PredictionPool, () => {
+  test("create makes the session user the owner and first member", () => {
+    const pool = createPool();
+    const snapshot = pool.toSnapshot();
+    expect(snapshot.fixtureSlug).toBe("springboks-vs-all-blacks-2026-09-06");
+    expect(snapshot.title).toBe("Boks tips");
+    expect(snapshot.inviteCode).toMatch(/^[a-z0-9]{8}$/);
+    expect(snapshot.createdByUserId).toBe("user-a");
+    expect(snapshot.entries).toHaveLength(1);
+    expect(snapshot.entries[0]).toMatchObject({
+      userId: "user-a",
+      role: "owner",
+      tip: null,
+    });
+    expect(pool.isLocked()).toBe(false);
+  });
+
+  test("join is idempotent and adds later members", () => {
+    const pool = createPool();
+    pool.join("user-b");
+    pool.join("user-b");
+    expect(pool.memberCount).toBe(2);
+    expect(pool.entryOf("user-b")?.role.value).toBe("member");
+  });
+
+  test("submitPick auto-joins and stores the tip before lock", () => {
+    const pool = createPool();
+    pool.submitPick(
+      "user-b",
+      parsePoolPick({ homeScore: 27, awayScore: 20, winner: "home" }),
+    );
+    expect(pool.memberCount).toBe(2);
+    expect(pool.entryOf("user-b")?.toSnapshot()).toMatchObject({
+      homeScore: 27,
+      awayScore: 20,
+      winner: "home",
+    });
+  });
+
+  test("locks picks at kicksOffAt", () => {
+    const kicksOffAt = new Date("2026-09-06T15:00:00.000Z");
+    const pool = createPool({ kicksOffAt });
+    expect(pool.isLocked(new Date("2026-09-06T14:59:59.000Z"))).toBe(false);
+    expect(pool.isLocked(kicksOffAt)).toBe(true);
+    expect(() =>
+      pool.submitPick(
+        "user-a",
+        parsePoolPick({ winner: "home" }),
+        new Date("2026-09-06T15:00:01.000Z"),
+      ),
+    ).toThrow(PoolLockedError);
+  });
+
+  test("owner records a result and locks further picks", () => {
+    const pool = createPool();
+    pool.submitPick("user-a", parsePoolPick({ winner: "home" }));
+    pool.recordResult("user-a", parsePoolResult({ homeScore: 24, awayScore: 17 }));
+    expect(pool.result?.winner.value).toBe("home");
+    expect(pool.isLocked()).toBe(true);
+    expect(() =>
+      pool.submitPick("user-b", parsePoolPick({ winner: "away" })),
+    ).toThrow(PoolLockedError);
+  });
+
+  test("non-owners cannot record a result", () => {
+    const pool = createPool();
+    pool.join("user-b");
+    expect(() =>
+      pool.recordResult(
+        "user-b",
+        parsePoolResult({ homeScore: 10, awayScore: 10 }),
+      ),
+    ).toThrow(PoolForbiddenError);
+  });
+
+  test("parsePoolPick requires at least one field and derives winner", () => {
+    expect(() => parsePoolPick({})).toThrow(DomainError);
+    expect(parsePoolPick({ homeScore: 12, awayScore: 18 }).winner).toEqual(
+      PredictionWinner.AWAY,
+    );
+    expect(parsePoolPick({ tip: "  Springboks  " }).tip).toBe("Springboks");
+  });
+});

--- a/src/modules/pools/entities/prediction-pool.ts
+++ b/src/modules/pools/entities/prediction-pool.ts
@@ -1,0 +1,306 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { FixtureSlug } from "./fixture-slug";
+import { InviteCode } from "./invite-code";
+import { PoolEntry, PoolPickInput, POOL_TIP_MAX_LENGTH } from "./pool-entry";
+import { PoolForbiddenError } from "./pool-forbidden-error";
+import { PoolLockedError } from "./pool-locked-error";
+import { PoolMemberRole } from "./pool-member-role";
+import { PoolTitle } from "./pool-title";
+import {
+  parseOptionalPredictionScore,
+  parsePredictionScore,
+} from "./prediction-score";
+import { PredictionWinner } from "./prediction-winner";
+
+export type PredictionResult = {
+  homeScore: number;
+  awayScore: number;
+  winner: PredictionWinner;
+};
+
+export type PredictionPoolSnapshot = {
+  id: string;
+  fixtureSlug: string;
+  title: string | null;
+  inviteCode: string;
+  createdByUserId: string;
+  kicksOffAt: string | null;
+  lockedAt: string | null;
+  result: {
+    homeScore: number;
+    awayScore: number;
+    winner: "home" | "away" | "draw";
+  } | null;
+  createdAt: string;
+  updatedAt: string;
+  entries: ReturnType<PoolEntry["toSnapshot"]>[];
+};
+
+export type CreatePredictionPoolProps = {
+  fixtureSlug: FixtureSlug;
+  title: PoolTitle | null;
+  createdByUserId: string;
+  kicksOffAt?: Date | null;
+};
+
+function parseKicksOffAt(raw: unknown): Date | null {
+  if (raw == null || raw === "") return null;
+  if (raw instanceof Date) {
+    if (Number.isNaN(raw.getTime())) {
+      throw new DomainError("kicksOffAt must be a valid ISO datetime");
+    }
+    return raw;
+  }
+  if (typeof raw !== "string") {
+    throw new DomainError("kicksOffAt must be an ISO datetime");
+  }
+  const value = raw.trim();
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new DomainError("kicksOffAt must be a valid ISO datetime");
+  }
+  return date;
+}
+
+function parseTip(raw: unknown): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") {
+    throw new DomainError("tip must be a string");
+  }
+  const tip = raw.trim();
+  if (tip.length === 0) return null;
+  if (tip.length > POOL_TIP_MAX_LENGTH) {
+    throw new DomainError(`tip must be at most ${POOL_TIP_MAX_LENGTH} characters`);
+  }
+  return tip;
+}
+
+export function parsePoolPick(input: {
+  tip?: unknown;
+  homeScore?: unknown;
+  awayScore?: unknown;
+  winner?: unknown;
+}): PoolPickInput {
+  const tip = parseTip(input.tip);
+  const homeScore = parseOptionalPredictionScore(input.homeScore, "homeScore");
+  const awayScore = parseOptionalPredictionScore(input.awayScore, "awayScore");
+  let winner = PredictionWinner.fromOptional(input.winner);
+
+  if (homeScore != null && awayScore != null && !winner) {
+    winner = PredictionWinner.fromScores(homeScore, awayScore);
+  }
+
+  if (tip == null && homeScore == null && awayScore == null && winner == null) {
+    throw new DomainError("pick must include tip, score, or winner");
+  }
+
+  return { tip, homeScore, awayScore, winner };
+}
+
+export function parsePoolResult(input: {
+  homeScore: unknown;
+  awayScore: unknown;
+  winner?: unknown;
+}): PredictionResult {
+  const homeScore = parsePredictionScore(input.homeScore, "homeScore");
+  const awayScore = parsePredictionScore(input.awayScore, "awayScore");
+  const winner =
+    PredictionWinner.fromOptional(input.winner) ??
+    PredictionWinner.fromScores(homeScore, awayScore);
+  return { homeScore, awayScore, winner };
+}
+
+export class PredictionPool {
+  private constructor(
+    readonly id: string,
+    readonly fixtureSlug: FixtureSlug,
+    readonly title: PoolTitle | null,
+    readonly inviteCode: InviteCode,
+    readonly createdByUserId: string,
+    readonly kicksOffAt: Date | null,
+    readonly createdAt: Date,
+    private lockedAtValue: Date | null,
+    private resultValue: PredictionResult | null,
+    private updatedAtValue: Date,
+    private entriesValue: PoolEntry[],
+  ) {}
+
+  static create(props: CreatePredictionPoolProps): PredictionPool {
+    const ownerId = requiredTrimmed(props.createdByUserId, "userId");
+    const now = new Date();
+    return new PredictionPool(
+      randomUUID(),
+      props.fixtureSlug,
+      props.title,
+      InviteCode.generate(),
+      ownerId,
+      props.kicksOffAt ?? null,
+      now,
+      null,
+      null,
+      now,
+      [PoolEntry.owner(ownerId, now)],
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    fixtureSlug: FixtureSlug;
+    title: PoolTitle | null;
+    inviteCode: InviteCode;
+    createdByUserId: string;
+    kicksOffAt: Date | null;
+    lockedAt: Date | null;
+    result: PredictionResult | null;
+    createdAt: Date;
+    updatedAt: Date;
+    entries: PoolEntry[];
+  }): PredictionPool {
+    return new PredictionPool(
+      props.id,
+      props.fixtureSlug,
+      props.title,
+      props.inviteCode,
+      props.createdByUserId,
+      props.kicksOffAt,
+      props.createdAt,
+      props.lockedAt,
+      props.result,
+      props.updatedAt,
+      [...props.entries],
+    );
+  }
+
+  static fromSnapshot(snapshot: PredictionPoolSnapshot): PredictionPool {
+    return PredictionPool.rehydrate({
+      id: snapshot.id,
+      fixtureSlug: FixtureSlug.from(snapshot.fixtureSlug),
+      title: PoolTitle.from(snapshot.title),
+      inviteCode: InviteCode.from(snapshot.inviteCode),
+      createdByUserId: snapshot.createdByUserId,
+      kicksOffAt: snapshot.kicksOffAt
+        ? parseKicksOffAt(snapshot.kicksOffAt)
+        : null,
+      lockedAt: snapshot.lockedAt ? new Date(snapshot.lockedAt) : null,
+      result: snapshot.result
+        ? {
+            homeScore: snapshot.result.homeScore,
+            awayScore: snapshot.result.awayScore,
+            winner: PredictionWinner.from(snapshot.result.winner),
+          }
+        : null,
+      createdAt: new Date(snapshot.createdAt),
+      updatedAt: new Date(snapshot.updatedAt),
+      entries: snapshot.entries.map((entry) =>
+        PoolEntry.rehydrate({
+          id: entry.id,
+          userId: entry.userId,
+          role: PoolMemberRole.from(entry.role),
+          tip: entry.tip,
+          homeScore: entry.homeScore,
+          awayScore: entry.awayScore,
+          winner: PredictionWinner.fromOptional(entry.winner),
+          createdAt: new Date(entry.createdAt),
+          updatedAt: new Date(entry.updatedAt),
+        }),
+      ),
+    });
+  }
+
+  static parseKicksOffAt = parseKicksOffAt;
+
+  get lockedAt(): Date | null {
+    return this.lockedAtValue;
+  }
+
+  get result(): PredictionResult | null {
+    return this.resultValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  get entries(): readonly PoolEntry[] {
+    return this.entriesValue;
+  }
+
+  get memberCount(): number {
+    return this.entriesValue.length;
+  }
+
+  entryOf(userId: string): PoolEntry | null {
+    const id = userId.trim();
+    return this.entriesValue.find((entry) => entry.userId === id) ?? null;
+  }
+
+  isLocked(now = new Date()): boolean {
+    if (this.lockedAtValue) return true;
+    if (this.resultValue) return true;
+    if (this.kicksOffAt && now.getTime() >= this.kicksOffAt.getTime()) {
+      return true;
+    }
+    return false;
+  }
+
+  join(userId: string): void {
+    const id = requiredTrimmed(userId, "userId");
+    if (this.entryOf(id)) return;
+    this.entriesValue = [...this.entriesValue, PoolEntry.member(id)];
+    this.updatedAtValue = new Date();
+  }
+
+  submitPick(userId: string, pick: PoolPickInput, now = new Date()): void {
+    if (this.isLocked(now)) {
+      throw new PoolLockedError();
+    }
+    const id = requiredTrimmed(userId, "userId");
+    this.join(id);
+    const entry = this.entryOf(id);
+    if (!entry) {
+      throw new DomainError("userId is required");
+    }
+    entry.applyPick(pick, now);
+    this.updatedAtValue = now;
+  }
+
+  recordResult(
+    userId: string,
+    result: PredictionResult,
+    now = new Date(),
+  ): void {
+    const id = requiredTrimmed(userId, "userId");
+    const entry = this.entryOf(id);
+    if (!entry?.role.isOwner) {
+      throw new PoolForbiddenError();
+    }
+    this.resultValue = result;
+    this.lockedAtValue = now;
+    this.updatedAtValue = now;
+  }
+
+  toSnapshot(): PredictionPoolSnapshot {
+    return {
+      id: this.id,
+      fixtureSlug: this.fixtureSlug.value,
+      title: this.title?.value ?? null,
+      inviteCode: this.inviteCode.value,
+      createdByUserId: this.createdByUserId,
+      kicksOffAt: this.kicksOffAt?.toISOString() ?? null,
+      lockedAt: this.lockedAtValue?.toISOString() ?? null,
+      result: this.resultValue
+        ? {
+            homeScore: this.resultValue.homeScore,
+            awayScore: this.resultValue.awayScore,
+            winner: this.resultValue.winner.value,
+          }
+        : null,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+      entries: this.entriesValue.map((entry) => entry.toSnapshot()),
+    };
+  }
+}

--- a/src/modules/pools/entities/prediction-score.ts
+++ b/src/modules/pools/entities/prediction-score.ts
@@ -1,0 +1,26 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const PREDICTION_SCORE_MAX = 200;
+
+export function parsePredictionScore(
+  raw: unknown,
+  field: "homeScore" | "awayScore",
+): number {
+  if (typeof raw !== "number" || !Number.isInteger(raw)) {
+    throw new DomainError(`${field} must be an integer`);
+  }
+  if (raw < 0 || raw > PREDICTION_SCORE_MAX) {
+    throw new DomainError(
+      `${field} must be between 0 and ${PREDICTION_SCORE_MAX}`,
+    );
+  }
+  return raw;
+}
+
+export function parseOptionalPredictionScore(
+  raw: unknown,
+  field: "homeScore" | "awayScore",
+): number | null {
+  if (raw == null) return null;
+  return parsePredictionScore(raw, field);
+}

--- a/src/modules/pools/entities/prediction-winner.ts
+++ b/src/modules/pools/entities/prediction-winner.ts
@@ -1,0 +1,33 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export type PredictionWinnerValue = "home" | "away" | "draw";
+
+export class PredictionWinner {
+  static readonly HOME = new PredictionWinner("home");
+  static readonly AWAY = new PredictionWinner("away");
+  static readonly DRAW = new PredictionWinner("draw");
+
+  private constructor(readonly value: PredictionWinnerValue) {}
+
+  static from(raw: unknown): PredictionWinner {
+    if (raw === "home") return PredictionWinner.HOME;
+    if (raw === "away") return PredictionWinner.AWAY;
+    if (raw === "draw") return PredictionWinner.DRAW;
+    throw new DomainError("winner must be home, away, or draw");
+  }
+
+  static fromOptional(raw: unknown): PredictionWinner | null {
+    if (raw == null || raw === "") return null;
+    return PredictionWinner.from(raw);
+  }
+
+  static fromScores(homeScore: number, awayScore: number): PredictionWinner {
+    if (homeScore > awayScore) return PredictionWinner.HOME;
+    if (awayScore > homeScore) return PredictionWinner.AWAY;
+    return PredictionWinner.DRAW;
+  }
+
+  equals(other: PredictionWinner): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/pools/index.ts
+++ b/src/modules/pools/index.ts
@@ -1,0 +1,86 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { FriendProfileLookup } from "../friends/repositories/friendship.repository";
+import { createPoolsController } from "./controllers/pools.controller";
+import { PoolRepository } from "./repositories/pool.repository";
+import { PrismaPoolRepository } from "./repositories/prisma-pool.repository";
+import { createPoolsRoutes } from "./routes/pools.routes";
+import {
+  CreatePool,
+  GetPool,
+  GetPoolStandings,
+  JoinPool,
+  RecordPoolResult,
+  SubmitPoolPick,
+} from "./services/pools.service";
+
+export type CreatePoolsModuleParams = {
+  prisma: PrismaClient;
+  poolRepository?: PoolRepository;
+  friendProfileLookup: FriendProfileLookup;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type PoolsModule = {
+  router: Router;
+  poolRepository: PoolRepository;
+};
+
+export function createPoolsModule({
+  prisma,
+  poolRepository: poolRepositoryOverride,
+  friendProfileLookup,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreatePoolsModuleParams): PoolsModule {
+  const poolRepository =
+    poolRepositoryOverride ?? new PrismaPoolRepository(prisma);
+
+  const controller = createPoolsController({
+    createPool: new CreatePool(poolRepository, friendProfileLookup),
+    getPool: new GetPool(poolRepository, friendProfileLookup),
+    joinPool: new JoinPool(poolRepository, friendProfileLookup),
+    submitPoolPick: new SubmitPoolPick(poolRepository, friendProfileLookup),
+    recordPoolResult: new RecordPoolResult(poolRepository, friendProfileLookup),
+    getPoolStandings: new GetPoolStandings(poolRepository, friendProfileLookup),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createPoolsRoutes(controller, { requireAuth }),
+    poolRepository,
+  };
+}
+
+export { createPoolsController } from "./controllers/pools.controller";
+export { InMemoryPoolRepository } from "./repositories/in-memory-pool.repository";
+export { PrismaPoolRepository } from "./repositories/prisma-pool.repository";
+export type { PoolRepository } from "./repositories/pool.repository";
+export { PredictionPool } from "./entities/prediction-pool";
+export { FixtureSlug, FIXTURE_SLUG_MAX_LENGTH } from "./entities/fixture-slug";
+export { InviteCode } from "./entities/invite-code";
+export { PoolTitle } from "./entities/pool-title";
+export { PoolNotFoundError } from "./entities/pool-not-found-error";
+export { PoolLockedError } from "./entities/pool-locked-error";
+export { PoolForbiddenError } from "./entities/pool-forbidden-error";
+export { PoolPersistenceError } from "./entities/pool-persistence-error";
+export {
+  CreatePool,
+  GetPool,
+  GetPoolStandings,
+  JoinPool,
+  RecordPoolResult,
+  SubmitPoolPick,
+} from "./services/pools.service";
+export type {
+  PublicPool,
+  PublicPoolMember,
+  PublicStanding,
+} from "./services/pools.service";

--- a/src/modules/pools/repositories/in-memory-pool.repository.ts
+++ b/src/modules/pools/repositories/in-memory-pool.repository.ts
@@ -1,0 +1,55 @@
+import { PredictionPool } from "../entities/prediction-pool";
+import { PoolPersistenceError } from "../entities/pool-persistence-error";
+import { PoolRepository } from "./pool.repository";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class InMemoryPoolRepository implements PoolRepository {
+  private readonly byId = new Map<string, PredictionPool>();
+  private readonly byCode = new Map<string, string>();
+
+  async findById(id: string): Promise<PredictionPool | null> {
+    return clone(this.byId.get(id) ?? null);
+  }
+
+  async findByInviteCode(inviteCode: string): Promise<PredictionPool | null> {
+    const id = this.byCode.get(inviteCode.toLowerCase());
+    if (!id) return null;
+    return this.findById(id);
+  }
+
+  async findByIdOrCode(idOrCode: string): Promise<PredictionPool | null> {
+    const trimmed = idOrCode.trim();
+    if (!trimmed) return null;
+    if (UUID_PATTERN.test(trimmed)) {
+      return (await this.findById(trimmed)) ?? this.findByInviteCode(trimmed);
+    }
+    return this.findByInviteCode(trimmed);
+  }
+
+  async create(pool: PredictionPool): Promise<PredictionPool> {
+    const stored = clone(pool)!;
+    if (this.byCode.has(stored.inviteCode.value)) {
+      throw new PoolPersistenceError("Invite code already in use");
+    }
+    this.byId.set(stored.id, stored);
+    this.byCode.set(stored.inviteCode.value, stored.id);
+    return clone(stored)!;
+  }
+
+  async persist(pool: PredictionPool): Promise<PredictionPool> {
+    if (!this.byId.has(pool.id)) {
+      throw new PoolPersistenceError("Unable to save prediction pool");
+    }
+    const stored = clone(pool)!;
+    this.byId.set(stored.id, stored);
+    this.byCode.set(stored.inviteCode.value, stored.id);
+    return clone(stored)!;
+  }
+}
+
+function clone(pool: PredictionPool | null): PredictionPool | null {
+  if (!pool) return null;
+  return PredictionPool.fromSnapshot(pool.toSnapshot());
+}

--- a/src/modules/pools/repositories/pool.repository.ts
+++ b/src/modules/pools/repositories/pool.repository.ts
@@ -1,0 +1,9 @@
+import { PredictionPool } from "../entities/prediction-pool";
+
+export interface PoolRepository {
+  findById(id: string): Promise<PredictionPool | null>;
+  findByInviteCode(inviteCode: string): Promise<PredictionPool | null>;
+  findByIdOrCode(idOrCode: string): Promise<PredictionPool | null>;
+  create(pool: PredictionPool): Promise<PredictionPool>;
+  persist(pool: PredictionPool): Promise<PredictionPool>;
+}

--- a/src/modules/pools/repositories/prisma-pool.repository.ts
+++ b/src/modules/pools/repositories/prisma-pool.repository.ts
@@ -1,0 +1,224 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { FixtureSlug } from "../entities/fixture-slug";
+import { InviteCode } from "../entities/invite-code";
+import { PoolEntry } from "../entities/pool-entry";
+import { PoolMemberRole } from "../entities/pool-member-role";
+import { PoolPersistenceError } from "../entities/pool-persistence-error";
+import { PoolTitle } from "../entities/pool-title";
+import { PredictionPool } from "../entities/prediction-pool";
+import { PredictionWinner } from "../entities/prediction-winner";
+import { PoolRepository } from "./pool.repository";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type EntryRow = {
+  id: string;
+  userId: string;
+  role: "owner" | "member";
+  tip: string | null;
+  homeScore: number | null;
+  awayScore: number | null;
+  winner: "home" | "away" | "draw" | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type PoolRow = {
+  id: string;
+  fixtureSlug: string;
+  title: string | null;
+  inviteCode: string;
+  createdByUserId: string;
+  kicksOffAt: Date | null;
+  lockedAt: Date | null;
+  resultHomeScore: number | null;
+  resultAwayScore: number | null;
+  resultWinner: "home" | "away" | "draw" | null;
+  createdAt: Date;
+  updatedAt: Date;
+  entries: EntryRow[];
+};
+
+function toDomain(row: PoolRow): PredictionPool {
+  const result =
+    row.resultHomeScore != null &&
+    row.resultAwayScore != null &&
+    row.resultWinner
+      ? {
+          homeScore: row.resultHomeScore,
+          awayScore: row.resultAwayScore,
+          winner: PredictionWinner.from(row.resultWinner),
+        }
+      : null;
+
+  return PredictionPool.rehydrate({
+    id: row.id,
+    fixtureSlug: FixtureSlug.from(row.fixtureSlug),
+    title: PoolTitle.from(row.title),
+    inviteCode: InviteCode.from(row.inviteCode),
+    createdByUserId: row.createdByUserId,
+    kicksOffAt: row.kicksOffAt,
+    lockedAt: row.lockedAt,
+    result,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    entries: row.entries.map((entry) =>
+      PoolEntry.rehydrate({
+        id: entry.id,
+        userId: entry.userId,
+        role: PoolMemberRole.from(entry.role),
+        tip: entry.tip,
+        homeScore: entry.homeScore,
+        awayScore: entry.awayScore,
+        winner: PredictionWinner.fromOptional(entry.winner),
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+      }),
+    ),
+  });
+}
+
+export class PrismaPoolRepository implements PoolRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(id: string): Promise<PredictionPool | null> {
+    try {
+      const row = await this.prisma.predictionPool.findUnique({
+        where: { id },
+        include: { entries: { orderBy: { createdAt: "asc" } } },
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new PoolPersistenceError("Failed to load prediction pool", {
+        cause: error,
+      });
+    }
+  }
+
+  async findByInviteCode(inviteCode: string): Promise<PredictionPool | null> {
+    try {
+      const row = await this.prisma.predictionPool.findUnique({
+        where: { inviteCode },
+        include: { entries: { orderBy: { createdAt: "asc" } } },
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new PoolPersistenceError("Failed to load prediction pool", {
+        cause: error,
+      });
+    }
+  }
+
+  async findByIdOrCode(idOrCode: string): Promise<PredictionPool | null> {
+    const trimmed = idOrCode.trim();
+    if (!trimmed) return null;
+    if (UUID_PATTERN.test(trimmed)) {
+      return (await this.findById(trimmed)) ?? this.findByInviteCode(trimmed);
+    }
+    return this.findByInviteCode(trimmed);
+  }
+
+  async create(pool: PredictionPool): Promise<PredictionPool> {
+    const snapshot = pool.toSnapshot();
+    try {
+      const row = await this.prisma.predictionPool.create({
+        data: {
+          id: snapshot.id,
+          fixtureSlug: snapshot.fixtureSlug,
+          title: snapshot.title,
+          inviteCode: snapshot.inviteCode,
+          createdByUserId: snapshot.createdByUserId,
+          kicksOffAt: pool.kicksOffAt,
+          lockedAt: pool.lockedAt,
+          resultHomeScore: snapshot.result?.homeScore ?? null,
+          resultAwayScore: snapshot.result?.awayScore ?? null,
+          resultWinner: snapshot.result?.winner ?? null,
+          createdAt: pool.createdAt,
+          updatedAt: pool.updatedAt,
+          entries: {
+            create: snapshot.entries.map((entry) => ({
+              id: entry.id,
+              userId: entry.userId,
+              role: entry.role,
+              tip: entry.tip,
+              homeScore: entry.homeScore,
+              awayScore: entry.awayScore,
+              winner: entry.winner,
+              createdAt: new Date(entry.createdAt),
+              updatedAt: new Date(entry.updatedAt),
+            })),
+          },
+        },
+        include: { entries: { orderBy: { createdAt: "asc" } } },
+      });
+      return toDomain(row);
+    } catch (error) {
+      throw new PoolPersistenceError("Failed to create prediction pool", {
+        cause: error,
+      });
+    }
+  }
+
+  async persist(pool: PredictionPool): Promise<PredictionPool> {
+    const snapshot = pool.toSnapshot();
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.predictionPool.update({
+          where: { id: snapshot.id },
+          data: {
+            title: snapshot.title,
+            kicksOffAt: pool.kicksOffAt,
+            lockedAt: pool.lockedAt,
+            resultHomeScore: snapshot.result?.homeScore ?? null,
+            resultAwayScore: snapshot.result?.awayScore ?? null,
+            resultWinner: snapshot.result?.winner ?? null,
+            updatedAt: pool.updatedAt,
+          },
+        });
+
+        for (const entry of snapshot.entries) {
+          await tx.predictionPoolEntry.upsert({
+            where: {
+              poolId_userId: {
+                poolId: snapshot.id,
+                userId: entry.userId,
+              },
+            },
+            create: {
+              id: entry.id,
+              poolId: snapshot.id,
+              userId: entry.userId,
+              role: entry.role,
+              tip: entry.tip,
+              homeScore: entry.homeScore,
+              awayScore: entry.awayScore,
+              winner: entry.winner,
+              createdAt: new Date(entry.createdAt),
+              updatedAt: new Date(entry.updatedAt),
+            },
+            update: {
+              role: entry.role,
+              tip: entry.tip,
+              homeScore: entry.homeScore,
+              awayScore: entry.awayScore,
+              winner: entry.winner,
+              updatedAt: new Date(entry.updatedAt),
+            },
+          });
+        }
+      });
+
+      const reloaded = await this.findById(snapshot.id);
+      if (!reloaded) {
+        throw new PoolPersistenceError("Failed to load prediction pool");
+      }
+      return reloaded;
+    } catch (error) {
+      if (error instanceof PoolPersistenceError) throw error;
+      throw new PoolPersistenceError("Failed to save prediction pool", {
+        cause: error,
+      });
+    }
+  }
+}

--- a/src/modules/pools/routes/pools.routes.ts
+++ b/src/modules/pools/routes/pools.routes.ts
@@ -1,0 +1,42 @@
+import { Router } from "express";
+
+import { createPoolsController } from "../controllers/pools.controller";
+
+export function createPoolsRoutes(
+  controller: ReturnType<typeof createPoolsController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.post("/api/pools", options.requireAuth, (req, res) => {
+    void controller.create(req, res);
+  });
+
+  router.get("/api/pools/:idOrCode", (req, res) => {
+    void controller.get(req, res);
+  });
+
+  router.post("/api/pools/:idOrCode/join", options.requireAuth, (req, res) => {
+    void controller.join(req, res);
+  });
+
+  router.post("/api/pools/:idOrCode/picks", options.requireAuth, (req, res) => {
+    void controller.pick(req, res);
+  });
+
+  router.post("/api/pools/:idOrCode/result", options.requireAuth, (req, res) => {
+    void controller.result(req, res);
+  });
+
+  router.get("/api/pools/:idOrCode/standings", (req, res) => {
+    void controller.standings(req, res);
+  });
+
+  return router;
+}

--- a/src/modules/pools/services/pools.service.test.ts
+++ b/src/modules/pools/services/pools.service.test.ts
@@ -1,0 +1,197 @@
+import { DomainError } from "../../../lib/domain-error";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { PoolForbiddenError } from "../entities/pool-forbidden-error";
+import { PoolLockedError } from "../entities/pool-locked-error";
+import { PoolNotFoundError } from "../entities/pool-not-found-error";
+import { InMemoryPoolRepository } from "../repositories/in-memory-pool.repository";
+import {
+  CreatePool,
+  GetPool,
+  GetPoolStandings,
+  JoinPool,
+  RecordPoolResult,
+  SubmitPoolPick,
+} from "./pools.service";
+
+const SLUG = "springboks-vs-all-blacks-2026-09-06";
+
+describe("prediction pool services", () => {
+  function setup() {
+    const pools = new InMemoryPoolRepository();
+    const profiles = new InMemoryFriendProfileLookup();
+    profiles.seed({
+      userId: "user-a",
+      displayName: "Alex",
+      handle: "alex",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-b",
+      displayName: "Blake",
+      handle: "blake",
+      avatarUrl: null,
+    });
+    return {
+      pools,
+      create: new CreatePool(pools, profiles),
+      get: new GetPool(pools, profiles),
+      join: new JoinPool(pools, profiles),
+      pick: new SubmitPoolPick(pools, profiles),
+      result: new RecordPoolResult(pools, profiles),
+      standings: new GetPoolStandings(pools, profiles),
+    };
+  }
+
+  test("create persists a fixture-scoped pool with an invite code", async () => {
+    const { create } = setup();
+    const { pool } = await create.execute({
+      userId: "user-a",
+      fixtureSlug: SLUG,
+      title: "  Boks tips  ",
+    });
+
+    expect(pool).toMatchObject({
+      fixtureSlug: SLUG,
+      title: "Boks tips",
+      createdByUserId: "user-a",
+      memberCount: 1,
+      joined: true,
+      role: "owner",
+      locked: false,
+      result: null,
+    });
+    expect(pool.inviteCode).toMatch(/^[a-z0-9]{8}$/);
+    expect(pool.members[0]).toMatchObject({
+      id: "user-a",
+      handle: "alex",
+      role: "owner",
+    });
+  });
+
+  test("create rejects invalid slugs and blank userId", async () => {
+    const { create } = setup();
+    await expect(
+      create.execute({ userId: "  ", fixtureSlug: SLUG }),
+    ).rejects.toBeInstanceOf(DomainError);
+    await expect(
+      create.execute({ userId: "user-a", fixtureSlug: "Springboks" }),
+    ).rejects.toBeInstanceOf(DomainError);
+  });
+
+  test("get is public and join/picks use the session user only", async () => {
+    const { create, get, join, pick } = setup();
+    const created = await create.execute({
+      userId: "user-a",
+      fixtureSlug: SLUG,
+    });
+
+    const guest = await get.execute({
+      idOrCode: created.pool.inviteCode,
+    });
+    expect(guest.pool.joined).toBe(false);
+    expect(guest.pool.role).toBeNull();
+    expect(guest.pool.inviteCode).toBe(created.pool.inviteCode);
+
+    const byId = await get.execute({
+      idOrCode: created.pool.id,
+      userId: "user-a",
+    });
+    expect(byId.pool.joined).toBe(true);
+
+    const joined = await join.execute({
+      userId: "user-b",
+      idOrCode: created.pool.inviteCode,
+    });
+    expect(joined.pool.memberCount).toBe(2);
+    expect(joined.pool.role).toBe("member");
+
+    const picked = await pick.execute({
+      userId: "user-b",
+      idOrCode: created.pool.inviteCode,
+      homeScore: 27,
+      awayScore: 20,
+    });
+    expect(picked.pool.myPick).toEqual({
+      tip: null,
+      homeScore: 27,
+      awayScore: 20,
+      winner: "home",
+    });
+  });
+
+  test("standings stay identity until a result is recorded", async () => {
+    const { create, pick, result, standings } = setup();
+    const created = await create.execute({
+      userId: "user-a",
+      fixtureSlug: SLUG,
+    });
+    await pick.execute({
+      userId: "user-a",
+      idOrCode: created.pool.id,
+      winner: "home",
+    });
+    await pick.execute({
+      userId: "user-b",
+      idOrCode: created.pool.inviteCode,
+      homeScore: 24,
+      awayScore: 17,
+    });
+
+    const before = await standings.execute({ idOrCode: created.pool.inviteCode });
+    expect(before.result).toBeNull();
+    expect(before.standings).toHaveLength(2);
+    expect(before.standings.every((row) => row.points === 0 && row.rank === 1)).toBe(
+      true,
+    );
+
+    await result.execute({
+      userId: "user-a",
+      idOrCode: created.pool.id,
+      homeScore: 24,
+      awayScore: 17,
+    });
+
+    const after = await standings.execute({ idOrCode: created.pool.inviteCode });
+    expect(after.result).toEqual({
+      homeScore: 24,
+      awayScore: 17,
+      winner: "home",
+    });
+    const blake = after.standings.find((row) => row.handle === "blake");
+    const alex = after.standings.find((row) => row.handle === "alex");
+    expect(blake?.points).toBe(3);
+    expect(alex?.points).toBe(1);
+    expect(blake?.rank).toBe(1);
+    expect(alex?.rank).toBe(2);
+  });
+
+  test("picks lock at kickoff and unknown pools 404", async () => {
+    const { create, pick, get, result } = setup();
+    const created = await create.execute({
+      userId: "user-a",
+      fixtureSlug: SLUG,
+      kicksOffAt: "2020-01-01T12:00:00.000Z",
+    });
+
+    await expect(
+      pick.execute({
+        userId: "user-b",
+        idOrCode: created.pool.inviteCode,
+        winner: "away",
+      }),
+    ).rejects.toBeInstanceOf(PoolLockedError);
+
+    await expect(
+      get.execute({ idOrCode: "zzzzzzzz" }),
+    ).rejects.toBeInstanceOf(PoolNotFoundError);
+
+    await expect(
+      result.execute({
+        userId: "user-b",
+        idOrCode: created.pool.id,
+        homeScore: 1,
+        awayScore: 0,
+      }),
+    ).rejects.toBeInstanceOf(PoolForbiddenError);
+  });
+});

--- a/src/modules/pools/services/pools.service.ts
+++ b/src/modules/pools/services/pools.service.ts
@@ -1,0 +1,366 @@
+import { DomainError } from "../../../lib/domain-error";
+import {
+  FriendProfile,
+  FriendProfileLookup,
+} from "../../friends/repositories/friendship.repository";
+import { FixtureSlug } from "../entities/fixture-slug";
+import { PoolNotFoundError } from "../entities/pool-not-found-error";
+import { PoolTitle } from "../entities/pool-title";
+import {
+  parsePoolPick,
+  parsePoolResult,
+  PredictionPool,
+} from "../entities/prediction-pool";
+import { PoolRepository } from "../repositories/pool.repository";
+
+export type PublicPoolPick = {
+  tip: string | null;
+  homeScore: number | null;
+  awayScore: number | null;
+  winner: "home" | "away" | "draw" | null;
+};
+
+export type PublicPoolMember = {
+  id: string;
+  displayName: string;
+  handle: string;
+  avatarUrl: string | null;
+  role: "owner" | "member";
+  joinedAt: string;
+  pick: PublicPoolPick | null;
+};
+
+export type PublicPoolResult = {
+  homeScore: number;
+  awayScore: number;
+  winner: "home" | "away" | "draw";
+};
+
+export type PublicPool = {
+  id: string;
+  fixtureSlug: string;
+  title: string | null;
+  inviteCode: string;
+  createdByUserId: string;
+  kicksOffAt: string | null;
+  lockedAt: string | null;
+  locked: boolean;
+  result: PublicPoolResult | null;
+  memberCount: number;
+  joined: boolean;
+  role: "owner" | "member" | null;
+  myPick: PublicPoolPick | null;
+  createdAt: string;
+  members: PublicPoolMember[];
+};
+
+export type PublicStanding = {
+  userId: string;
+  displayName: string;
+  handle: string;
+  avatarUrl: string | null;
+  points: number;
+  rank: number;
+  pick: PublicPoolPick | null;
+};
+
+function requireUserId(userId: string): string {
+  const id = userId.trim();
+  if (!id) throw new DomainError("userId is required");
+  return id;
+}
+
+function toPublicPick(entry: {
+  tip: string | null;
+  homeScore: number | null;
+  awayScore: number | null;
+  winner: "home" | "away" | "draw" | null;
+}): PublicPoolPick | null {
+  if (
+    entry.tip == null &&
+    entry.homeScore == null &&
+    entry.awayScore == null &&
+    entry.winner == null
+  ) {
+    return null;
+  }
+  return {
+    tip: entry.tip,
+    homeScore: entry.homeScore,
+    awayScore: entry.awayScore,
+    winner: entry.winner,
+  };
+}
+
+async function resolveProfile(
+  lookup: FriendProfileLookup,
+  userId: string,
+): Promise<FriendProfile> {
+  const profile = await lookup.findByUserId(userId);
+  if (profile) return profile;
+  return {
+    userId,
+    displayName: "Player",
+    handle: userId.slice(0, 8),
+    avatarUrl: null,
+  };
+}
+
+async function toPublicMembers(
+  lookup: FriendProfileLookup,
+  pool: PredictionPool,
+): Promise<PublicPoolMember[]> {
+  const out: PublicPoolMember[] = [];
+  for (const entry of pool.toSnapshot().entries) {
+    const profile = await resolveProfile(lookup, entry.userId);
+    out.push({
+      id: profile.userId,
+      displayName: profile.displayName,
+      handle: profile.handle,
+      avatarUrl: profile.avatarUrl,
+      role: entry.role,
+      joinedAt: entry.createdAt,
+      pick: toPublicPick(entry),
+    });
+  }
+  return out;
+}
+
+async function toPublicPool(
+  lookup: FriendProfileLookup,
+  pool: PredictionPool,
+  userId?: string | null,
+  now = new Date(),
+): Promise<PublicPool> {
+  const snapshot = pool.toSnapshot();
+  const membership = userId ? pool.entryOf(userId) : null;
+  return {
+    id: snapshot.id,
+    fixtureSlug: snapshot.fixtureSlug,
+    title: snapshot.title,
+    inviteCode: snapshot.inviteCode,
+    createdByUserId: snapshot.createdByUserId,
+    kicksOffAt: snapshot.kicksOffAt,
+    lockedAt: snapshot.lockedAt,
+    locked: pool.isLocked(now),
+    result: snapshot.result,
+    memberCount: pool.memberCount,
+    joined: membership != null,
+    role: membership?.role.value ?? null,
+    myPick: membership ? toPublicPick(membership.toSnapshot()) : null,
+    createdAt: snapshot.createdAt,
+    members: await toPublicMembers(lookup, pool),
+  };
+}
+
+function scorePick(
+  pick: PublicPoolPick | null,
+  result: PublicPoolResult,
+): number {
+  if (!pick) return 0;
+  if (
+    pick.homeScore != null &&
+    pick.awayScore != null &&
+    pick.homeScore === result.homeScore &&
+    pick.awayScore === result.awayScore
+  ) {
+    return 3;
+  }
+  if (pick.winner && pick.winner === result.winner) {
+    return 1;
+  }
+  return 0;
+}
+
+export class CreatePool {
+  constructor(
+    private readonly pools: PoolRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    fixtureSlug: unknown;
+    title?: unknown;
+    kicksOffAt?: unknown;
+  }): Promise<{ pool: PublicPool }> {
+    const userId = requireUserId(input.userId);
+    const pool = PredictionPool.create({
+      fixtureSlug: FixtureSlug.from(input.fixtureSlug),
+      title: PoolTitle.from(input.title),
+      createdByUserId: userId,
+      kicksOffAt: PredictionPool.parseKicksOffAt(input.kicksOffAt),
+    });
+    const saved = await this.pools.create(pool);
+    return { pool: await toPublicPool(this.profiles, saved, userId) };
+  }
+}
+
+export class GetPool {
+  constructor(
+    private readonly pools: PoolRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    idOrCode: string;
+    userId?: string | null;
+  }): Promise<{ pool: PublicPool }> {
+    const idOrCode = input.idOrCode.trim();
+    if (!idOrCode) throw new DomainError("pool id or invite code is required");
+
+    const pool = await this.pools.findByIdOrCode(idOrCode);
+    if (!pool) throw new PoolNotFoundError();
+
+    return { pool: await toPublicPool(this.profiles, pool, input.userId) };
+  }
+}
+
+export class JoinPool {
+  constructor(
+    private readonly pools: PoolRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    idOrCode: string;
+  }): Promise<{ pool: PublicPool }> {
+    const userId = requireUserId(input.userId);
+    const idOrCode = input.idOrCode.trim();
+    if (!idOrCode) throw new DomainError("pool id or invite code is required");
+
+    const pool = await this.pools.findByIdOrCode(idOrCode);
+    if (!pool) throw new PoolNotFoundError();
+
+    pool.join(userId);
+    const saved = await this.pools.persist(pool);
+    return { pool: await toPublicPool(this.profiles, saved, userId) };
+  }
+}
+
+export class SubmitPoolPick {
+  constructor(
+    private readonly pools: PoolRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    idOrCode: string;
+    tip?: unknown;
+    homeScore?: unknown;
+    awayScore?: unknown;
+    winner?: unknown;
+  }): Promise<{ pool: PublicPool }> {
+    const userId = requireUserId(input.userId);
+    const idOrCode = input.idOrCode.trim();
+    if (!idOrCode) throw new DomainError("pool id or invite code is required");
+
+    const pool = await this.pools.findByIdOrCode(idOrCode);
+    if (!pool) throw new PoolNotFoundError();
+
+    pool.submitPick(
+      userId,
+      parsePoolPick({
+        tip: input.tip,
+        homeScore: input.homeScore,
+        awayScore: input.awayScore,
+        winner: input.winner,
+      }),
+    );
+    const saved = await this.pools.persist(pool);
+    return { pool: await toPublicPool(this.profiles, saved, userId) };
+  }
+}
+
+export class RecordPoolResult {
+  constructor(
+    private readonly pools: PoolRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    idOrCode: string;
+    homeScore: unknown;
+    awayScore: unknown;
+    winner?: unknown;
+  }): Promise<{ pool: PublicPool }> {
+    const userId = requireUserId(input.userId);
+    const idOrCode = input.idOrCode.trim();
+    if (!idOrCode) throw new DomainError("pool id or invite code is required");
+
+    const pool = await this.pools.findByIdOrCode(idOrCode);
+    if (!pool) throw new PoolNotFoundError();
+
+    pool.recordResult(
+      userId,
+      parsePoolResult({
+        homeScore: input.homeScore,
+        awayScore: input.awayScore,
+        winner: input.winner,
+      }),
+    );
+    const saved = await this.pools.persist(pool);
+    return { pool: await toPublicPool(this.profiles, saved, userId) };
+  }
+}
+
+export class GetPoolStandings {
+  constructor(
+    private readonly pools: PoolRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { idOrCode: string }): Promise<{
+    locked: boolean;
+    result: PublicPoolResult | null;
+    standings: PublicStanding[];
+  }> {
+    const idOrCode = input.idOrCode.trim();
+    if (!idOrCode) throw new DomainError("pool id or invite code is required");
+
+    const pool = await this.pools.findByIdOrCode(idOrCode);
+    if (!pool) throw new PoolNotFoundError();
+
+    const snapshot = pool.toSnapshot();
+    const rows: PublicStanding[] = [];
+    for (const entry of snapshot.entries) {
+      const profile = await resolveProfile(this.profiles, entry.userId);
+      const pick = toPublicPick(entry);
+      rows.push({
+        userId: profile.userId,
+        displayName: profile.displayName,
+        handle: profile.handle,
+        avatarUrl: profile.avatarUrl,
+        points: snapshot.result ? scorePick(pick, snapshot.result) : 0,
+        rank: 1,
+        pick,
+      });
+    }
+
+    if (snapshot.result) {
+      rows.sort((a, b) => b.points - a.points || a.displayName.localeCompare(b.displayName));
+      let lastPoints = Number.POSITIVE_INFINITY;
+      let lastRank = 0;
+      rows.forEach((row, index) => {
+        if (row.points !== lastPoints) {
+          lastRank = index + 1;
+          lastPoints = row.points;
+        }
+        row.rank = lastRank;
+      });
+    }
+
+    return {
+      locked: pool.isLocked(),
+      result: snapshot.result,
+      standings: rows,
+    };
+  }
+}
+
+export { PoolNotFoundError } from "../entities/pool-not-found-error";
+export { PoolLockedError } from "../entities/pool-locked-error";
+export { PoolForbiddenError } from "../entities/pool-forbidden-error";


### PR DESCRIPTION
## Why

[landing-page#117](https://github.com/leaguesports/landing-page/issues/117) needs a public create/join API so WhatsApp Watch can share a fixture tip pool. This is the API slice for [landing-page#108](https://github.com/leaguesports/landing-page/issues/108) under broadcasts north star [#105](https://github.com/leaguesports/landing-page/issues/105).

Friends / invite-link v1 only. No money, wallets, or season fantasy.

## Contract

Session cookie `token`. `userId` is taken from the session only — body `userId` is ignored.

| Method | Path | Auth | Body | Response |
| --- | --- | --- | --- | --- |
| `POST` | `/api/pools` | required | `{ fixtureSlug, title?, kicksOffAt? }` | `201 { pool }` |
| `GET` | `/api/pools/:idOrCode` | optional | — | `200 { pool }` (guests may view) |
| `POST` | `/api/pools/:idOrCode/join` | required | — | `200 { pool }` |
| `POST` | `/api/pools/:idOrCode/picks` | required | `{ tip?, homeScore?, awayScore?, winner? }` | `200 { pool }` |
| `GET` | `/api/pools/:idOrCode/standings` | public | — | `{ locked, result, standings }` |
| `POST` | `/api/pools/:idOrCode/result` | owner | `{ homeScore, awayScore, winner? }` | `200 { pool }` |

`idOrCode` is the pool UUID **or** the 8-char lowercase invite code.

`pool` shape:

```json
{
  "id": "uuid",
  "fixtureSlug": "springboks-vs-all-blacks-2026-09-06",
  "title": "Boks tips",
  "inviteCode": "ab12cd34",
  "createdByUserId": "…",
  "kicksOffAt": "2026-09-06T15:00:00.000Z",
  "lockedAt": null,
  "locked": false,
  "result": null,
  "memberCount": 1,
  "joined": true,
  "role": "owner",
  "myPick": null,
  "createdAt": "…",
  "members": [{ "id", "displayName", "handle", "avatarUrl", "role", "joinedAt", "pick" }]
}
```

### Validation
- `fixtureSlug`: lowercase `[a-z0-9-]+`, max 80 (same rule as fixture follow).
- `title`: optional, max 80.
- `winner`: `home` \| `away` \| `draw`. Derived from scores when omitted.
- Scores: integers 0–200. Pick must include tip, score, or winner.
- Create auto-joins the session user as owner. Submit pick auto-joins if needed.

### Lock cutoff
Tips lock at `kicksOffAt` (kickoff) when provided. Recording a result also locks. If neither exists, picks stay open until the owner records a result. Locked picks return `409`.

### Standings
Until a result is recorded, standings are identity (every member `points: 0`, `rank: 1`). After result: exact score = 3, correct winner = 1.

## Notes
- Prisma migration `20260906120000_prediction_pool` is included. **Do not migrate/deploy Railway from this PR.**
- Does not change fixture-follow (#24) or training enroll (#28).
- Landing UI will consume this contract and soft-fail on API 404 until this is deployed.

Closes nothing yet — landing PR follows.