### PR TITLE
Capture finished padel match + golf round (one-shot lock)

### DIFF
--- a/src/modules/golf-round/controllers/golf-round.controller.ts
+++ b/src/modules/golf-round/controllers/golf-round.controller.ts
@@ -5,6 +5,7 @@ import { DomainError } from "../../../lib/domain-error";
 import { GolfRoundLockConflictError } from "../entities/golf-round-lock-conflict-error";
 import { GolfRoundPersistenceError } from "../entities/golf-round-persistence-error";
 import { GolfRoundVenueNotFoundError } from "../entities/golf-round-venue-not-found-error";
+import { CaptureFinishedGolfRound } from "../services/capture-finished-golf-round.service";
 import { CreateGolfRound } from "../services/create-golf-round.service";
 import { GetGolfRoundById } from "../services/get-golf-round-by-id.service";
 import {
@@ -13,6 +14,7 @@ import {
 } from "../services/list-locked-golf-rounds.service";
 import { LockGolfRound } from "../services/lock-golf-round.service";
 import { sanitizePlayersForCreate } from "../utils/bind-session-user";
+import { resolvePlayedAt } from "../utils/played-at";
 
 const playerSchema = z.object({
   slot: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
@@ -63,8 +65,24 @@ const lockGolfRoundBodySchema = z.object({
   }),
 });
 
+const captureGolfRoundBodySchema = z.object({
+  venueCmsId: z.string(),
+  startsAt: z.string().optional(),
+  playedAt: z.string().optional(),
+  holesPlayed: z.union([z.literal(9), z.literal(18)]),
+  startingHole: z.number().optional(),
+  teeName: z.string().nullable().optional(),
+  course: z.object({
+    name: z.string().nullable().optional(),
+    holes: z.array(courseHoleSchema).min(1),
+  }),
+  players: z.array(playerSchema).min(1).max(4),
+  score: lockGolfRoundBodySchema.shape.score,
+});
+
 export function createGolfRoundController(deps: {
   createGolfRound: CreateGolfRound;
+  captureFinishedGolfRound: CaptureFinishedGolfRound;
   getGolfRoundById: GetGolfRoundById;
   lockGolfRound: LockGolfRound;
   listLockedGolfRoundsByPlayer: ListLockedGolfRoundsByPlayer;
@@ -78,6 +96,44 @@ export function createGolfRoundController(deps: {
         const sessionUserId = deps.tryGetSessionUserId(req);
         const players = sanitizePlayersForCreate(body.players, sessionUserId);
         const round = await deps.createGolfRound.execute({ ...body, players });
+        return res.status(201).json(round.toSnapshot());
+      } catch (error) {
+        return sendGolfRoundError(res, error);
+      }
+    },
+
+    async capture(req: Request, res: Response) {
+      try {
+        const sessionUserId = deps.tryGetSessionUserId(req);
+        if (!sessionUserId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const body = z.parse(captureGolfRoundBodySchema, req.body ?? {});
+        const startsAt = resolvePlayedAt(body);
+        if (!startsAt) {
+          return res.status(400).json({ error: "startsAt or playedAt is required" });
+        }
+
+        const players = sanitizePlayersForCreate(body.players, sessionUserId);
+        if (!players.some((player) => player.userId === sessionUserId)) {
+          return res.status(403).json({
+            error: "Only a seated player can capture this golf round",
+          });
+        }
+
+        const round = await deps.captureFinishedGolfRound.execute({
+          venueCmsId: body.venueCmsId,
+          startsAt,
+          holesPlayed: body.holesPlayed,
+          startingHole: body.startingHole,
+          teeName: body.teeName,
+          course: body.course,
+          players,
+          score: body.score,
+          lockedByUserId: sessionUserId,
+        });
+
         return res.status(201).json(round.toSnapshot());
       } catch (error) {
         return sendGolfRoundError(res, error);

--- a/src/modules/golf-round/controllers/golf-rounds.http.test.ts
+++ b/src/modules/golf-round/controllers/golf-rounds.http.test.ts
@@ -220,6 +220,113 @@ describe("golf rounds HTTP", () => {
     expect(items.map((item) => item.id)).toEqual([createdBody.id]);
   });
 
+  test("POST /api/golf-rounds/capture writes a locked round from one payload", async () => {
+    const captured = await fetch(`${server.url}/api/golf-rounds/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        venueCmsId: "sanity-course-1",
+        playedAt: "2026-09-04T10:00:00.000Z",
+        holesPlayed: 9,
+        startingHole: 1,
+        teeName: "White",
+        course: { name: "Links Nine", holes: courseHoles9 },
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+          { slot: 3, displayName: "Riley", isGuest: false, userId: null },
+        ],
+        score: scoreA,
+      }),
+    });
+    const capturedBody = (await captured.json()) as {
+      id: string;
+      status: string;
+      score: unknown;
+      startsAt: string;
+    };
+
+    expect(captured.status).toBe(201);
+    expect(capturedBody.status).toBe("locked");
+    expect(capturedBody.score).toEqual(scoreA);
+    expect(capturedBody.startsAt).toBe("2026-09-04T10:00:00.000Z");
+
+    const history = await fetch(
+      `${server.url}/api/golf-rounds?playerUserId=user-riley`,
+    );
+    const items = (await history.json()) as { id: string }[];
+    expect(items.map((item) => item.id)).toEqual([capturedBody.id]);
+  });
+
+  test("POST /api/golf-rounds/capture requires a seated session player", async () => {
+    const unauth = await fetch(`${server.url}/api/golf-rounds/capture`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...createBody,
+        score: scoreA,
+      }),
+    });
+    expect(unauth.status).toBe(401);
+
+    const guestsOnly = await fetch(`${server.url}/api/golf-rounds/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+        ],
+        score: scoreForPlayers([1, 2, 3, 4, 5, 6, 7, 8, 9], [1, 2], 4),
+      }),
+    });
+    expect(guestsOnly.status).toBe(403);
+
+    const missingVenue = await fetch(`${server.url}/api/golf-rounds/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        venueCmsId: "no-such-course",
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+          { slot: 3, displayName: "Riley", isGuest: false, userId: null },
+        ],
+        score: scoreA,
+      }),
+    });
+    expect(missingVenue.status).toBe(404);
+
+    const badScore = await fetch(`${server.url}/api/golf-rounds/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+          { slot: 3, displayName: "Riley", isGuest: false, userId: null },
+        ],
+        score: scoreForPlayers([1, 2], [1, 2, 3], 4),
+      }),
+    });
+    expect(badScore.status).toBe(400);
+  });
+
   test("GET missing golf round is 404", async () => {
     const response = await fetch(`${server.url}/api/golf-rounds/missing`);
     expect(response.status).toBe(404);

--- a/src/modules/golf-round/entities/golf-round.test.ts
+++ b/src/modules/golf-round/entities/golf-round.test.ts
@@ -1,0 +1,45 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { GolfRound } from "./golf-round";
+import { StartsAt } from "./starts-at";
+
+const courseHoles9 = Array.from({ length: 9 }, (_, index) => ({
+  number: index + 1,
+  par: ((index % 3) + 3) as 3 | 4 | 5,
+  strokeIndex: index + 1,
+}));
+
+const score = {
+  holes: courseHoles9.map((hole) => ({
+    number: hole.number,
+    strokes: { "1": 4, "2": 5 },
+  })),
+};
+
+describe(GolfRound, () => {
+  test("captureFinished creates a locked round without a live session", () => {
+    const lockedAt = new Date("2026-09-04T12:00:00.000Z");
+    const round = GolfRound.captureFinished({
+      venueCmsId: CmsId.from("sanity-course-1"),
+      startsAt: StartsAt.from("2026-09-04T10:00:00.000Z"),
+      holesPlayed: 9,
+      startingHole: 1,
+      teeName: "White",
+      course: { name: "Links Nine", holes: courseHoles9 },
+      players: [
+        { slot: 1, displayName: "Alex", isGuest: false, userId: "user-1" },
+        { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+      ],
+      score,
+      lockedByUserId: "user-1",
+      lockedAt,
+    });
+
+    expect(round.toSnapshot()).toMatchObject({
+      status: "locked",
+      lockedAt: "2026-09-04T12:00:00.000Z",
+      score,
+    });
+    expect(round.lockedByUserId).toBe("user-1");
+    expect(round.hasPlayerUserId("user-1")).toBe(true);
+  });
+});

--- a/src/modules/golf-round/entities/golf-round.ts
+++ b/src/modules/golf-round/entities/golf-round.ts
@@ -79,6 +79,22 @@ export class GolfRound {
     );
   }
 
+  static captureFinished(
+    props: CreateGolfRoundProps & {
+      score: unknown;
+      lockedByUserId: string;
+      lockedAt?: Date;
+    },
+  ): GolfRound {
+    const round = GolfRound.create(props);
+    const score = GolfScore.from(props.score, {
+      holeNumbers: round.course.holeNumbers(),
+      playerSlots: round.playerSlots(),
+    });
+    round.lock(score, props.lockedAt ?? new Date(), props.lockedByUserId);
+    return round;
+  }
+
   static rehydrate(props: {
     id: string;
     venueCmsId: CmsId;

--- a/src/modules/golf-round/index.ts
+++ b/src/modules/golf-round/index.ts
@@ -6,6 +6,7 @@ import { createGolfRoundController } from "./controllers/golf-round.controller";
 import { GolfRoundRepository } from "./repositories/golf-round.repository";
 import { PrismaGolfRoundRepository } from "./repositories/prisma-golf-round.repository";
 import { createGolfRoundRoutes } from "./routes/golf-round.routes";
+import { CaptureFinishedGolfRound } from "./services/capture-finished-golf-round.service";
 import { CreateGolfRound } from "./services/create-golf-round.service";
 import { GetGolfRoundById } from "./services/get-golf-round-by-id.service";
 import {
@@ -37,6 +38,10 @@ export function createGolfRoundModule({
 
   const controller = createGolfRoundController({
     createGolfRound: new CreateGolfRound(golfRoundRepository, venueRepository),
+    captureFinishedGolfRound: new CaptureFinishedGolfRound(
+      golfRoundRepository,
+      venueRepository,
+    ),
     getGolfRoundById: new GetGolfRoundById(golfRoundRepository),
     lockGolfRound: new LockGolfRound(golfRoundRepository),
     listLockedGolfRoundsByPlayer: new ListLockedGolfRoundsByPlayer(
@@ -61,6 +66,7 @@ export { GolfRound } from "./entities/golf-round";
 export { InMemoryGolfRoundRepository } from "./repositories/in-memory-golf-round.repository";
 export { PrismaGolfRoundRepository } from "./repositories/prisma-golf-round.repository";
 export type { GolfRoundRepository } from "./repositories/golf-round.repository";
+export { CaptureFinishedGolfRound } from "./services/capture-finished-golf-round.service";
 export { CreateGolfRound } from "./services/create-golf-round.service";
 export { GetGolfRoundById } from "./services/get-golf-round-by-id.service";
 export { LockGolfRound } from "./services/lock-golf-round.service";

--- a/src/modules/golf-round/repositories/prisma-golf-round.repository.ts
+++ b/src/modules/golf-round/repositories/prisma-golf-round.repository.ts
@@ -56,11 +56,14 @@ export class PrismaGolfRoundRepository implements GolfRoundRepository {
           id: snapshot.id,
           venueCmsId: snapshot.venueCmsId,
           startsAt: round.startsAt.value,
-          status: "live",
+          status: snapshot.status,
           holesPlayed: snapshot.holesPlayed,
           startingHole: snapshot.startingHole,
           teeName: snapshot.teeName,
           course: snapshot.course,
+          lockedAt: round.lockedAt,
+          lockedByUserId: round.lockedByUserId,
+          score: snapshot.score === null ? undefined : snapshot.score,
           players: {
             create: round.players.map((player) => ({
               slot: player.slot,

--- a/src/modules/golf-round/routes/golf-round.routes.ts
+++ b/src/modules/golf-round/routes/golf-round.routes.ts
@@ -11,6 +11,10 @@ export function createGolfRoundRoutes(
     void controller.create(req, res);
   });
 
+  router.post("/api/golf-rounds/capture", (req, res) => {
+    void controller.capture(req, res);
+  });
+
   router.get("/api/golf-rounds", (req, res) => {
     void controller.listByPlayer(req, res);
   });

--- a/src/modules/golf-round/services/capture-finished-golf-round.service.ts
+++ b/src/modules/golf-round/services/capture-finished-golf-round.service.ts
@@ -1,0 +1,49 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { GolfPlayerInput } from "../entities/golf-player";
+import { GolfRound } from "../entities/golf-round";
+import { GolfRoundVenueNotFoundError } from "../entities/golf-round-venue-not-found-error";
+import { StartsAt } from "../entities/starts-at";
+import { GolfRoundRepository } from "../repositories/golf-round.repository";
+
+export type CaptureFinishedGolfRoundInput = {
+  venueCmsId: string;
+  startsAt: unknown;
+  holesPlayed: unknown;
+  startingHole?: unknown;
+  teeName?: string | null;
+  course: unknown;
+  players: GolfPlayerInput[];
+  score: unknown;
+  lockedByUserId: string;
+};
+
+export class CaptureFinishedGolfRound {
+  constructor(
+    private readonly rounds: GolfRoundRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async execute(input: CaptureFinishedGolfRoundInput): Promise<GolfRound> {
+    const venueCmsId = CmsId.from(input.venueCmsId);
+    const venue = await this.venues.findByCmsId(venueCmsId);
+    if (!venue) {
+      throw new GolfRoundVenueNotFoundError();
+    }
+
+    const round = GolfRound.captureFinished({
+      venueCmsId,
+      startsAt: StartsAt.from(input.startsAt),
+      holesPlayed: input.holesPlayed as number,
+      startingHole:
+        input.startingHole === undefined ? 1 : (input.startingHole as number),
+      teeName: input.teeName,
+      course: input.course,
+      players: input.players,
+      score: input.score,
+      lockedByUserId: input.lockedByUserId,
+    });
+
+    return this.rounds.create(round);
+  }
+}

--- a/src/modules/golf-round/utils/played-at.ts
+++ b/src/modules/golf-round/utils/played-at.ts
@@ -1,0 +1,12 @@
+export function resolvePlayedAt(body: {
+  startsAt?: string;
+  playedAt?: string;
+}): string | undefined {
+  const startsAt = typeof body.startsAt === "string" ? body.startsAt.trim() : "";
+  if (startsAt.length > 0) {
+    return startsAt;
+  }
+
+  const playedAt = typeof body.playedAt === "string" ? body.playedAt.trim() : "";
+  return playedAt.length > 0 ? playedAt : undefined;
+}

--- a/src/modules/match/controllers/match.controller.ts
+++ b/src/modules/match/controllers/match.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { z } from "zod";
 
+import { CaptureFinishedMatch } from "../services/capture-finished-match.service";
 import { CreateMatch } from "../services/create-match.service";
 import { GetMatchById } from "../services/get-match-by-id.service";
 import {
@@ -13,6 +14,7 @@ import { MatchLockConflictError } from "../entities/match-lock-conflict-error";
 import { MatchVenueNotFoundError } from "../entities/match-venue-not-found-error";
 import { MatchPersistenceError } from "../entities/match-persistence-error";
 import { sanitizePairingsForCreate } from "../utils/bind-session-user";
+import { resolvePlayedAt } from "../utils/played-at";
 
 const playerSchema = z.object({
   userId: z.string().nullable().optional(),
@@ -65,8 +67,20 @@ const lockMatchBodySchema = z.object({
   winner: z.enum(["A", "B"]),
 });
 
+const captureMatchBodySchema = z.object({
+  venueCmsId: z.string(),
+  startsAt: z.string().optional(),
+  playedAt: z.string().optional(),
+  ruleset: z.enum(["golden_point", "advantage"]),
+  pairings: pairingsSchema,
+  servingTeam: z.enum(["A", "B"]).optional(),
+  score: lockMatchBodySchema.shape.score,
+  winner: lockMatchBodySchema.shape.winner,
+});
+
 export function createMatchController(deps: {
   createMatch: CreateMatch;
+  captureFinishedMatch: CaptureFinishedMatch;
   getMatchById: GetMatchById;
   lockMatch: LockMatch;
   listLockedMatchesByPlayer: ListLockedMatchesByPlayer;
@@ -80,6 +94,46 @@ export function createMatchController(deps: {
         const sessionUserId = deps.tryGetSessionUserId(req);
         const pairings = sanitizePairingsForCreate(body.pairings, sessionUserId);
         const match = await deps.createMatch.execute({ ...body, pairings });
+        return res.status(201).json(match.toSnapshot());
+      } catch (error) {
+        return sendMatchError(res, error);
+      }
+    },
+
+    async capture(req: Request, res: Response) {
+      try {
+        const sessionUserId = deps.tryGetSessionUserId(req);
+        if (!sessionUserId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const body = z.parse(captureMatchBodySchema, req.body ?? {});
+        const startsAt = resolvePlayedAt(body);
+        if (!startsAt) {
+          return res.status(400).json({ error: "startsAt or playedAt is required" });
+        }
+
+        const pairings = sanitizePairingsForCreate(body.pairings, sessionUserId);
+        const seated = [pairings.teamA[0], pairings.teamA[1], pairings.teamB[0], pairings.teamB[1]].some(
+          (player) => player.userId === sessionUserId,
+        );
+        if (!seated) {
+          return res.status(403).json({
+            error: "Only a seated player can capture this match",
+          });
+        }
+
+        const match = await deps.captureFinishedMatch.execute({
+          venueCmsId: body.venueCmsId,
+          startsAt,
+          ruleset: body.ruleset,
+          pairings,
+          servingTeam: body.servingTeam,
+          score: body.score,
+          winner: body.winner,
+          lockedByUserId: sessionUserId,
+        });
+
         return res.status(201).json(match.toSnapshot());
       } catch (error) {
         return sendMatchError(res, error);

--- a/src/modules/match/controllers/matches.http.test.ts
+++ b/src/modules/match/controllers/matches.http.test.ts
@@ -285,6 +285,133 @@ describe("matches HTTP", () => {
     ).toBe(true);
   });
 
+  test("POST /api/matches/capture writes a locked match from one payload", async () => {
+    const captured = await fetch(`${server.url}/api/matches/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        venueCmsId: "sanity-court-1",
+        playedAt: "2026-08-29T10:00:00.000Z",
+        ruleset: "golden_point",
+        pairings: {
+          teamA: pairings.teamA,
+          teamB: [
+            { displayName: "Jordan", isGuest: true, userId: null },
+            { displayName: "Riley", isGuest: false, userId: null },
+          ],
+        },
+        score: scoreA,
+        winner: "A",
+      }),
+    });
+    const capturedBody = (await captured.json()) as {
+      id: string;
+      status: string;
+      winner: string;
+      score: unknown;
+      startsAt: string;
+    };
+
+    expect(captured.status).toBe(201);
+    expect(capturedBody.status).toBe("locked");
+    expect(capturedBody.winner).toBe("A");
+    expect(capturedBody.score).toEqual(scoreA);
+    expect(capturedBody.startsAt).toBe("2026-08-29T10:00:00.000Z");
+
+    const history = await fetch(
+      `${server.url}/api/matches?playerUserId=user-riley`,
+    );
+    const items = (await history.json()) as { id: string }[];
+    expect(items.map((item) => item.id)).toEqual([capturedBody.id]);
+  });
+
+  test("POST /api/matches/capture requires a seated session player", async () => {
+    const unauth = await fetch(`${server.url}/api/matches/capture`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...createBody,
+        score: scoreA,
+        winner: "A",
+      }),
+    });
+    expect(unauth.status).toBe(401);
+
+    const guestsOnly = await fetch(`${server.url}/api/matches/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        pairings: {
+          teamA: [
+            { displayName: "Alex", isGuest: true, userId: null },
+            { displayName: "Sam", isGuest: true, userId: null },
+          ],
+          teamB: [
+            { displayName: "Jordan", isGuest: true, userId: null },
+            { displayName: "Riley", isGuest: true, userId: null },
+          ],
+        },
+        score: scoreA,
+        winner: "A",
+      }),
+    });
+    expect(guestsOnly.status).toBe(403);
+
+    const missingWhen = await fetch(`${server.url}/api/matches/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        venueCmsId: "sanity-court-1",
+        ruleset: "golden_point",
+        pairings: {
+          teamA: pairings.teamA,
+          teamB: [
+            { displayName: "Jordan", isGuest: true, userId: null },
+            { displayName: "Riley", isGuest: false, userId: null },
+          ],
+        },
+        score: scoreA,
+        winner: "A",
+      }),
+    });
+    expect(missingWhen.status).toBe(400);
+    expect(await missingWhen.json()).toEqual({
+      error: "startsAt or playedAt is required",
+    });
+
+    const missingVenue = await fetch(`${server.url}/api/matches/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        venueCmsId: "no-such-court",
+        pairings: {
+          teamA: pairings.teamA,
+          teamB: [
+            { displayName: "Jordan", isGuest: true, userId: null },
+            { displayName: "Riley", isGuest: false, userId: null },
+          ],
+        },
+        score: scoreA,
+        winner: "A",
+      }),
+    });
+    expect(missingVenue.status).toBe(404);
+  });
+
   test("GET missing match is 404", async () => {
     const response = await fetch(`${server.url}/api/matches/missing`);
     expect(response.status).toBe(404);

--- a/src/modules/match/entities/match.test.ts
+++ b/src/modules/match/entities/match.test.ts
@@ -109,6 +109,32 @@ describe(Match, () => {
     ).toThrow(DomainError);
   });
 
+  test("captureFinished creates a locked match without a live session", () => {
+    const lockedAt = new Date("2026-08-29T11:00:00.000Z");
+    const match = Match.captureFinished({
+      venueCmsId: CmsId.from("sanity-court-1"),
+      startsAt: StartsAt.from("2026-08-29T10:00:00.000Z"),
+      ruleset: Ruleset.from("golden_point"),
+      pairings: {
+        teamA: [user("user-1", "Alex"), guest("Sam")],
+        teamB: [guest("Jordan"), guest("Riley")],
+      },
+      servingTeam: Team.A,
+      score: lockScore,
+      winner: "A",
+      lockedByUserId: "user-1",
+      lockedAt,
+    });
+
+    expect(match.toSnapshot()).toMatchObject({
+      status: "locked",
+      winner: "A",
+      lockedAt: "2026-08-29T11:00:00.000Z",
+      score: lockScore,
+    });
+    expect(match.lockedByUserId).toBe("user-1");
+  });
+
   test("lock writes the result once and is idempotent for the same score", () => {
     const match = createLiveMatch();
     const lockedAt = new Date("2026-08-29T11:00:00.000Z");

--- a/src/modules/match/entities/match.ts
+++ b/src/modules/match/entities/match.ts
@@ -62,6 +62,24 @@ export class Match {
     );
   }
 
+  static captureFinished(
+    props: CreateMatchProps & {
+      score: unknown;
+      winner: unknown;
+      lockedByUserId: string;
+      lockedAt?: Date;
+    },
+  ): Match {
+    const match = Match.create(props);
+    match.lock(
+      MatchScore.from(props.score),
+      Team.from(props.winner, "winner"),
+      props.lockedAt ?? new Date(),
+      props.lockedByUserId,
+    );
+    return match;
+  }
+
   static rehydrate(props: {
     id: string;
     venueCmsId: CmsId;

--- a/src/modules/match/index.ts
+++ b/src/modules/match/index.ts
@@ -6,6 +6,7 @@ import { createMatchController } from "./controllers/match.controller";
 import { PrismaMatchRepository } from "./repositories/prisma-match.repository";
 import { MatchRepository } from "./repositories/match.repository";
 import { createMatchRoutes } from "./routes/match.routes";
+import { CaptureFinishedMatch } from "./services/capture-finished-match.service";
 import { CreateMatch } from "./services/create-match.service";
 import { GetMatchById } from "./services/get-match-by-id.service";
 import {
@@ -37,6 +38,10 @@ export function createMatchModule({
 
   const controller = createMatchController({
     createMatch: new CreateMatch(matchRepository, venueRepository),
+    captureFinishedMatch: new CaptureFinishedMatch(
+      matchRepository,
+      venueRepository,
+    ),
     getMatchById: new GetMatchById(matchRepository),
     lockMatch: new LockMatch(matchRepository),
     listLockedMatchesByPlayer: new ListLockedMatchesByPlayer(
@@ -61,6 +66,7 @@ export { Match } from "./entities/match";
 export { InMemoryMatchRepository } from "./repositories/in-memory-match.repository";
 export { PrismaMatchRepository } from "./repositories/prisma-match.repository";
 export type { MatchRepository } from "./repositories/match.repository";
+export { CaptureFinishedMatch } from "./services/capture-finished-match.service";
 export { CreateMatch } from "./services/create-match.service";
 export { GetMatchById } from "./services/get-match-by-id.service";
 export { LockMatch } from "./services/lock-match.service";

--- a/src/modules/match/repositories/prisma-match.repository.test.ts
+++ b/src/modules/match/repositories/prisma-match.repository.test.ts
@@ -205,6 +205,40 @@ describe(PrismaMatchRepository, () => {
     );
   });
 
+  test("create persists a captureFinished match as locked", async () => {
+    const prisma = createPrismaMap();
+    const repository = new PrismaMatchRepository(
+      prisma as unknown as PrismaClient,
+    );
+    const match = Match.captureFinished({
+      venueCmsId: CmsId.from("sanity-court-1"),
+      startsAt: StartsAt.from("2026-08-29T10:00:00.000Z"),
+      ruleset: Ruleset.from("golden_point"),
+      pairings: {
+        teamA: [
+          { displayName: "Alex", isGuest: true, userId: null },
+          { displayName: "Sam", isGuest: true, userId: null },
+        ],
+        teamB: [
+          { displayName: "Jordan", isGuest: true, userId: null },
+          { displayName: "Riley", isGuest: false, userId: "user-1" },
+        ],
+      },
+      servingTeam: Team.A,
+      score: { sets: [{ gamesA: 6, gamesB: 4, winner: "A" }] },
+      winner: "A",
+      lockedByUserId: "user-1",
+      lockedAt: new Date("2026-08-29T11:00:00.000Z"),
+    });
+
+    const stored = await repository.create(match);
+
+    expect(stored.status).toBe("locked");
+    expect(prisma.matches.get(match.id)?.status).toBe("locked");
+    expect(prisma.matches.get(match.id)?.winnerTeam).toBe("A");
+    expect(await repository.listLockedByPlayerUserId("user-1")).toHaveLength(1);
+  });
+
   test("persistLock conflicts when another result already won the race", async () => {
     const prisma = createPrismaMap();
     const repository = new PrismaMatchRepository(

--- a/src/modules/match/repositories/prisma-match.repository.ts
+++ b/src/modules/match/repositories/prisma-match.repository.ts
@@ -62,8 +62,12 @@ export class PrismaMatchRepository implements MatchRepository {
           venueCmsId: snapshot.venueCmsId,
           startsAt: match.startsAt.value,
           ruleset: snapshot.ruleset,
-          status: "live",
+          status: snapshot.status,
           servingTeam: snapshot.servingTeam,
+          winnerTeam: snapshot.winner,
+          lockedAt: match.lockedAt,
+          lockedByUserId: match.lockedByUserId,
+          score: snapshot.score === null ? undefined : snapshot.score,
           players: {
             create: match.pairings.players.map((player) => ({
               slot: player.slot.value,

--- a/src/modules/match/routes/match.routes.ts
+++ b/src/modules/match/routes/match.routes.ts
@@ -11,6 +11,10 @@ export function createMatchRoutes(
     void controller.create(req, res);
   });
 
+  router.post("/api/matches/capture", (req, res) => {
+    void controller.capture(req, res);
+  });
+
   router.get("/api/matches", (req, res) => {
     void controller.listByPlayer(req, res);
   });

--- a/src/modules/match/services/capture-finished-match.service.ts
+++ b/src/modules/match/services/capture-finished-match.service.ts
@@ -1,0 +1,51 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { Match } from "../entities/match";
+import { MatchVenueNotFoundError } from "../entities/match-venue-not-found-error";
+import { MatchRepository } from "../repositories/match.repository";
+import { PairingsInput } from "../entities/pairings";
+import { Ruleset } from "../entities/ruleset";
+import { StartsAt } from "../entities/starts-at";
+import { Team } from "../entities/team";
+
+export type CaptureFinishedMatchInput = {
+  venueCmsId: string;
+  startsAt: unknown;
+  ruleset: unknown;
+  pairings: PairingsInput;
+  servingTeam?: unknown;
+  score: unknown;
+  winner: unknown;
+  lockedByUserId: string;
+};
+
+export class CaptureFinishedMatch {
+  constructor(
+    private readonly matches: MatchRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async execute(input: CaptureFinishedMatchInput): Promise<Match> {
+    const venueCmsId = CmsId.from(input.venueCmsId);
+    const venue = await this.venues.findByCmsId(venueCmsId);
+    if (!venue) {
+      throw new MatchVenueNotFoundError();
+    }
+
+    const match = Match.captureFinished({
+      venueCmsId,
+      startsAt: StartsAt.from(input.startsAt),
+      ruleset: Ruleset.from(input.ruleset),
+      pairings: input.pairings,
+      servingTeam:
+        input.servingTeam === undefined || input.servingTeam === null
+          ? Team.A
+          : Team.from(input.servingTeam, "servingTeam"),
+      score: input.score,
+      winner: input.winner,
+      lockedByUserId: input.lockedByUserId,
+    });
+
+    return this.matches.create(match);
+  }
+}

--- a/src/modules/match/services/create-match.service.test.ts
+++ b/src/modules/match/services/create-match.service.test.ts
@@ -6,6 +6,7 @@ import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venu
 import { DomainError } from "../../../lib/domain-error";
 import { MatchVenueNotFoundError } from "../entities/match-venue-not-found-error";
 import { InMemoryMatchRepository } from "../repositories/in-memory-match.repository";
+import { CaptureFinishedMatch } from "./capture-finished-match.service";
 import { CreateMatch } from "./create-match.service";
 import {
   ListLockedMatchesByPlayer,
@@ -73,6 +74,32 @@ describe("match application", () => {
     );
     expect((await matches.findById(second.id))?.id).toBe(second.id);
     expect(second.toSnapshot().servingTeam).toBe("B");
+  });
+
+  test("captureFinished persists a locked match that history lists immediately", async () => {
+    const venues = new InMemoryVenueRepository();
+    const matches = new InMemoryMatchRepository();
+    await seedVenue(venues);
+    const capture = new CaptureFinishedMatch(matches, venues);
+
+    const match = await capture.execute({
+      venueCmsId: "sanity-court-1",
+      startsAt: "2026-08-29T10:00:00.000Z",
+      ruleset: "golden_point",
+      pairings: guests,
+      score: scoreA,
+      winner: "A",
+      lockedByUserId: "user-riley",
+    });
+
+    expect(match.status).toBe("locked");
+    expect(match.toSnapshot().score).toEqual(scoreA);
+    expect(match.lockedByUserId).toBe("user-riley");
+
+    const history = await new ListLockedMatchesByPlayer(matches, venues).execute(
+      "user-riley",
+    );
+    expect(history.map((item) => item.id)).toEqual([match.id]);
   });
 
   test("create fails when the venue cmsId is unknown", async () => {

--- a/src/modules/match/utils/played-at.ts
+++ b/src/modules/match/utils/played-at.ts
@@ -1,0 +1,12 @@
+export function resolvePlayedAt(body: {
+  startsAt?: string;
+  playedAt?: string;
+}): string | undefined {
+  const startsAt = typeof body.startsAt === "string" ? body.startsAt.trim() : "";
+  if (startsAt.length > 0) {
+    return startsAt;
+  }
+
+  const playedAt = typeof body.playedAt === "string" ? body.playedAt.trim() : "";
+  return playedAt.length > 0 ? playedAt : undefined;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #31.

Play hub needs **Capture results**: record a finished padel match or golf round without opening a live scorecard. Live start (`POST /api/matches`, `POST /api/golf-rounds`) is unchanged.

Related: [landing-page#149](https://github.com/leaguesports/landing-page/issues/149) (Play v2). Do **not** merge — Brandon will merge.

## What existed vs what this adds

**Already on main (no live-path change):**
- Padel live create/lock/history: `POST /api/matches`, `GET /api/matches/:id`, `POST /api/matches/:id/lock`, history lists
- Golf live create/lock/history: `POST /api/golf-rounds`, `GET /api/golf-rounds/:id`, `POST /api/golf-rounds/:id/lock`, history lists
- Session bind on create; lock requires a seated session player
- Domain `Match.lock()` / `GolfRound.lock()` + venue-required models

**Added:**
- `Match.captureFinished` / `GolfRound.captureFinished` — create then lock on the aggregate
- `POST /api/matches/capture` and `POST /api/golf-rounds/capture`
- Prisma `create` persists an already-locked aggregate (so capture is one write)
- `playedAt` alias for `startsAt`

`venueCmsId` stays **required** — existing Match/GolfRound models FK to Venue. No venue-less schema for v1.

---

## Frontend contract

Auth for both capture routes: signed-in session cookie `token` (same JWT as lock).  
`401` `{ "error": "Unauthorized" }` if missing/invalid.

Session user **must be a seated named player** after sanitize (same rules as live create: only the session `userId` is kept; omit `userId` on a non-guest seat and it is bound to the session).  
All-guest pairings/players → `403`.

Foreign `userId`s are stripped to guests (same as live create).

Idempotency is **not** implemented for v1 (each capture mints a new id).

### Padel — `POST /api/matches/capture`

**201** locked match snapshot (same shape as `GET /api/matches/:id`).

```json
{
  "venueCmsId": "sanity-court-1",
  "startsAt": "2026-08-29T10:00:00.000Z",
  "playedAt": "2026-08-29T10:00:00.000Z",
  "ruleset": "golden_point",
  "servingTeam": "A",
  "pairings": {
    "teamA": [
      { "displayName": "Alex", "isGuest": true, "userId": null },
      { "displayName": "Sam", "isGuest": true, "userId": null }
    ],
    "teamB": [
      { "displayName": "Jordan", "isGuest": true, "userId": null },
      { "displayName": "Riley", "isGuest": false, "userId": null }
    ]
  },
  "score": {
    "sets": [
      { "gamesA": 6, "gamesB": 4, "tieBreak": null, "winner": "A" }
    ]
  },
  "winner": "A"
}
```

| Field | Required | Notes |
|---|---|---|
| `venueCmsId` | yes | Sanity court `_id`; must exist (`404` if unknown) |
| `startsAt` or `playedAt` | one of | ISO datetime. `startsAt` wins if both sent. Stored as `startsAt` |
| `ruleset` | yes | `golden_point` \| `advantage` |
| `pairings.teamA` / `teamB` | yes | Exactly two players each |
| `servingTeam` | no | `A` \| `B`, default `A` |
| `score.sets[]` | yes | `gamesA`, `gamesB` non-negative ints; optional `tieBreak: { pointsA, pointsB }`; optional set `winner` `A`\|`B` |
| `winner` | yes | Match winner `A` \| `B` |

**201 response** (match snapshot):

```json
{
  "id": "uuid",
  "venueCmsId": "sanity-court-1",
  "startsAt": "2026-08-29T10:00:00.000Z",
  "ruleset": "golden_point",
  "status": "locked",
  "servingTeam": "A",
  "pairings": {
    "teamA": [
      { "slot": "A1", "userId": null, "displayName": "Alex", "isGuest": true },
      { "slot": "A2", "userId": null, "displayName": "Sam", "isGuest": true }
    ],
    "teamB": [
      { "slot": "B1", "userId": null, "displayName": "Jordan", "isGuest": true },
      { "slot": "B2", "userId": "<sessionUserId>", "displayName": "Riley", "isGuest": false }
    ]
  },
  "score": { "sets": [{ "gamesA": 6, "gamesB": 4, "tieBreak": null, "winner": "A" }] },
  "winner": "A",
  "lockedAt": "2026-09-07T04:30:00.000Z"
}
```

Deep-link: `/padel/{id}`. History: existing `GET /api/matches?playerUserId=` and `GET /api/venues/:cmsId/matches`.

### Golf — `POST /api/golf-rounds/capture`

**201** locked round snapshot (same shape as `GET /api/golf-rounds/:id`).

```json
{
  "venueCmsId": "sanity-course-1",
  "startsAt": "2026-09-04T10:00:00.000Z",
  "playedAt": "2026-09-04T10:00:00.000Z",
  "holesPlayed": 9,
  "startingHole": 1,
  "teeName": "White",
  "course": {
    "name": "Links Nine",
    "holes": [{ "number": 1, "par": 4, "strokeIndex": 1 }]
  },
  "players": [
    { "slot": 1, "displayName": "Alex", "isGuest": true, "userId": null },
    { "slot": 2, "displayName": "Riley", "isGuest": false, "userId": null }
  ],
  "score": {
    "holes": [
      { "number": 1, "strokes": { "1": 4, "2": 5 } }
    ]
  }
}
```

| Field | Required | Notes |
|---|---|---|
| `venueCmsId` | yes | Sanity course `_id`; must exist (`404`) |
| `startsAt` or `playedAt` | one of | ISO datetime. `startsAt` wins if both sent |
| `holesPlayed` | yes | `9` or `18` |
| `startingHole` | no | 1–18, default `1` |
| `teeName` | no | string or null |
| `course.holes` | yes | Length must equal `holesPlayed`; consecutive from `startingHole`; unique `number` and `strokeIndex`; `par` 3–5 |
| `players` | yes | 1–4; unique `slot` 1–4 |
| `score.holes` | yes | Same hole order as course; `strokes` keyed by slot string (`"1"`…); each stroke integer 1–15 |

**201 response** (round snapshot): `status: "locked"`, `score`, `lockedAt`, players with slots. Deep-link: `/golf/{id}`. History: existing `GET /api/golf-rounds?playerUserId=` and `GET /api/venues/:cmsId/golf-rounds`.

### Errors (both)

| Status | When |
|---|---|
| `400` | Invalid payload / domain rules (`Invalid match payload` / `Invalid golf round payload` or a `DomainError` message). Missing `startsAt`/`playedAt` → `{ "error": "startsAt or playedAt is required" }` |
| `401` | No session |
| `403` | Session user not seated |
| `404` | Unknown `venueCmsId` |
| `503` | Persistence failure |

### Live create (unchanged — Start game)

- `POST /api/matches` — still returns `status: "live"`; anonymous OK
- `POST /api/golf-rounds` — same
- Lock remains `POST /api/matches/:id/lock` and `POST /api/golf-rounds/:id/lock` for in-progress scorecards

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c7ca88b-691d-4919-ad06-79fbf4cf9130?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c7ca88b-691d-4919-ad06-79fbf4cf9130&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

