### PR TITLE
feat: organise game (invites, RSVP, start live)

### DIFF
--- a/prisma/migrations/20260907080000_organised_game/migration.sql
+++ b/prisma/migrations/20260907080000_organised_game/migration.sql
@@ -1,0 +1,69 @@
+-- CreateEnum
+CREATE TYPE "OrganisedGameSport" AS ENUM ('padel', 'golf');
+
+-- CreateEnum
+CREATE TYPE "OrganisedGameStatus" AS ENUM ('open', 'started', 'cancelled');
+
+-- CreateEnum
+CREATE TYPE "OrganisedGameRsvp" AS ENUM ('pending', 'accepted', 'declined');
+
+-- CreateTable
+CREATE TABLE "OrganisedGame" (
+    "id" TEXT NOT NULL,
+    "hostUserId" TEXT NOT NULL,
+    "sport" "OrganisedGameSport" NOT NULL,
+    "status" "OrganisedGameStatus" NOT NULL DEFAULT 'open',
+    "venueCmsId" TEXT NOT NULL,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "notes" TEXT,
+    "capacity" INTEGER NOT NULL,
+    "inviteToken" VARCHAR(32) NOT NULL,
+    "liveScorecardId" TEXT,
+    "livePath" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OrganisedGame_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OrganisedGameInvite" (
+    "id" TEXT NOT NULL,
+    "gameId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "rsvp" "OrganisedGameRsvp" NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "respondedAt" TIMESTAMP(3),
+
+    CONSTRAINT "OrganisedGameInvite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrganisedGame_inviteToken_key" ON "OrganisedGame"("inviteToken");
+
+-- CreateIndex
+CREATE INDEX "OrganisedGame_hostUserId_idx" ON "OrganisedGame"("hostUserId");
+
+-- CreateIndex
+CREATE INDEX "OrganisedGame_venueCmsId_idx" ON "OrganisedGame"("venueCmsId");
+
+-- CreateIndex
+CREATE INDEX "OrganisedGame_status_startsAt_idx" ON "OrganisedGame"("status", "startsAt");
+
+-- CreateIndex
+CREATE INDEX "OrganisedGame_hostUserId_status_idx" ON "OrganisedGame"("hostUserId", "status");
+
+-- CreateIndex
+CREATE INDEX "OrganisedGameInvite_userId_idx" ON "OrganisedGameInvite"("userId");
+
+-- CreateIndex
+CREATE INDEX "OrganisedGameInvite_gameId_idx" ON "OrganisedGameInvite"("gameId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrganisedGameInvite_gameId_userId_key" ON "OrganisedGameInvite"("gameId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "OrganisedGame" ADD CONSTRAINT "OrganisedGame_venueCmsId_fkey" FOREIGN KEY ("venueCmsId") REFERENCES "Venue"("cmsId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrganisedGameInvite" ADD CONSTRAINT "OrganisedGameInvite_gameId_fkey" FOREIGN KEY ("gameId") REFERENCES "OrganisedGame"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,13 +61,14 @@ model SportFollow {
 }
 
 model Venue {
-  id         String        @id @default(uuid())
-  cmsId      String        @unique
-  name       String
-  slug       String
-  matches    Match[]
-  golfRounds GolfRound[]
-  follows    VenueFollow[]
+  id              String           @id @default(uuid())
+  cmsId           String           @unique
+  name            String
+  slug            String
+  matches         Match[]
+  golfRounds      GolfRound[]
+  follows         VenueFollow[]
+  organisedGames  OrganisedGame[]
 }
 
 model VenueFollow {
@@ -307,6 +308,62 @@ model MatchPlayer {
 enum GolfRoundStatus {
   live
   locked
+}
+
+enum OrganisedGameSport {
+  padel
+  golf
+}
+
+enum OrganisedGameStatus {
+  open
+  started
+  cancelled
+}
+
+enum OrganisedGameRsvp {
+  pending
+  accepted
+  declined
+}
+
+// Host-scheduled padel/golf gathering. No User FK — same as Friendship /
+// CommunityMember. Share token is the unguessable invite surface.
+model OrganisedGame {
+  id              String              @id @default(uuid())
+  hostUserId      String
+  sport           OrganisedGameSport
+  status          OrganisedGameStatus @default(open)
+  venueCmsId      String
+  venue           Venue               @relation(fields: [venueCmsId], references: [cmsId])
+  startsAt        DateTime
+  notes           String?
+  capacity        Int
+  inviteToken     String              @unique @db.VarChar(32)
+  liveScorecardId String?
+  livePath        String?
+  createdAt       DateTime            @default(now())
+  updatedAt       DateTime            @updatedAt
+  invites         OrganisedGameInvite[]
+
+  @@index([hostUserId])
+  @@index([venueCmsId])
+  @@index([status, startsAt])
+  @@index([hostUserId, status])
+}
+
+model OrganisedGameInvite {
+  id          String            @id @default(uuid())
+  gameId      String
+  game        OrganisedGame     @relation(fields: [gameId], references: [id], onDelete: Cascade)
+  userId      String
+  rsvp        OrganisedGameRsvp @default(pending)
+  createdAt   DateTime          @default(now())
+  respondedAt DateTime?
+
+  @@unique([gameId, userId])
+  @@index([userId])
+  @@index([gameId])
 }
 
 model GolfRound {

--- a/src/app.ts
+++ b/src/app.ts
@@ -46,6 +46,10 @@ import {
   createPoolsModule,
   PoolRepository,
 } from "./modules/pools";
+import {
+  createOrganisedGamesModule,
+  OrganisedGameRepository,
+} from "./modules/organised-games";
 
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
@@ -60,6 +64,7 @@ export type CreateAppDependencies = {
   trainingEnrollmentRepository?: TrainingEnrollmentRepository;
   integrationConnectionRepository?: IntegrationConnectionRepository;
   poolRepository?: PoolRepository;
+  organisedGameRepository?: OrganisedGameRepository;
 };
 
 export async function createApp(
@@ -156,6 +161,17 @@ export async function createApp(
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
+  const organisedGames = createOrganisedGamesModule({
+    prisma,
+    venueRepository: venue.venueRepository,
+    friendshipRepository: friends.friendshipRepository,
+    friendProfileLookup: friends.friendProfileLookup,
+    matchRepository: match.matchRepository,
+    golfRoundRepository: golfRound.golfRoundRepository,
+    organisedGameRepository: dependencies.organisedGameRepository,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
@@ -168,6 +184,7 @@ export async function createApp(
   app.use(training.router);
   app.use(integrations.router);
   app.use(pools.router);
+  app.use(organisedGames.router);
 
   app.use(
     (

--- a/src/modules/organised-games/controllers/organised-games.controller.ts
+++ b/src/modules/organised-games/controllers/organised-games.controller.ts
@@ -1,0 +1,344 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { GolfRoundVenueNotFoundError } from "../../golf-round/entities/golf-round-venue-not-found-error";
+import { MatchVenueNotFoundError } from "../../match/entities/match-venue-not-found-error";
+import { OrganisedGameCapacityError } from "../entities/organised-game-capacity-error";
+import { OrganisedGameForbiddenError } from "../entities/organised-game-forbidden-error";
+import { OrganisedGameNotFoundError } from "../entities/organised-game-not-found-error";
+import { OrganisedGameNotFriendError } from "../entities/organised-game-not-friend-error";
+import { OrganisedGameNotOpenError } from "../entities/organised-game-not-open-error";
+import { OrganisedGamePersistenceError } from "../entities/organised-game-persistence-error";
+import { OrganisedGameStartWindowError } from "../entities/organised-game-start-window-error";
+import { OrganisedGameVenueNotFoundError } from "../entities/organised-game-venue-not-found-error";
+import {
+  CancelOrganisedGame,
+  CreateOrganisedGame,
+  GetOrganisedGame,
+  GetOrganisedGameByToken,
+  InviteFriends,
+  JoinByInviteToken,
+  ListInvites,
+  ListMyOrganisedGames,
+  RsvpOrganisedGame,
+  StartOrganisedGame,
+} from "../services/organised-games.service";
+
+const playerSchema = z.object({
+  userId: z.string().nullable().optional(),
+  displayName: z.string(),
+  isGuest: z.boolean(),
+});
+
+const pairingsSchema = z.object({
+  teamA: z.tuple([playerSchema, playerSchema]),
+  teamB: z.tuple([playerSchema, playerSchema]),
+});
+
+const golfPlayerSchema = z.object({
+  slot: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
+  userId: z.string().nullable().optional(),
+  displayName: z.string(),
+  isGuest: z.boolean(),
+});
+
+const courseHoleSchema = z.object({
+  number: z.number(),
+  par: z.number(),
+  strokeIndex: z.number(),
+});
+
+const createBodySchema = z.object({
+  sport: z.string(),
+  venueCmsId: z.string(),
+  startsAt: z.string(),
+  notes: z.string().nullable().optional(),
+  capacity: z.number().optional(),
+  inviteUserIds: z.array(z.string()).optional(),
+});
+
+const gameIdParamSchema = z.object({
+  id: z.string(),
+});
+
+const tokenParamSchema = z.object({
+  token: z.string(),
+});
+
+const inviteBodySchema = z.object({
+  userIds: z.array(z.string()),
+});
+
+const rsvpBodySchema = z.object({
+  rsvp: z.string(),
+});
+
+const startBodySchema = z
+  .object({
+    ruleset: z.enum(["golden_point", "advantage"]).optional(),
+    servingTeam: z.enum(["A", "B"]).optional(),
+    pairings: pairingsSchema.optional(),
+    holesPlayed: z.union([z.literal(9), z.literal(18)]).optional(),
+    startingHole: z.number().optional(),
+    teeName: z.string().nullable().optional(),
+    course: z
+      .object({
+        name: z.string().nullable().optional(),
+        holes: z.array(courseHoleSchema).min(1),
+      })
+      .optional(),
+    players: z.array(golfPlayerSchema).min(1).max(4).optional(),
+  })
+  .optional();
+
+export function createOrganisedGamesController(deps: {
+  createOrganisedGame: CreateOrganisedGame;
+  getOrganisedGame: GetOrganisedGame;
+  getOrganisedGameByToken: GetOrganisedGameByToken;
+  listMyOrganisedGames: ListMyOrganisedGames;
+  inviteFriends: InviteFriends;
+  listInvites: ListInvites;
+  joinByInviteToken: JoinByInviteToken;
+  rsvpOrganisedGame: RsvpOrganisedGame;
+  cancelOrganisedGame: CancelOrganisedGame;
+  startOrganisedGame: StartOrganisedGame;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async create(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const body = z.parse(createBodySchema, req.body ?? {});
+        const result = await deps.createOrganisedGame.execute({
+          userId,
+          sport: body.sport,
+          venueCmsId: body.venueCmsId,
+          startsAt: body.startsAt,
+          notes: body.notes,
+          capacity: body.capacity,
+          inviteUserIds: body.inviteUserIds,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendOrganisedGameError(res, error);
+      }
+    },
+
+    async me(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const result = await deps.listMyOrganisedGames.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendOrganisedGameError(res, error);
+      }
+    },
+
+    async get(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(gameIdParamSchema, req.params);
+        const result = await deps.getOrganisedGame.execute({
+          userId,
+          gameId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendOrganisedGameError(res, error);
+      }
+    },
+
+    async getByToken(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { token } = z.parse(tokenParamSchema, req.params);
+        const result = await deps.getOrganisedGameByToken.execute({
+          userId,
+          token,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendOrganisedGameError(res, error);
+      }
+    },
+
+    async joinByToken(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { token } = z.parse(tokenParamSchema, req.params);
+        const result = await deps.joinByInviteToken.execute({
+          userId,
+          token,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendOrganisedGameError(res, error);
+      }
+    },
+
+    async listInvites(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(gameIdParamSchema, req.params);
+        const result = await deps.listInvites.execute({
+          userId,
+          gameId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendOrganisedGameError(res, error);
+      }
+    },
+
+    async invite(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(gameIdParamSchema, req.params);
+        const body = z.parse(inviteBodySchema, req.body ?? {});
+        const result = await deps.inviteFriends.execute({
+          userId,
+          gameId: id,
+          userIds: body.userIds,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendOrganisedGameError(res, error);
+      }
+    },
+
+    async rsvp(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(gameIdParamSchema, req.params);
+        const body = z.parse(rsvpBodySchema, req.body ?? {});
+        const result = await deps.rsvpOrganisedGame.execute({
+          userId,
+          gameId: id,
+          rsvp: body.rsvp,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendOrganisedGameError(res, error);
+      }
+    },
+
+    async start(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(gameIdParamSchema, req.params);
+        const body = z.parse(startBodySchema, req.body ?? {}) ?? {};
+        const result = await deps.startOrganisedGame.execute({
+          userId,
+          gameId: id,
+          ...body,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendOrganisedGameError(res, error);
+      }
+    },
+
+    async cancel(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(gameIdParamSchema, req.params);
+        const result = await deps.cancelOrganisedGame.execute({
+          userId,
+          gameId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendOrganisedGameError(res, error);
+      }
+    },
+  };
+}
+
+function sendOrganisedGameError(res: Response, error: unknown) {
+  if (error instanceof OrganisedGameNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (
+    error instanceof OrganisedGameVenueNotFoundError ||
+    error instanceof MatchVenueNotFoundError ||
+    error instanceof GolfRoundVenueNotFoundError
+  ) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof OrganisedGameForbiddenError) {
+    return res.status(403).json({ error: error.message });
+  }
+
+  if (error instanceof OrganisedGameNotFriendError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (
+    error instanceof OrganisedGameCapacityError ||
+    error instanceof OrganisedGameNotOpenError
+  ) {
+    return res.status(409).json({ error: error.message });
+  }
+
+  if (error instanceof OrganisedGameStartWindowError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid organised game payload" });
+  }
+
+  if (error instanceof OrganisedGamePersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/organised-games/controllers/organised-games.http.test.ts
+++ b/src/modules/organised-games/controllers/organised-games.http.test.ts
@@ -1,0 +1,415 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { InMemoryGolfRoundRepository } from "../../golf-round/repositories/in-memory-golf-round.repository";
+import { signAuthenticationToken } from "../../identity/utils/jwt";
+import { InMemoryMatchRepository } from "../../match/repositories/in-memory-match.repository";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { InMemoryOrganisedGameRepository } from "../repositories/in-memory-organised-game.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function becomeFriends(
+  friendships: InMemoryFriendshipRepository,
+  a: string,
+  b: string,
+) {
+  const pending = await friendships.createPending(a, b);
+  await friendships.accept(pending.id);
+}
+
+describe("organised games HTTP", () => {
+  const config = makeConfig();
+  let venues: InMemoryVenueRepository;
+  let friendships: InMemoryFriendshipRepository;
+  let profiles: InMemoryFriendProfileLookup;
+  let games: InMemoryOrganisedGameRepository;
+  let matches: InMemoryMatchRepository;
+  let rounds: InMemoryGolfRoundRepository;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  function cookie(userId: string) {
+    return `token=${signAuthenticationToken(config, { userId })}`;
+  }
+
+  beforeEach(async () => {
+    venues = new InMemoryVenueRepository();
+    friendships = new InMemoryFriendshipRepository();
+    profiles = new InMemoryFriendProfileLookup();
+    games = new InMemoryOrganisedGameRepository();
+    matches = new InMemoryMatchRepository();
+    rounds = new InMemoryGolfRoundRepository();
+
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-court-1"),
+        VenueName.from("Padel Club"),
+        Slug.from("padel-club"),
+      ),
+      { refreshDetails: false },
+    );
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-course-1"),
+        VenueName.from("Golf Club"),
+        Slug.from("golf-club"),
+      ),
+      { refreshDetails: false },
+    );
+
+    profiles.seed({
+      userId: "user-a",
+      displayName: "Alex",
+      handle: "alex",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-b",
+      displayName: "Blake",
+      handle: "blake",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-c",
+      displayName: "Casey",
+      handle: "casey",
+      avatarUrl: null,
+    });
+
+    await becomeFriends(friendships, "user-a", "user-b");
+
+    app = await createApp(config, {
+      venueRepository: venues,
+      friendshipRepository: friendships,
+      friendProfileLookup: profiles,
+      organisedGameRepository: games,
+      matchRepository: matches,
+      golfRoundRepository: rounds,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("create requires auth, 404s unknown venue, and returns host invite token", async () => {
+    const unauth = await fetch(`${server.url}/api/organised-games`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sport: "padel",
+        venueCmsId: "sanity-court-1",
+        startsAt: new Date().toISOString(),
+      }),
+    });
+    expect(unauth.status).toBe(401);
+
+    const missingVenue = await fetch(`${server.url}/api/organised-games`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        sport: "padel",
+        venueCmsId: "no-such-venue",
+        startsAt: new Date().toISOString(),
+      }),
+    });
+    expect(missingVenue.status).toBe(404);
+    expect(await missingVenue.json()).toEqual({ error: "Venue not found" });
+
+    const created = await fetch(`${server.url}/api/organised-games`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        sport: "padel",
+        venueCmsId: "sanity-court-1",
+        startsAt: new Date().toISOString(),
+        notes: "League night",
+        inviteUserIds: ["user-b"],
+      }),
+    });
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as {
+      game: {
+        id: string;
+        inviteToken: string;
+        invitees: Array<{ id: string; rsvp: string }>;
+      };
+    };
+    expect(createdBody.game.inviteToken).toHaveLength(32);
+    expect(createdBody.game.invitees).toEqual([
+      expect.objectContaining({ id: "user-b", rsvp: "pending" }),
+    ]);
+
+    const stranger = await fetch(
+      `${server.url}/api/organised-games/${createdBody.game.id}`,
+      { headers: { Cookie: cookie("user-c") } },
+    );
+    expect(stranger.status).toBe(404);
+  });
+
+  test("shareable token join, RSVP rules, hub lists, and start live padel", async () => {
+    const created = await fetch(`${server.url}/api/organised-games`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        sport: "padel",
+        venueCmsId: "sanity-court-1",
+        startsAt: new Date().toISOString(),
+        inviteUserIds: ["user-b"],
+      }),
+    });
+    const { game } = (await created.json()) as {
+      game: { id: string; inviteToken: string };
+    };
+
+    const preview = await fetch(
+      `${server.url}/api/organised-games/invite/${game.inviteToken}`,
+      { headers: { Cookie: cookie("user-c") } },
+    );
+    expect(preview.status).toBe(200);
+    expect(await preview.json()).toMatchObject({
+      game: { id: game.id, viewer: { role: "guest", rsvp: null } },
+    });
+
+    const joined = await fetch(
+      `${server.url}/api/organised-games/invite/${game.inviteToken}/join`,
+      { method: "POST", headers: { Cookie: cookie("user-c") } },
+    );
+    expect(joined.status).toBe(200);
+    expect(await joined.json()).toMatchObject({
+      game: { viewer: { role: "invitee", rsvp: "pending" }, inviteToken: null },
+    });
+
+    const hostRsvp = await fetch(
+      `${server.url}/api/organised-games/${game.id}/rsvp`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({ rsvp: "accepted" }),
+      },
+    );
+    expect(hostRsvp.status).toBe(403);
+
+    const accept = await fetch(
+      `${server.url}/api/organised-games/${game.id}/rsvp`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-b"),
+        },
+        body: JSON.stringify({ rsvp: "accepted" }),
+      },
+    );
+    expect(accept.status).toBe(200);
+    expect(await accept.json()).toMatchObject({
+      game: { viewer: { role: "invitee", rsvp: "accepted" } },
+    });
+
+    const invites = await fetch(
+      `${server.url}/api/organised-games/${game.id}/invites`,
+      { headers: { Cookie: cookie("user-a") } },
+    );
+    expect(invites.status).toBe(200);
+    expect(await invites.json()).toMatchObject({
+      invites: [
+        { id: "user-b", rsvp: "accepted" },
+        { id: "user-c", rsvp: "pending" },
+      ],
+    });
+
+    const hubHost = await fetch(`${server.url}/api/me/organised-games`, {
+      headers: { Cookie: cookie("user-a") },
+    });
+    expect(hubHost.status).toBe(200);
+    expect(await hubHost.json()).toMatchObject({
+      hosted: [{ id: game.id }],
+      invited: [],
+    });
+
+    const hubInvitee = await fetch(`${server.url}/api/me/organised-games`, {
+      headers: { Cookie: cookie("user-b") },
+    });
+    expect(await hubInvitee.json()).toMatchObject({
+      hosted: [],
+      invited: [{ id: game.id, viewer: { rsvp: "accepted" } }],
+    });
+
+    const start = await fetch(
+      `${server.url}/api/organised-games/${game.id}/start`,
+      { method: "POST", headers: { Cookie: cookie("user-a") } },
+    );
+    expect(start.status).toBe(201);
+    const started = (await start.json()) as {
+      game: { status: string; live: { id: string; path: string } };
+      live: { sport: string; id: string; path: string };
+    };
+    expect(started.game.status).toBe("started");
+    expect(started.live.sport).toBe("padel");
+    expect(started.live.path).toBe(`/padel/${started.live.id}`);
+
+    const live = await fetch(
+      `${server.url}/api/matches/${started.live.id}`,
+    );
+    expect(live.status).toBe(200);
+    expect(await live.json()).toMatchObject({
+      id: started.live.id,
+      status: "live",
+      venueCmsId: "sanity-court-1",
+      pairings: {
+        teamA: [
+          { userId: "user-a", isGuest: false },
+          { userId: "user-b", isGuest: false },
+        ],
+      },
+    });
+  });
+
+  test("golf start uses default 9-hole course and seats host", async () => {
+    const created = await fetch(`${server.url}/api/organised-games`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        sport: "golf",
+        venueCmsId: "sanity-course-1",
+        startsAt: new Date().toISOString(),
+      }),
+    });
+    const { game } = (await created.json()) as { game: { id: string } };
+
+    const notHost = await fetch(
+      `${server.url}/api/organised-games/${game.id}/start`,
+      { method: "POST", headers: { Cookie: cookie("user-b") } },
+    );
+    expect(notHost.status).toBe(403);
+
+    const start = await fetch(
+      `${server.url}/api/organised-games/${game.id}/start`,
+      { method: "POST", headers: { Cookie: cookie("user-a") } },
+    );
+    expect(start.status).toBe(201);
+    const started = (await start.json()) as {
+      live: { sport: string; id: string; path: string };
+    };
+    expect(started.live.sport).toBe("golf");
+    expect(started.live.path).toBe(`/golf/${started.live.id}`);
+
+    const round = await fetch(
+      `${server.url}/api/golf-rounds/${started.live.id}`,
+    );
+    expect(round.status).toBe(200);
+    expect(await round.json()).toMatchObject({
+      id: started.live.id,
+      status: "live",
+      venueCmsId: "sanity-course-1",
+      holesPlayed: 9,
+      players: [{ slot: 1, userId: "user-a", isGuest: false }],
+    });
+  });
+
+  test("non-friend invite is 400; cancel is host-only", async () => {
+    const created = await fetch(`${server.url}/api/organised-games`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        sport: "padel",
+        venueCmsId: "sanity-court-1",
+        startsAt: new Date().toISOString(),
+      }),
+    });
+    const { game } = (await created.json()) as { game: { id: string } };
+
+    const inviteStranger = await fetch(
+      `${server.url}/api/organised-games/${game.id}/invites`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({ userIds: ["user-c"] }),
+      },
+    );
+    expect(inviteStranger.status).toBe(400);
+
+    const cancelAsFriend = await fetch(
+      `${server.url}/api/organised-games/${game.id}/cancel`,
+      { method: "POST", headers: { Cookie: cookie("user-b") } },
+    );
+    expect(cancelAsFriend.status).toBe(403);
+
+    const cancel = await fetch(
+      `${server.url}/api/organised-games/${game.id}/cancel`,
+      { method: "POST", headers: { Cookie: cookie("user-a") } },
+    );
+    expect(cancel.status).toBe(200);
+    expect(await cancel.json()).toMatchObject({
+      game: { status: "cancelled" },
+    });
+
+    const startCancelled = await fetch(
+      `${server.url}/api/organised-games/${game.id}/start`,
+      { method: "POST", headers: { Cookie: cookie("user-a") } },
+    );
+    expect(startCancelled.status).toBe(409);
+  });
+});

--- a/src/modules/organised-games/entities/invite-token.ts
+++ b/src/modules/organised-games/entities/invite-token.ts
@@ -1,0 +1,31 @@
+import { randomBytes } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+export const INVITE_TOKEN_LENGTH = 32;
+const INVITE_TOKEN_PATTERN = /^[a-f0-9]+$/;
+
+export class InviteToken {
+  private constructor(readonly value: string) {}
+
+  static generate(): InviteToken {
+    return new InviteToken(randomBytes(16).toString("hex"));
+  }
+
+  static from(raw: unknown): InviteToken {
+    const value = requiredTrimmed(raw, "inviteToken").toLowerCase();
+    if (value.length !== INVITE_TOKEN_LENGTH) {
+      throw new DomainError(
+        `inviteToken must be ${INVITE_TOKEN_LENGTH} characters`,
+      );
+    }
+    if (!INVITE_TOKEN_PATTERN.test(value)) {
+      throw new DomainError("inviteToken is invalid");
+    }
+    return new InviteToken(value);
+  }
+
+  equals(other: InviteToken): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-capacity-error.ts
+++ b/src/modules/organised-games/entities/organised-game-capacity-error.ts
@@ -1,0 +1,6 @@
+export class OrganisedGameCapacityError extends Error {
+  constructor(message = "This organised game is full") {
+    super(message);
+    this.name = "OrganisedGameCapacityError";
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-capacity.ts
+++ b/src/modules/organised-games/entities/organised-game-capacity.ts
@@ -1,0 +1,31 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const CAPACITY_MIN = 2;
+export const CAPACITY_MAX = 8;
+
+export class OrganisedGameCapacity {
+  private constructor(readonly value: number) {}
+
+  static from(raw: unknown, fallback: number): OrganisedGameCapacity {
+    if (raw == null) {
+      return OrganisedGameCapacity.fromNumber(fallback);
+    }
+
+    if (typeof raw !== "number" || !Number.isInteger(raw)) {
+      throw new DomainError(
+        `capacity must be an integer between ${CAPACITY_MIN} and ${CAPACITY_MAX}`,
+      );
+    }
+
+    return OrganisedGameCapacity.fromNumber(raw);
+  }
+
+  private static fromNumber(value: number): OrganisedGameCapacity {
+    if (value < CAPACITY_MIN || value > CAPACITY_MAX) {
+      throw new DomainError(
+        `capacity must be an integer between ${CAPACITY_MIN} and ${CAPACITY_MAX}`,
+      );
+    }
+    return new OrganisedGameCapacity(value);
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-forbidden-error.ts
+++ b/src/modules/organised-games/entities/organised-game-forbidden-error.ts
@@ -1,0 +1,6 @@
+export class OrganisedGameForbiddenError extends Error {
+  constructor(message = "Not allowed for this organised game") {
+    super(message);
+    this.name = "OrganisedGameForbiddenError";
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-invite.ts
+++ b/src/modules/organised-games/entities/organised-game-invite.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from "node:crypto";
+
+import { requiredTrimmed } from "../../../lib/domain-error";
+import { OrganisedGameRsvp } from "./organised-game-rsvp";
+
+export type OrganisedGameInviteSnapshot = {
+  id: string;
+  userId: string;
+  rsvp: "pending" | "accepted" | "declined";
+  invitedAt: string;
+  respondedAt: string | null;
+};
+
+export class OrganisedGameInvite {
+  private constructor(
+    readonly id: string,
+    readonly userId: string,
+    private rsvpValue: OrganisedGameRsvp,
+    readonly invitedAt: Date,
+    private respondedAtValue: Date | null,
+  ) {}
+
+  static pending(userId: string, invitedAt = new Date()): OrganisedGameInvite {
+    return new OrganisedGameInvite(
+      randomUUID(),
+      requiredTrimmed(userId, "userId"),
+      OrganisedGameRsvp.PENDING,
+      invitedAt,
+      null,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    userId: string;
+    rsvp: OrganisedGameRsvp;
+    invitedAt: Date;
+    respondedAt: Date | null;
+  }): OrganisedGameInvite {
+    return new OrganisedGameInvite(
+      props.id,
+      props.userId,
+      props.rsvp,
+      props.invitedAt,
+      props.respondedAt,
+    );
+  }
+
+  get rsvp(): OrganisedGameRsvp {
+    return this.rsvpValue;
+  }
+
+  get respondedAt(): Date | null {
+    return this.respondedAtValue;
+  }
+
+  setRsvp(rsvp: OrganisedGameRsvp, now = new Date()): void {
+    this.rsvpValue = rsvp;
+    this.respondedAtValue = rsvp.isPending ? null : now;
+  }
+
+  toSnapshot(): OrganisedGameInviteSnapshot {
+    return {
+      id: this.id,
+      userId: this.userId,
+      rsvp: this.rsvpValue.value,
+      invitedAt: this.invitedAt.toISOString(),
+      respondedAt: this.respondedAtValue?.toISOString() ?? null,
+    };
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-not-found-error.ts
+++ b/src/modules/organised-games/entities/organised-game-not-found-error.ts
@@ -1,0 +1,6 @@
+export class OrganisedGameNotFoundError extends Error {
+  constructor(message = "Organised game not found") {
+    super(message);
+    this.name = "OrganisedGameNotFoundError";
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-not-friend-error.ts
+++ b/src/modules/organised-games/entities/organised-game-not-friend-error.ts
@@ -1,0 +1,6 @@
+export class OrganisedGameNotFriendError extends Error {
+  constructor(message = "Can only invite an accepted friend") {
+    super(message);
+    this.name = "OrganisedGameNotFriendError";
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-not-open-error.ts
+++ b/src/modules/organised-games/entities/organised-game-not-open-error.ts
@@ -1,0 +1,6 @@
+export class OrganisedGameNotOpenError extends Error {
+  constructor(message = "Organised game is not open") {
+    super(message);
+    this.name = "OrganisedGameNotOpenError";
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-notes.ts
+++ b/src/modules/organised-games/entities/organised-game-notes.ts
@@ -1,0 +1,23 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const NOTES_MAX_LENGTH = 280;
+
+export class OrganisedGameNotes {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): OrganisedGameNotes | null {
+    if (raw == null) return null;
+    if (typeof raw !== "string") {
+      throw new DomainError("notes must be a string");
+    }
+
+    const notes = raw.trim();
+    if (notes.length === 0) return null;
+    if (notes.length > NOTES_MAX_LENGTH) {
+      throw new DomainError(
+        `notes must be at most ${NOTES_MAX_LENGTH} characters`,
+      );
+    }
+    return new OrganisedGameNotes(notes);
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-persistence-error.ts
+++ b/src/modules/organised-games/entities/organised-game-persistence-error.ts
@@ -1,0 +1,9 @@
+export class OrganisedGamePersistenceError extends Error {
+  constructor(
+    message = "Unable to save organised game",
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "OrganisedGamePersistenceError";
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-rsvp.ts
+++ b/src/modules/organised-games/entities/organised-game-rsvp.ts
@@ -1,0 +1,55 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const ORGANISED_GAME_RSVPS = ["pending", "accepted", "declined"] as const;
+export type OrganisedGameRsvpValue = (typeof ORGANISED_GAME_RSVPS)[number];
+
+export class OrganisedGameRsvp {
+  static readonly PENDING = new OrganisedGameRsvp("pending");
+  static readonly ACCEPTED = new OrganisedGameRsvp("accepted");
+  static readonly DECLINED = new OrganisedGameRsvp("declined");
+
+  private constructor(readonly value: OrganisedGameRsvpValue) {}
+
+  static from(raw: unknown): OrganisedGameRsvp {
+    if (typeof raw !== "string") {
+      throw new DomainError("rsvp must be pending, accepted, or declined");
+    }
+
+    const rsvp = raw.trim().toLowerCase();
+    if (rsvp === "pending") return OrganisedGameRsvp.PENDING;
+    if (rsvp === "accepted") return OrganisedGameRsvp.ACCEPTED;
+    if (rsvp === "declined") return OrganisedGameRsvp.DECLINED;
+
+    throw new DomainError("rsvp must be pending, accepted, or declined");
+  }
+
+  /** Invitee-facing command: accept or decline only. */
+  static fromDecision(raw: unknown): OrganisedGameRsvp {
+    const rsvp = OrganisedGameRsvp.from(raw);
+    if (rsvp.isPending) {
+      throw new DomainError("rsvp must be accepted or declined");
+    }
+    return rsvp;
+  }
+
+  get isPending(): boolean {
+    return this.value === "pending";
+  }
+
+  get isAccepted(): boolean {
+    return this.value === "accepted";
+  }
+
+  get isDeclined(): boolean {
+    return this.value === "declined";
+  }
+
+  /** Occupies a capacity slot (host always occupies one separately). */
+  get occupiesSlot(): boolean {
+    return !this.isDeclined;
+  }
+
+  equals(other: OrganisedGameRsvp): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-sport.ts
+++ b/src/modules/organised-games/entities/organised-game-sport.ts
@@ -1,0 +1,43 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const ORGANISED_GAME_SPORTS = ["padel", "golf"] as const;
+export type OrganisedGameSportValue = (typeof ORGANISED_GAME_SPORTS)[number];
+
+export class OrganisedGameSport {
+  static readonly PADEL = new OrganisedGameSport("padel");
+  static readonly GOLF = new OrganisedGameSport("golf");
+
+  private constructor(readonly value: OrganisedGameSportValue) {}
+
+  static from(raw: unknown): OrganisedGameSport {
+    if (typeof raw !== "string") {
+      throw new DomainError("sport must be padel or golf");
+    }
+
+    const sport = raw.trim().toLowerCase();
+    if (sport === "padel") return OrganisedGameSport.PADEL;
+    if (sport === "golf") return OrganisedGameSport.GOLF;
+
+    throw new DomainError("sport must be padel or golf");
+  }
+
+  get isPadel(): boolean {
+    return this.value === "padel";
+  }
+
+  get isGolf(): boolean {
+    return this.value === "golf";
+  }
+
+  equals(other: OrganisedGameSport): boolean {
+    return this.value === other.value;
+  }
+
+  livePath(scorecardId: string): string {
+    return this.isPadel ? `/padel/${scorecardId}` : `/golf/${scorecardId}`;
+  }
+
+  defaultCapacity(): number {
+    return 4;
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-start-window-error.ts
+++ b/src/modules/organised-games/entities/organised-game-start-window-error.ts
@@ -1,0 +1,8 @@
+export class OrganisedGameStartWindowError extends Error {
+  constructor(
+    message = "Host can start from 12 hours before startsAt until 24 hours after",
+  ) {
+    super(message);
+    this.name = "OrganisedGameStartWindowError";
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-status.ts
+++ b/src/modules/organised-games/entities/organised-game-status.ts
@@ -1,0 +1,41 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const ORGANISED_GAME_STATUSES = ["open", "started", "cancelled"] as const;
+export type OrganisedGameStatusValue = (typeof ORGANISED_GAME_STATUSES)[number];
+
+export class OrganisedGameStatus {
+  static readonly OPEN = new OrganisedGameStatus("open");
+  static readonly STARTED = new OrganisedGameStatus("started");
+  static readonly CANCELLED = new OrganisedGameStatus("cancelled");
+
+  private constructor(readonly value: OrganisedGameStatusValue) {}
+
+  static from(raw: unknown): OrganisedGameStatus {
+    if (typeof raw !== "string") {
+      throw new DomainError("status must be open, started, or cancelled");
+    }
+
+    const status = raw.trim().toLowerCase();
+    if (status === "open") return OrganisedGameStatus.OPEN;
+    if (status === "started") return OrganisedGameStatus.STARTED;
+    if (status === "cancelled") return OrganisedGameStatus.CANCELLED;
+
+    throw new DomainError("status must be open, started, or cancelled");
+  }
+
+  get isOpen(): boolean {
+    return this.value === "open";
+  }
+
+  get isStarted(): boolean {
+    return this.value === "started";
+  }
+
+  get isCancelled(): boolean {
+    return this.value === "cancelled";
+  }
+
+  equals(other: OrganisedGameStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/organised-games/entities/organised-game-venue-not-found-error.ts
+++ b/src/modules/organised-games/entities/organised-game-venue-not-found-error.ts
@@ -1,0 +1,6 @@
+export class OrganisedGameVenueNotFoundError extends Error {
+  constructor(message = "Venue not found") {
+    super(message);
+    this.name = "OrganisedGameVenueNotFoundError";
+  }
+}

--- a/src/modules/organised-games/entities/organised-game.test.ts
+++ b/src/modules/organised-games/entities/organised-game.test.ts
@@ -1,0 +1,148 @@
+import { DomainError } from "../../../lib/domain-error";
+import { CmsId } from "../../venue/entities/cms-id";
+import { InviteToken } from "./invite-token";
+import { OrganisedGame } from "./organised-game";
+import { OrganisedGameCapacity } from "./organised-game-capacity";
+import { OrganisedGameCapacityError } from "./organised-game-capacity-error";
+import { OrganisedGameForbiddenError } from "./organised-game-forbidden-error";
+import { OrganisedGameNotOpenError } from "./organised-game-not-open-error";
+import { OrganisedGameNotes } from "./organised-game-notes";
+import { OrganisedGameRsvp } from "./organised-game-rsvp";
+import { OrganisedGameSport } from "./organised-game-sport";
+import { OrganisedGameStartWindowError } from "./organised-game-start-window-error";
+import { OrganisedGameStatus } from "./organised-game-status";
+import { StartsAt } from "./starts-at";
+
+function createOpenGame(overrides: { startsAt?: string } = {}) {
+  return OrganisedGame.create({
+    hostUserId: "host-1",
+    sport: OrganisedGameSport.from("padel"),
+    venueCmsId: CmsId.from("sanity-court-1"),
+    startsAt: StartsAt.from(overrides.startsAt ?? "2026-09-07T18:00:00.000Z"),
+    notes: OrganisedGameNotes.from("Sunday hit"),
+    capacity: OrganisedGameCapacity.from(4, 4),
+  });
+}
+
+describe("organised game value objects", () => {
+  test("sport is padel or golf", () => {
+    expect(OrganisedGameSport.from("Padel").value).toBe("padel");
+    expect(OrganisedGameSport.from("golf").livePath("abc")).toBe("/golf/abc");
+    expect(() => OrganisedGameSport.from("darts")).toThrow(DomainError);
+  });
+
+  test("status and rsvp are closed sets", () => {
+    expect(OrganisedGameStatus.from("open").isOpen).toBe(true);
+    expect(() => OrganisedGameStatus.from("live")).toThrow(DomainError);
+    expect(OrganisedGameRsvp.fromDecision("accepted").isAccepted).toBe(true);
+    expect(() => OrganisedGameRsvp.fromDecision("pending")).toThrow(
+      DomainError,
+    );
+  });
+
+  test("notes trim, omit blanks, and cap length", () => {
+    expect(OrganisedGameNotes.from("  hi  ")?.value).toBe("hi");
+    expect(OrganisedGameNotes.from("  ")).toBeNull();
+    expect(() => OrganisedGameNotes.from("x".repeat(281))).toThrow(DomainError);
+  });
+
+  test("capacity is 2–8", () => {
+    expect(OrganisedGameCapacity.from(undefined, 4).value).toBe(4);
+    expect(() => OrganisedGameCapacity.from(1, 4)).toThrow(DomainError);
+    expect(() => OrganisedGameCapacity.from(9, 4)).toThrow(DomainError);
+  });
+});
+
+describe(OrganisedGame, () => {
+  test("create mints an unguessable invite token and starts open", () => {
+    const game = createOpenGame();
+    const snapshot = game.toSnapshot();
+
+    expect(game.id).toBeTruthy();
+    expect(snapshot).toMatchObject({
+      hostUserId: "host-1",
+      sport: "padel",
+      status: "open",
+      venueCmsId: "sanity-court-1",
+      notes: "Sunday hit",
+      capacity: 4,
+      live: null,
+    });
+    expect(snapshot.inviteToken).toHaveLength(32);
+    expect(game.invites).toHaveLength(0);
+    expect(game.occupiedCount()).toBe(1);
+  });
+
+  test("invite is idempotent, rejects host, and respects capacity", () => {
+    const game = createOpenGame();
+    game.addInvitee("friend-a");
+    game.addInvitee("  friend-a  ");
+    expect(game.invites).toHaveLength(1);
+
+    expect(() => game.addInvitee("host-1")).toThrow(DomainError);
+
+    game.addInvitee("friend-b");
+    game.addInvitee("friend-c");
+    expect(game.isAtCapacity()).toBe(true);
+    expect(() => game.addInvitee("friend-d")).toThrow(
+      OrganisedGameCapacityError,
+    );
+
+    game.rsvp("friend-c", OrganisedGameRsvp.fromDecision("declined"));
+    expect(game.isAtCapacity()).toBe(false);
+    game.addInvitee("friend-d");
+    expect(game.inviteOf("friend-d")?.rsvp.isPending).toBe(true);
+  });
+
+  test("only an invitee can RSVP; host without an invite cannot", () => {
+    const game = createOpenGame();
+    expect(() =>
+      game.rsvp("host-1", OrganisedGameRsvp.fromDecision("accepted")),
+    ).toThrow(OrganisedGameForbiddenError);
+
+    game.addInvitee("friend-a");
+    game.rsvp("friend-a", OrganisedGameRsvp.fromDecision("accepted"));
+    expect(game.inviteOf("friend-a")?.rsvp.isAccepted).toBe(true);
+    expect(game.inviteOf("friend-a")?.respondedAt).toBeTruthy();
+  });
+
+  test("start is host-windowed and idempotent once live", () => {
+    const startsAt = new Date("2026-09-07T18:00:00.000Z");
+    const game = createOpenGame({ startsAt: startsAt.toISOString() });
+
+    expect(() =>
+      game.start(
+        { id: "match-1", path: "/padel/match-1" },
+        new Date(startsAt.getTime() - 13 * 60 * 60 * 1000),
+      ),
+    ).toThrow(OrganisedGameStartWindowError);
+
+    game.start(
+      { id: "match-1", path: "/padel/match-1" },
+      new Date(startsAt.getTime() - 60 * 60 * 1000),
+    );
+    expect(game.status.isStarted).toBe(true);
+    expect(game.live).toEqual({ id: "match-1", path: "/padel/match-1" });
+
+    game.start(
+      { id: "match-2", path: "/padel/match-2" },
+      new Date(startsAt.getTime()),
+    );
+    expect(game.live?.id).toBe("match-1");
+  });
+
+  test("cancel and start require open status", () => {
+    const game = createOpenGame();
+    game.cancel();
+    expect(game.status.isCancelled).toBe(true);
+    expect(() => game.addInvitee("friend-a")).toThrow(OrganisedGameNotOpenError);
+    expect(() => game.cancel()).toThrow(OrganisedGameNotOpenError);
+  });
+
+  test("fromSnapshot round-trips", () => {
+    const game = createOpenGame();
+    game.addInvitee("friend-a");
+    const copy = OrganisedGame.fromSnapshot(game.toSnapshot());
+    expect(copy.toSnapshot()).toEqual(game.toSnapshot());
+  });
+});

--- a/src/modules/organised-games/entities/organised-game.ts
+++ b/src/modules/organised-games/entities/organised-game.ts
@@ -1,0 +1,296 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { CmsId } from "../../venue/entities/cms-id";
+import { InviteToken } from "./invite-token";
+import { OrganisedGameCapacity } from "./organised-game-capacity";
+import { OrganisedGameCapacityError } from "./organised-game-capacity-error";
+import { OrganisedGameForbiddenError } from "./organised-game-forbidden-error";
+import { OrganisedGameInvite } from "./organised-game-invite";
+import { OrganisedGameNotOpenError } from "./organised-game-not-open-error";
+import { OrganisedGameNotes } from "./organised-game-notes";
+import { OrganisedGameRsvp } from "./organised-game-rsvp";
+import { OrganisedGameSport } from "./organised-game-sport";
+import { OrganisedGameStartWindowError } from "./organised-game-start-window-error";
+import { OrganisedGameStatus } from "./organised-game-status";
+import { StartsAt } from "./starts-at";
+
+/** Host may start from 12 hours before `startsAt` until 24 hours after. */
+export const START_WINDOW_BEFORE_MS = 12 * 60 * 60 * 1000;
+export const START_WINDOW_AFTER_MS = 24 * 60 * 60 * 1000;
+
+export type LiveScorecardSnapshot = {
+  id: string;
+  path: string;
+};
+
+export type OrganisedGameSnapshot = {
+  id: string;
+  hostUserId: string;
+  sport: "padel" | "golf";
+  status: "open" | "started" | "cancelled";
+  venueCmsId: string;
+  startsAt: string;
+  notes: string | null;
+  capacity: number;
+  inviteToken: string;
+  live: LiveScorecardSnapshot | null;
+  createdAt: string;
+  updatedAt: string;
+  invites: ReturnType<OrganisedGameInvite["toSnapshot"]>[];
+};
+
+export type CreateOrganisedGameProps = {
+  hostUserId: string;
+  sport: OrganisedGameSport;
+  venueCmsId: CmsId;
+  startsAt: StartsAt;
+  notes: OrganisedGameNotes | null;
+  capacity: OrganisedGameCapacity;
+};
+
+export class OrganisedGame {
+  private constructor(
+    readonly id: string,
+    readonly hostUserId: string,
+    readonly sport: OrganisedGameSport,
+    private statusValue: OrganisedGameStatus,
+    readonly venueCmsId: CmsId,
+    readonly startsAt: StartsAt,
+    readonly notes: OrganisedGameNotes | null,
+    readonly capacity: OrganisedGameCapacity,
+    readonly inviteToken: InviteToken,
+    readonly createdAt: Date,
+    private updatedAtValue: Date,
+    private liveScorecardIdValue: string | null,
+    private livePathValue: string | null,
+    private invitesValue: OrganisedGameInvite[],
+  ) {}
+
+  static create(props: CreateOrganisedGameProps): OrganisedGame {
+    const hostUserId = requiredTrimmed(props.hostUserId, "userId");
+    const now = new Date();
+    return new OrganisedGame(
+      randomUUID(),
+      hostUserId,
+      props.sport,
+      OrganisedGameStatus.OPEN,
+      props.venueCmsId,
+      props.startsAt,
+      props.notes,
+      props.capacity,
+      InviteToken.generate(),
+      now,
+      now,
+      null,
+      null,
+      [],
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    hostUserId: string;
+    sport: OrganisedGameSport;
+    status: OrganisedGameStatus;
+    venueCmsId: CmsId;
+    startsAt: StartsAt;
+    notes: OrganisedGameNotes | null;
+    capacity: OrganisedGameCapacity;
+    inviteToken: InviteToken;
+    createdAt: Date;
+    updatedAt: Date;
+    liveScorecardId: string | null;
+    livePath: string | null;
+    invites: OrganisedGameInvite[];
+  }): OrganisedGame {
+    return new OrganisedGame(
+      props.id,
+      props.hostUserId,
+      props.sport,
+      props.status,
+      props.venueCmsId,
+      props.startsAt,
+      props.notes,
+      props.capacity,
+      props.inviteToken,
+      props.createdAt,
+      props.updatedAt,
+      props.liveScorecardId,
+      props.livePath,
+      [...props.invites],
+    );
+  }
+
+  static fromSnapshot(snapshot: OrganisedGameSnapshot): OrganisedGame {
+    return OrganisedGame.rehydrate({
+      id: snapshot.id,
+      hostUserId: snapshot.hostUserId,
+      sport: OrganisedGameSport.from(snapshot.sport),
+      status: OrganisedGameStatus.from(snapshot.status),
+      venueCmsId: CmsId.from(snapshot.venueCmsId),
+      startsAt: StartsAt.from(snapshot.startsAt),
+      notes: OrganisedGameNotes.from(snapshot.notes),
+      capacity: OrganisedGameCapacity.from(
+        snapshot.capacity,
+        snapshot.capacity,
+      ),
+      inviteToken: InviteToken.from(snapshot.inviteToken),
+      createdAt: new Date(snapshot.createdAt),
+      updatedAt: new Date(snapshot.updatedAt),
+      liveScorecardId: snapshot.live?.id ?? null,
+      livePath: snapshot.live?.path ?? null,
+      invites: snapshot.invites.map((invite) =>
+        OrganisedGameInvite.rehydrate({
+          id: invite.id,
+          userId: invite.userId,
+          rsvp: OrganisedGameRsvp.from(invite.rsvp),
+          invitedAt: new Date(invite.invitedAt),
+          respondedAt: invite.respondedAt ? new Date(invite.respondedAt) : null,
+        }),
+      ),
+    });
+  }
+
+  get status(): OrganisedGameStatus {
+    return this.statusValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  get invites(): readonly OrganisedGameInvite[] {
+    return this.invitesValue;
+  }
+
+  get live(): LiveScorecardSnapshot | null {
+    if (!this.liveScorecardIdValue || !this.livePathValue) return null;
+    return { id: this.liveScorecardIdValue, path: this.livePathValue };
+  }
+
+  isHost(userId: string): boolean {
+    return this.hostUserId === userId.trim();
+  }
+
+  inviteOf(userId: string): OrganisedGameInvite | null {
+    const id = userId.trim();
+    return this.invitesValue.find((invite) => invite.userId === id) ?? null;
+  }
+
+  isParticipant(userId: string): boolean {
+    return this.isHost(userId) || this.inviteOf(userId) != null;
+  }
+
+  /** Host + non-declined invitees. */
+  occupiedCount(): number {
+    const inviteSlots = this.invitesValue.filter((invite) =>
+      invite.rsvp.occupiesSlot,
+    ).length;
+    return 1 + inviteSlots;
+  }
+
+  isAtCapacity(): boolean {
+    return this.occupiedCount() >= this.capacity.value;
+  }
+
+  acceptedInvitees(): OrganisedGameInvite[] {
+    return this.invitesValue.filter((invite) => invite.rsvp.isAccepted);
+  }
+
+  isWithinStartWindow(now = new Date()): boolean {
+    const start = this.startsAt.value.getTime();
+    const t = now.getTime();
+    return (
+      t >= start - START_WINDOW_BEFORE_MS && t <= start + START_WINDOW_AFTER_MS
+    );
+  }
+
+  addInvitee(userId: string, now = new Date()): OrganisedGameInvite {
+    const id = requiredTrimmed(userId, "userId");
+    if (id === this.hostUserId) {
+      throw new DomainError("Host cannot be invited as an invitee");
+    }
+    if (!this.statusValue.isOpen) {
+      throw new OrganisedGameNotOpenError();
+    }
+
+    const existing = this.inviteOf(id);
+    if (existing) return existing;
+
+    if (this.isAtCapacity()) {
+      throw new OrganisedGameCapacityError();
+    }
+
+    const invite = OrganisedGameInvite.pending(id, now);
+    this.invitesValue = [...this.invitesValue, invite];
+    this.touch(now);
+    return invite;
+  }
+
+  rsvp(userId: string, decision: OrganisedGameRsvp, now = new Date()): void {
+    const id = requiredTrimmed(userId, "userId");
+    if (!this.statusValue.isOpen) {
+      throw new OrganisedGameNotOpenError();
+    }
+
+    const invite = this.inviteOf(id);
+    if (!invite) {
+      throw new OrganisedGameForbiddenError(
+        "Only an invitee can RSVP this organised game",
+      );
+    }
+
+    invite.setRsvp(decision, now);
+    this.touch(now);
+  }
+
+  start(live: LiveScorecardSnapshot, now = new Date()): void {
+    if (this.statusValue.isStarted && this.live) {
+      return;
+    }
+    if (!this.statusValue.isOpen) {
+      throw new OrganisedGameNotOpenError();
+    }
+    if (!this.isWithinStartWindow(now)) {
+      throw new OrganisedGameStartWindowError();
+    }
+
+    const id = requiredTrimmed(live.id, "liveScorecardId");
+    const path = requiredTrimmed(live.path, "livePath");
+    this.statusValue = OrganisedGameStatus.STARTED;
+    this.liveScorecardIdValue = id;
+    this.livePathValue = path;
+    this.touch(now);
+  }
+
+  cancel(now = new Date()): void {
+    if (!this.statusValue.isOpen) {
+      throw new OrganisedGameNotOpenError();
+    }
+    this.statusValue = OrganisedGameStatus.CANCELLED;
+    this.touch(now);
+  }
+
+  toSnapshot(): OrganisedGameSnapshot {
+    return {
+      id: this.id,
+      hostUserId: this.hostUserId,
+      sport: this.sport.value,
+      status: this.statusValue.value,
+      venueCmsId: this.venueCmsId.value,
+      startsAt: this.startsAt.toIsoString(),
+      notes: this.notes?.value ?? null,
+      capacity: this.capacity.value,
+      inviteToken: this.inviteToken.value,
+      live: this.live,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+      invites: this.invitesValue.map((invite) => invite.toSnapshot()),
+    };
+  }
+
+  private touch(now: Date): void {
+    this.updatedAtValue = now;
+  }
+}

--- a/src/modules/organised-games/entities/starts-at.ts
+++ b/src/modules/organised-games/entities/starts-at.ts
@@ -1,0 +1,29 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export class StartsAt {
+  private constructor(readonly value: Date) {}
+
+  static from(raw: unknown): StartsAt {
+    if (raw instanceof Date) {
+      if (Number.isNaN(raw.getTime())) {
+        throw new DomainError("startsAt must be a valid date");
+      }
+      return new StartsAt(raw);
+    }
+
+    if (typeof raw !== "string" || raw.trim().length === 0) {
+      throw new DomainError("startsAt is required");
+    }
+
+    const parsed = new Date(raw);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new DomainError("startsAt must be a valid date");
+    }
+
+    return new StartsAt(parsed);
+  }
+
+  toIsoString(): string {
+    return this.value.toISOString();
+  }
+}

--- a/src/modules/organised-games/index.ts
+++ b/src/modules/organised-games/index.ts
@@ -1,0 +1,149 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import {
+  FriendProfileLookup,
+  FriendshipRepository,
+} from "../friends/repositories/friendship.repository";
+import { GolfRoundRepository } from "../golf-round/repositories/golf-round.repository";
+import { CreateGolfRound } from "../golf-round/services/create-golf-round.service";
+import { MatchRepository } from "../match/repositories/match.repository";
+import { CreateMatch } from "../match/services/create-match.service";
+import { VenueRepository } from "../venue/repositories/venue.repository";
+import { createOrganisedGamesController } from "./controllers/organised-games.controller";
+import { OrganisedGameRepository } from "./repositories/organised-game.repository";
+import { PrismaOrganisedGameRepository } from "./repositories/prisma-organised-game.repository";
+import { createOrganisedGamesRoutes } from "./routes/organised-games.routes";
+import {
+  CancelOrganisedGame,
+  CreateOrganisedGame,
+  GetOrganisedGame,
+  GetOrganisedGameByToken,
+  InviteFriends,
+  JoinByInviteToken,
+  ListInvites,
+  ListMyOrganisedGames,
+  RsvpOrganisedGame,
+  StartOrganisedGame,
+} from "./services/organised-games.service";
+
+export type CreateOrganisedGamesModuleParams = {
+  prisma: PrismaClient;
+  venueRepository: VenueRepository;
+  friendshipRepository: FriendshipRepository;
+  friendProfileLookup: FriendProfileLookup;
+  matchRepository: MatchRepository;
+  golfRoundRepository: GolfRoundRepository;
+  organisedGameRepository?: OrganisedGameRepository;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type OrganisedGamesModule = {
+  router: Router;
+  organisedGameRepository: OrganisedGameRepository;
+};
+
+export function createOrganisedGamesModule({
+  prisma,
+  venueRepository,
+  friendshipRepository,
+  friendProfileLookup,
+  matchRepository,
+  golfRoundRepository,
+  organisedGameRepository: organisedGameRepositoryOverride,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreateOrganisedGamesModuleParams): OrganisedGamesModule {
+  const organisedGameRepository =
+    organisedGameRepositoryOverride ??
+    new PrismaOrganisedGameRepository(prisma);
+
+  const controller = createOrganisedGamesController({
+    createOrganisedGame: new CreateOrganisedGame(
+      organisedGameRepository,
+      venueRepository,
+      friendshipRepository,
+      friendProfileLookup,
+    ),
+    getOrganisedGame: new GetOrganisedGame(
+      organisedGameRepository,
+      friendProfileLookup,
+    ),
+    getOrganisedGameByToken: new GetOrganisedGameByToken(
+      organisedGameRepository,
+      friendProfileLookup,
+    ),
+    listMyOrganisedGames: new ListMyOrganisedGames(
+      organisedGameRepository,
+      friendProfileLookup,
+    ),
+    inviteFriends: new InviteFriends(
+      organisedGameRepository,
+      friendshipRepository,
+      friendProfileLookup,
+    ),
+    listInvites: new ListInvites(organisedGameRepository, friendProfileLookup),
+    joinByInviteToken: new JoinByInviteToken(
+      organisedGameRepository,
+      friendProfileLookup,
+    ),
+    rsvpOrganisedGame: new RsvpOrganisedGame(
+      organisedGameRepository,
+      friendProfileLookup,
+    ),
+    cancelOrganisedGame: new CancelOrganisedGame(
+      organisedGameRepository,
+      friendProfileLookup,
+    ),
+    startOrganisedGame: new StartOrganisedGame(
+      organisedGameRepository,
+      friendProfileLookup,
+      new CreateMatch(matchRepository, venueRepository),
+      new CreateGolfRound(golfRoundRepository, venueRepository),
+    ),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createOrganisedGamesRoutes(controller, { requireAuth }),
+    organisedGameRepository,
+  };
+}
+
+export { createOrganisedGamesController } from "./controllers/organised-games.controller";
+export { InMemoryOrganisedGameRepository } from "./repositories/in-memory-organised-game.repository";
+export { PrismaOrganisedGameRepository } from "./repositories/prisma-organised-game.repository";
+export type { OrganisedGameRepository } from "./repositories/organised-game.repository";
+export { OrganisedGame } from "./entities/organised-game";
+export {
+  START_WINDOW_AFTER_MS,
+  START_WINDOW_BEFORE_MS,
+} from "./entities/organised-game";
+export { OrganisedGameSport } from "./entities/organised-game-sport";
+export { OrganisedGameStatus } from "./entities/organised-game-status";
+export { OrganisedGameRsvp } from "./entities/organised-game-rsvp";
+export { InviteToken } from "./entities/invite-token";
+export {
+  CancelOrganisedGame,
+  CreateOrganisedGame,
+  GetOrganisedGame,
+  GetOrganisedGameByToken,
+  InviteFriends,
+  JoinByInviteToken,
+  ListInvites,
+  ListMyOrganisedGames,
+  RsvpOrganisedGame,
+  StartOrganisedGame,
+} from "./services/organised-games.service";
+export type {
+  PublicInvitee,
+  PublicLiveScorecard,
+  PublicOrganisedGame,
+  PublicUser,
+} from "./services/organised-games.service";

--- a/src/modules/organised-games/repositories/in-memory-organised-game.repository.ts
+++ b/src/modules/organised-games/repositories/in-memory-organised-game.repository.ts
@@ -1,0 +1,55 @@
+import { OrganisedGame } from "../entities/organised-game";
+import { OrganisedGamePersistenceError } from "../entities/organised-game-persistence-error";
+import { OrganisedGameRepository } from "./organised-game.repository";
+
+export class InMemoryOrganisedGameRepository implements OrganisedGameRepository {
+  private readonly byId = new Map<string, OrganisedGame>();
+
+  async findById(id: string): Promise<OrganisedGame | null> {
+    return clone(this.byId.get(id) ?? null);
+  }
+
+  async findByInviteToken(token: string): Promise<OrganisedGame | null> {
+    const value = token.trim().toLowerCase();
+    for (const game of this.byId.values()) {
+      if (game.inviteToken.value === value) {
+        return clone(game)!;
+      }
+    }
+    return null;
+  }
+
+  async create(game: OrganisedGame): Promise<OrganisedGame> {
+    const stored = clone(game)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async persist(game: OrganisedGame): Promise<OrganisedGame> {
+    if (!this.byId.has(game.id)) {
+      throw new OrganisedGamePersistenceError("Unable to save organised game");
+    }
+    const stored = clone(game)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async listHostedBy(hostUserId: string): Promise<OrganisedGame[]> {
+    return [...this.byId.values()]
+      .filter((game) => game.hostUserId === hostUserId)
+      .sort((a, b) => b.startsAt.value.getTime() - a.startsAt.value.getTime())
+      .map((game) => clone(game)!);
+  }
+
+  async listInvitedUser(userId: string): Promise<OrganisedGame[]> {
+    return [...this.byId.values()]
+      .filter((game) => game.inviteOf(userId))
+      .sort((a, b) => b.startsAt.value.getTime() - a.startsAt.value.getTime())
+      .map((game) => clone(game)!);
+  }
+}
+
+function clone(game: OrganisedGame | null): OrganisedGame | null {
+  if (!game) return null;
+  return OrganisedGame.fromSnapshot(game.toSnapshot());
+}

--- a/src/modules/organised-games/repositories/organised-game.repository.ts
+++ b/src/modules/organised-games/repositories/organised-game.repository.ts
@@ -1,0 +1,10 @@
+import { OrganisedGame } from "../entities/organised-game";
+
+export interface OrganisedGameRepository {
+  findById(id: string): Promise<OrganisedGame | null>;
+  findByInviteToken(token: string): Promise<OrganisedGame | null>;
+  create(game: OrganisedGame): Promise<OrganisedGame>;
+  persist(game: OrganisedGame): Promise<OrganisedGame>;
+  listHostedBy(hostUserId: string): Promise<OrganisedGame[]>;
+  listInvitedUser(userId: string): Promise<OrganisedGame[]>;
+}

--- a/src/modules/organised-games/repositories/prisma-organised-game.repository.ts
+++ b/src/modules/organised-games/repositories/prisma-organised-game.repository.ts
@@ -1,0 +1,246 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { CmsId } from "../../venue/entities/cms-id";
+import { InviteToken } from "../entities/invite-token";
+import { OrganisedGame } from "../entities/organised-game";
+import { OrganisedGameCapacity } from "../entities/organised-game-capacity";
+import { OrganisedGameInvite } from "../entities/organised-game-invite";
+import { OrganisedGameNotes } from "../entities/organised-game-notes";
+import { OrganisedGamePersistenceError } from "../entities/organised-game-persistence-error";
+import { OrganisedGameRsvp } from "../entities/organised-game-rsvp";
+import { OrganisedGameSport } from "../entities/organised-game-sport";
+import { OrganisedGameStatus } from "../entities/organised-game-status";
+import { OrganisedGameVenueNotFoundError } from "../entities/organised-game-venue-not-found-error";
+import { StartsAt } from "../entities/starts-at";
+import { OrganisedGameRepository } from "./organised-game.repository";
+
+type InviteRow = {
+  id: string;
+  userId: string;
+  rsvp: "pending" | "accepted" | "declined";
+  createdAt: Date;
+  respondedAt: Date | null;
+};
+
+type GameRow = {
+  id: string;
+  hostUserId: string;
+  sport: "padel" | "golf";
+  status: "open" | "started" | "cancelled";
+  venueCmsId: string;
+  startsAt: Date;
+  notes: string | null;
+  capacity: number;
+  inviteToken: string;
+  liveScorecardId: string | null;
+  livePath: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  invites: InviteRow[];
+};
+
+function prismaErrorCode(error: unknown): string {
+  if (error && typeof error === "object" && "code" in error) {
+    return String((error as { code?: unknown }).code);
+  }
+  return "";
+}
+
+function isForeignKeyViolation(error: unknown): boolean {
+  return prismaErrorCode(error) === "P2003";
+}
+
+function toDomain(row: GameRow): OrganisedGame {
+  return OrganisedGame.rehydrate({
+    id: row.id,
+    hostUserId: row.hostUserId,
+    sport: OrganisedGameSport.from(row.sport),
+    status: OrganisedGameStatus.from(row.status),
+    venueCmsId: CmsId.from(row.venueCmsId),
+    startsAt: StartsAt.from(row.startsAt),
+    notes: OrganisedGameNotes.from(row.notes),
+    capacity: OrganisedGameCapacity.from(row.capacity, row.capacity),
+    inviteToken: InviteToken.from(row.inviteToken),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    liveScorecardId: row.liveScorecardId,
+    livePath: row.livePath,
+    invites: row.invites.map((invite) =>
+      OrganisedGameInvite.rehydrate({
+        id: invite.id,
+        userId: invite.userId,
+        rsvp: OrganisedGameRsvp.from(invite.rsvp),
+        invitedAt: invite.createdAt,
+        respondedAt: invite.respondedAt,
+      }),
+    ),
+  });
+}
+
+export class PrismaOrganisedGameRepository implements OrganisedGameRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(id: string): Promise<OrganisedGame | null> {
+    try {
+      const row = await this.prisma.organisedGame.findUnique({
+        where: { id },
+        include: { invites: { orderBy: { createdAt: "asc" } } },
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new OrganisedGamePersistenceError("Failed to load organised game", {
+        cause: error,
+      });
+    }
+  }
+
+  async findByInviteToken(token: string): Promise<OrganisedGame | null> {
+    try {
+      const row = await this.prisma.organisedGame.findUnique({
+        where: { inviteToken: token.trim().toLowerCase() },
+        include: { invites: { orderBy: { createdAt: "asc" } } },
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new OrganisedGamePersistenceError("Failed to load organised game", {
+        cause: error,
+      });
+    }
+  }
+
+  async create(game: OrganisedGame): Promise<OrganisedGame> {
+    const snapshot = game.toSnapshot();
+    try {
+      const row = await this.prisma.organisedGame.create({
+        data: {
+          id: snapshot.id,
+          hostUserId: snapshot.hostUserId,
+          sport: snapshot.sport,
+          status: snapshot.status,
+          venueCmsId: snapshot.venueCmsId,
+          startsAt: game.startsAt.value,
+          notes: snapshot.notes,
+          capacity: snapshot.capacity,
+          inviteToken: snapshot.inviteToken,
+          liveScorecardId: snapshot.live?.id ?? null,
+          livePath: snapshot.live?.path ?? null,
+          createdAt: game.createdAt,
+          updatedAt: game.updatedAt,
+          invites: {
+            create: snapshot.invites.map((invite) => ({
+              id: invite.id,
+              userId: invite.userId,
+              rsvp: invite.rsvp,
+              createdAt: new Date(invite.invitedAt),
+              respondedAt: invite.respondedAt
+                ? new Date(invite.respondedAt)
+                : null,
+            })),
+          },
+        },
+        include: { invites: { orderBy: { createdAt: "asc" } } },
+      });
+      return toDomain(row);
+    } catch (error) {
+      if (isForeignKeyViolation(error)) {
+        throw new OrganisedGameVenueNotFoundError();
+      }
+      throw new OrganisedGamePersistenceError(
+        "Failed to create organised game",
+        { cause: error },
+      );
+    }
+  }
+
+  async persist(game: OrganisedGame): Promise<OrganisedGame> {
+    const snapshot = game.toSnapshot();
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.organisedGame.update({
+          where: { id: snapshot.id },
+          data: {
+            status: snapshot.status,
+            notes: snapshot.notes,
+            capacity: snapshot.capacity,
+            liveScorecardId: snapshot.live?.id ?? null,
+            livePath: snapshot.live?.path ?? null,
+            updatedAt: game.updatedAt,
+          },
+        });
+
+        for (const invite of snapshot.invites) {
+          try {
+            await tx.organisedGameInvite.upsert({
+              where: {
+                gameId_userId: {
+                  gameId: snapshot.id,
+                  userId: invite.userId,
+                },
+              },
+              create: {
+                id: invite.id,
+                gameId: snapshot.id,
+                userId: invite.userId,
+                rsvp: invite.rsvp,
+                createdAt: new Date(invite.invitedAt),
+                respondedAt: invite.respondedAt
+                  ? new Date(invite.respondedAt)
+                  : null,
+              },
+              update: {
+                rsvp: invite.rsvp,
+                respondedAt: invite.respondedAt
+                  ? new Date(invite.respondedAt)
+                  : null,
+              },
+            });
+          } catch (error) {
+            if (prismaErrorCode(error) !== "P2002") throw error;
+          }
+        }
+      });
+
+      const reloaded = await this.findById(snapshot.id);
+      if (!reloaded) {
+        throw new OrganisedGamePersistenceError("Failed to load organised game");
+      }
+      return reloaded;
+    } catch (error) {
+      if (error instanceof OrganisedGamePersistenceError) throw error;
+      throw new OrganisedGamePersistenceError("Failed to save organised game", {
+        cause: error,
+      });
+    }
+  }
+
+  async listHostedBy(hostUserId: string): Promise<OrganisedGame[]> {
+    try {
+      const rows = await this.prisma.organisedGame.findMany({
+        where: { hostUserId },
+        orderBy: { startsAt: "desc" },
+        include: { invites: { orderBy: { createdAt: "asc" } } },
+      });
+      return rows.map(toDomain);
+    } catch (error) {
+      throw new OrganisedGamePersistenceError(
+        "Failed to list hosted organised games",
+        { cause: error },
+      );
+    }
+  }
+
+  async listInvitedUser(userId: string): Promise<OrganisedGame[]> {
+    try {
+      const rows = await this.prisma.organisedGame.findMany({
+        where: { invites: { some: { userId } } },
+        orderBy: { startsAt: "desc" },
+        include: { invites: { orderBy: { createdAt: "asc" } } },
+      });
+      return rows.map(toDomain);
+    } catch (error) {
+      throw new OrganisedGamePersistenceError(
+        "Failed to list invited organised games",
+        { cause: error },
+      );
+    }
+  }
+}

--- a/src/modules/organised-games/routes/organised-games.routes.ts
+++ b/src/modules/organised-games/routes/organised-games.routes.ts
@@ -1,0 +1,86 @@
+import { Router } from "express";
+
+import { createOrganisedGamesController } from "../controllers/organised-games.controller";
+
+export function createOrganisedGamesRoutes(
+  controller: ReturnType<typeof createOrganisedGamesController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.get("/api/me/organised-games", options.requireAuth, (req, res) => {
+    void controller.me(req, res);
+  });
+
+  router.post("/api/organised-games", options.requireAuth, (req, res) => {
+    void controller.create(req, res);
+  });
+
+  router.get(
+    "/api/organised-games/invite/:token",
+    options.requireAuth,
+    (req, res) => {
+      void controller.getByToken(req, res);
+    },
+  );
+
+  router.post(
+    "/api/organised-games/invite/:token/join",
+    options.requireAuth,
+    (req, res) => {
+      void controller.joinByToken(req, res);
+    },
+  );
+
+  router.get("/api/organised-games/:id", options.requireAuth, (req, res) => {
+    void controller.get(req, res);
+  });
+
+  router.get(
+    "/api/organised-games/:id/invites",
+    options.requireAuth,
+    (req, res) => {
+      void controller.listInvites(req, res);
+    },
+  );
+
+  router.post(
+    "/api/organised-games/:id/invites",
+    options.requireAuth,
+    (req, res) => {
+      void controller.invite(req, res);
+    },
+  );
+
+  router.post(
+    "/api/organised-games/:id/rsvp",
+    options.requireAuth,
+    (req, res) => {
+      void controller.rsvp(req, res);
+    },
+  );
+
+  router.post(
+    "/api/organised-games/:id/start",
+    options.requireAuth,
+    (req, res) => {
+      void controller.start(req, res);
+    },
+  );
+
+  router.post(
+    "/api/organised-games/:id/cancel",
+    options.requireAuth,
+    (req, res) => {
+      void controller.cancel(req, res);
+    },
+  );
+
+  return router;
+}

--- a/src/modules/organised-games/services/default-golf-course.ts
+++ b/src/modules/organised-games/services/default-golf-course.ts
@@ -1,0 +1,10 @@
+export function defaultNineHoleCourse() {
+  return {
+    name: null as string | null,
+    holes: Array.from({ length: 9 }, (_, index) => ({
+      number: index + 1,
+      par: 4,
+      strokeIndex: index + 1,
+    })),
+  };
+}

--- a/src/modules/organised-games/services/organised-games.service.test.ts
+++ b/src/modules/organised-games/services/organised-games.service.test.ts
@@ -1,0 +1,300 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { InMemoryGolfRoundRepository } from "../../golf-round/repositories/in-memory-golf-round.repository";
+import { CreateGolfRound } from "../../golf-round/services/create-golf-round.service";
+import { InMemoryMatchRepository } from "../../match/repositories/in-memory-match.repository";
+import { CreateMatch } from "../../match/services/create-match.service";
+import { OrganisedGameNotFriendError } from "../entities/organised-game-not-friend-error";
+import { OrganisedGameForbiddenError } from "../entities/organised-game-forbidden-error";
+import { OrganisedGameNotFoundError } from "../entities/organised-game-not-found-error";
+import { OrganisedGameStartWindowError } from "../entities/organised-game-start-window-error";
+import { OrganisedGameVenueNotFoundError } from "../entities/organised-game-venue-not-found-error";
+import { InMemoryOrganisedGameRepository } from "../repositories/in-memory-organised-game.repository";
+import {
+  CreateOrganisedGame,
+  GetOrganisedGame,
+  InviteFriends,
+  JoinByInviteToken,
+  ListMyOrganisedGames,
+  RsvpOrganisedGame,
+  StartOrganisedGame,
+} from "./organised-games.service";
+
+const STARTS_AT = "2026-09-07T18:00:00.000Z";
+
+async function seedVenue(venues: InMemoryVenueRepository, cmsId = "sanity-court-1") {
+  await venues.ensureFromCms(
+    Venue.registerFromCms(
+      CmsId.from(cmsId),
+      VenueName.from("Padel Club"),
+      Slug.from("padel-club"),
+    ),
+    { refreshDetails: false },
+  );
+}
+
+async function becomeFriends(
+  friendships: InMemoryFriendshipRepository,
+  a: string,
+  b: string,
+) {
+  const pending = await friendships.createPending(a, b);
+  await friendships.accept(pending.id);
+}
+
+function seedProfiles(profiles: InMemoryFriendProfileLookup) {
+  profiles.seed({
+    userId: "host-1",
+    displayName: "Alex",
+    handle: "alex",
+    avatarUrl: null,
+  });
+  profiles.seed({
+    userId: "friend-a",
+    displayName: "Blake",
+    handle: "blake",
+    avatarUrl: "https://cdn.example/blake.png",
+  });
+  profiles.seed({
+    userId: "friend-b",
+    displayName: "Casey",
+    handle: "casey",
+    avatarUrl: null,
+  });
+  profiles.seed({
+    userId: "stranger",
+    displayName: "Drew",
+    handle: "drew",
+    avatarUrl: null,
+  });
+}
+
+describe("organised games application", () => {
+  test("create requires a known venue and accepted-friend invites", async () => {
+    const venues = new InMemoryVenueRepository();
+    const games = new InMemoryOrganisedGameRepository();
+    const friendships = new InMemoryFriendshipRepository();
+    const profiles = new InMemoryFriendProfileLookup();
+    seedProfiles(profiles);
+    await seedVenue(venues);
+    await becomeFriends(friendships, "host-1", "friend-a");
+
+    const create = new CreateOrganisedGame(
+      games,
+      venues,
+      friendships,
+      profiles,
+    );
+
+    await expect(
+      create.execute({
+        userId: "host-1",
+        sport: "padel",
+        venueCmsId: "missing-venue",
+        startsAt: STARTS_AT,
+      }),
+    ).rejects.toBeInstanceOf(OrganisedGameVenueNotFoundError);
+
+    await expect(
+      create.execute({
+        userId: "host-1",
+        sport: "padel",
+        venueCmsId: "sanity-court-1",
+        startsAt: STARTS_AT,
+        inviteUserIds: ["stranger"],
+      }),
+    ).rejects.toBeInstanceOf(OrganisedGameNotFriendError);
+
+    const { game } = await create.execute({
+      userId: "host-1",
+      sport: "padel",
+      venueCmsId: "sanity-court-1",
+      startsAt: STARTS_AT,
+      notes: "Sunday hit",
+      inviteUserIds: ["friend-a"],
+    });
+
+    expect(game).toMatchObject({
+      sport: "padel",
+      status: "open",
+      venueCmsId: "sanity-court-1",
+      notes: "Sunday hit",
+      capacity: 4,
+      host: { id: "host-1", handle: "alex" },
+      viewer: { role: "host", rsvp: null },
+    });
+    expect(game.inviteToken).toHaveLength(32);
+    expect(game.invitees).toEqual([
+      expect.objectContaining({
+        id: "friend-a",
+        handle: "blake",
+        rsvp: "pending",
+      }),
+    ]);
+  });
+
+  test("stranger cannot GET by id; token join then RSVP; host cannot RSVP", async () => {
+    const venues = new InMemoryVenueRepository();
+    const games = new InMemoryOrganisedGameRepository();
+    const friendships = new InMemoryFriendshipRepository();
+    const profiles = new InMemoryFriendProfileLookup();
+    seedProfiles(profiles);
+    await seedVenue(venues);
+
+    const create = new CreateOrganisedGame(
+      games,
+      venues,
+      friendships,
+      profiles,
+    );
+    const { game } = await create.execute({
+      userId: "host-1",
+      sport: "golf",
+      venueCmsId: "sanity-court-1",
+      startsAt: STARTS_AT,
+    });
+
+    const get = new GetOrganisedGame(games, profiles);
+    await expect(
+      get.execute({ userId: "stranger", gameId: game.id }),
+    ).rejects.toBeInstanceOf(OrganisedGameNotFoundError);
+
+    const join = new JoinByInviteToken(games, profiles);
+    const joined = await join.execute({
+      userId: "stranger",
+      token: game.inviteToken!,
+    });
+    expect(joined.game.viewer).toEqual({ role: "invitee", rsvp: "pending" });
+    expect(joined.game.inviteToken).toBeNull();
+
+    const rsvp = new RsvpOrganisedGame(games, profiles);
+    await expect(
+      rsvp.execute({ userId: "host-1", gameId: game.id, rsvp: "accepted" }),
+    ).rejects.toBeInstanceOf(OrganisedGameForbiddenError);
+
+    const accepted = await rsvp.execute({
+      userId: "stranger",
+      gameId: game.id,
+      rsvp: "accepted",
+    });
+    expect(accepted.game.viewer.rsvp).toBe("accepted");
+
+    const hub = new ListMyOrganisedGames(games, profiles);
+    const listed = await hub.execute({ userId: "stranger" });
+    expect(listed.hosted).toHaveLength(0);
+    expect(listed.invited[0]?.id).toBe(game.id);
+  });
+
+  test("host start seats host + accepted invitees into a live padel match", async () => {
+    const venues = new InMemoryVenueRepository();
+    const games = new InMemoryOrganisedGameRepository();
+    const friendships = new InMemoryFriendshipRepository();
+    const profiles = new InMemoryFriendProfileLookup();
+    const matches = new InMemoryMatchRepository();
+    seedProfiles(profiles);
+    await seedVenue(venues);
+    await becomeFriends(friendships, "host-1", "friend-a");
+    await becomeFriends(friendships, "host-1", "friend-b");
+
+    const create = new CreateOrganisedGame(
+      games,
+      venues,
+      friendships,
+      profiles,
+    );
+    const now = new Date();
+    const { game } = await create.execute({
+      userId: "host-1",
+      sport: "padel",
+      venueCmsId: "sanity-court-1",
+      startsAt: now.toISOString(),
+      inviteUserIds: ["friend-a", "friend-b"],
+    });
+
+    const invite = new InviteFriends(games, friendships, profiles);
+    await expect(
+      invite.execute({
+        userId: "friend-a",
+        gameId: game.id,
+        userIds: ["friend-b"],
+      }),
+    ).rejects.toBeInstanceOf(OrganisedGameForbiddenError);
+
+    const rsvp = new RsvpOrganisedGame(games, profiles);
+    await rsvp.execute({
+      userId: "friend-a",
+      gameId: game.id,
+      rsvp: "accepted",
+    });
+    await rsvp.execute({
+      userId: "friend-b",
+      gameId: game.id,
+      rsvp: "declined",
+    });
+
+    const start = new StartOrganisedGame(
+      games,
+      profiles,
+      new CreateMatch(matches, venues),
+      new CreateGolfRound(new InMemoryGolfRoundRepository(), venues),
+    );
+    const started = await start.execute({ userId: "host-1", gameId: game.id });
+
+    expect(started.game.status).toBe("started");
+    expect(started.live.sport).toBe("padel");
+    expect(started.live.path).toBe(`/padel/${started.live.id}`);
+
+    const match = await matches.findById(started.live.id);
+    expect(match?.toSnapshot().pairings).toMatchObject({
+      teamA: [
+        { userId: "host-1", displayName: "Alex", isGuest: false },
+        { userId: "friend-a", displayName: "Blake", isGuest: false },
+      ],
+      teamB: [
+        { displayName: "Guest 3", isGuest: true, userId: null },
+        { displayName: "Guest 4", isGuest: true, userId: null },
+      ],
+    });
+
+    const again = await start.execute({ userId: "host-1", gameId: game.id });
+    expect(again.live.id).toBe(started.live.id);
+  });
+
+  test("start outside the window is rejected", async () => {
+    const venues = new InMemoryVenueRepository();
+    const games = new InMemoryOrganisedGameRepository();
+    const friendships = new InMemoryFriendshipRepository();
+    const profiles = new InMemoryFriendProfileLookup();
+    seedProfiles(profiles);
+    await seedVenue(venues);
+
+    const create = new CreateOrganisedGame(
+      games,
+      venues,
+      friendships,
+      profiles,
+    );
+    const { game } = await create.execute({
+      userId: "host-1",
+      sport: "padel",
+      venueCmsId: "sanity-court-1",
+      startsAt: "2030-01-01T00:00:00.000Z",
+    });
+
+    const start = new StartOrganisedGame(
+      games,
+      profiles,
+      new CreateMatch(new InMemoryMatchRepository(), venues),
+      new CreateGolfRound(new InMemoryGolfRoundRepository(), venues),
+    );
+
+    await expect(
+      start.execute({ userId: "host-1", gameId: game.id }),
+    ).rejects.toBeInstanceOf(OrganisedGameStartWindowError);
+  });
+});

--- a/src/modules/organised-games/services/organised-games.service.ts
+++ b/src/modules/organised-games/services/organised-games.service.ts
@@ -1,0 +1,525 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import {
+  FriendProfile,
+  FriendProfileLookup,
+  FriendshipRepository,
+} from "../../friends/repositories/friendship.repository";
+import { GolfPlayerInput } from "../../golf-round/entities/golf-player";
+import { CreateGolfRound } from "../../golf-round/services/create-golf-round.service";
+import { PairingsInput } from "../../match/entities/pairings";
+import { CreateMatch } from "../../match/services/create-match.service";
+import { CmsId } from "../../venue/entities/cms-id";
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { OrganisedGame } from "../entities/organised-game";
+import { OrganisedGameCapacity } from "../entities/organised-game-capacity";
+import { OrganisedGameForbiddenError } from "../entities/organised-game-forbidden-error";
+import { OrganisedGameNotFoundError } from "../entities/organised-game-not-found-error";
+import { OrganisedGameNotFriendError } from "../entities/organised-game-not-friend-error";
+import { OrganisedGameNotes } from "../entities/organised-game-notes";
+import { OrganisedGameRsvp } from "../entities/organised-game-rsvp";
+import { OrganisedGameSport } from "../entities/organised-game-sport";
+import { OrganisedGameVenueNotFoundError } from "../entities/organised-game-venue-not-found-error";
+import { StartsAt } from "../entities/starts-at";
+import { OrganisedGameRepository } from "../repositories/organised-game.repository";
+import { defaultNineHoleCourse } from "./default-golf-course";
+import {
+  assertHostSeatedInGolfPlayers,
+  assertHostSeatedInPairings,
+  golfPlayersFromAccepted,
+  pairingsFromAccepted,
+} from "./seat-players";
+
+export type PublicUser = {
+  id: string;
+  displayName: string;
+  handle: string;
+  avatarUrl: string | null;
+};
+
+export type PublicInvitee = PublicUser & {
+  inviteId: string;
+  rsvp: "pending" | "accepted" | "declined";
+  invitedAt: string;
+  respondedAt: string | null;
+};
+
+export type PublicLiveScorecard = {
+  sport: "padel" | "golf";
+  id: string;
+  path: string;
+};
+
+export type PublicOrganisedGame = {
+  id: string;
+  sport: "padel" | "golf";
+  status: "open" | "started" | "cancelled";
+  venueCmsId: string;
+  startsAt: string;
+  notes: string | null;
+  capacity: number;
+  host: PublicUser;
+  invitees: PublicInvitee[];
+  inviteToken: string | null;
+  viewer: {
+    role: "host" | "invitee" | "guest";
+    rsvp: "pending" | "accepted" | "declined" | null;
+  };
+  live: PublicLiveScorecard | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+async function resolveProfile(
+  lookup: FriendProfileLookup,
+  userId: string,
+): Promise<FriendProfile> {
+  const profile = await lookup.findByUserId(userId);
+  if (profile) return profile;
+  return {
+    userId,
+    displayName: "Player",
+    handle: userId.slice(0, 8),
+    avatarUrl: null,
+  };
+}
+
+function toPublicUser(profile: FriendProfile): PublicUser {
+  return {
+    id: profile.userId,
+    displayName: profile.displayName,
+    handle: profile.handle,
+    avatarUrl: profile.avatarUrl,
+  };
+}
+
+async function toPublicGame(
+  game: OrganisedGame,
+  lookup: FriendProfileLookup,
+  viewerUserId: string,
+  options: { revealInviteToken: boolean } = { revealInviteToken: false },
+): Promise<PublicOrganisedGame> {
+  const snapshot = game.toSnapshot();
+  const host = toPublicUser(await resolveProfile(lookup, game.hostUserId));
+  const invitees: PublicInvitee[] = [];
+  for (const invite of snapshot.invites) {
+    const profile = await resolveProfile(lookup, invite.userId);
+    invitees.push({
+      ...toPublicUser(profile),
+      inviteId: invite.id,
+      rsvp: invite.rsvp,
+      invitedAt: invite.invitedAt,
+      respondedAt: invite.respondedAt,
+    });
+  }
+
+  const invite = game.inviteOf(viewerUserId);
+  let role: "host" | "invitee" | "guest" = "guest";
+  if (game.isHost(viewerUserId)) role = "host";
+  else if (invite) role = "invitee";
+
+  return {
+    id: snapshot.id,
+    sport: snapshot.sport,
+    status: snapshot.status,
+    venueCmsId: snapshot.venueCmsId,
+    startsAt: snapshot.startsAt,
+    notes: snapshot.notes,
+    capacity: snapshot.capacity,
+    host,
+    invitees,
+    inviteToken: options.revealInviteToken ? snapshot.inviteToken : null,
+    viewer: {
+      role,
+      rsvp: invite?.rsvp.value ?? null,
+    },
+    live: snapshot.live
+      ? {
+          sport: snapshot.sport,
+          id: snapshot.live.id,
+          path: snapshot.live.path,
+        }
+      : null,
+    createdAt: snapshot.createdAt,
+    updatedAt: snapshot.updatedAt,
+  };
+}
+
+async function requireAcceptedFriend(
+  friendships: FriendshipRepository,
+  hostUserId: string,
+  otherUserId: string,
+): Promise<void> {
+  const existing = await friendships.findBetween(hostUserId, otherUserId);
+  if (!existing || existing.status !== "accepted") {
+    throw new OrganisedGameNotFriendError();
+  }
+}
+
+export class CreateOrganisedGame {
+  constructor(
+    private readonly games: OrganisedGameRepository,
+    private readonly venues: VenueRepository,
+    private readonly friendships: FriendshipRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    sport: unknown;
+    venueCmsId: unknown;
+    startsAt: unknown;
+    notes?: unknown;
+    capacity?: unknown;
+    inviteUserIds?: unknown;
+  }): Promise<{ game: PublicOrganisedGame }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const sport = OrganisedGameSport.from(input.sport);
+    const venueCmsId = CmsId.from(input.venueCmsId);
+    const venue = await this.venues.findByCmsId(venueCmsId);
+    if (!venue) {
+      throw new OrganisedGameVenueNotFoundError();
+    }
+
+    const game = OrganisedGame.create({
+      hostUserId: userId,
+      sport,
+      venueCmsId,
+      startsAt: StartsAt.from(input.startsAt),
+      notes: OrganisedGameNotes.from(input.notes),
+      capacity: OrganisedGameCapacity.from(
+        input.capacity,
+        sport.defaultCapacity(),
+      ),
+    });
+
+    const inviteUserIds = parseUserIds(input.inviteUserIds);
+    for (const inviteeId of inviteUserIds) {
+      await requireAcceptedFriend(this.friendships, userId, inviteeId);
+      game.addInvitee(inviteeId);
+    }
+
+    const saved = await this.games.create(game);
+    return {
+      game: await toPublicGame(saved, this.profiles, userId, {
+        revealInviteToken: true,
+      }),
+    };
+  }
+}
+
+export class GetOrganisedGame {
+  constructor(
+    private readonly games: OrganisedGameRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string; gameId: string }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const game = await this.games.findById(input.gameId.trim());
+    if (!game || !game.isParticipant(userId)) {
+      throw new OrganisedGameNotFoundError();
+    }
+    return {
+      game: await toPublicGame(game, this.profiles, userId, {
+        revealInviteToken: game.isHost(userId),
+      }),
+    };
+  }
+}
+
+export class GetOrganisedGameByToken {
+  constructor(
+    private readonly games: OrganisedGameRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string; token: string }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const game = await this.games.findByInviteToken(input.token);
+    if (!game) {
+      throw new OrganisedGameNotFoundError();
+    }
+    return {
+      game: await toPublicGame(game, this.profiles, userId, {
+        revealInviteToken: game.isHost(userId),
+      }),
+    };
+  }
+}
+
+export class ListMyOrganisedGames {
+  constructor(
+    private readonly games: OrganisedGameRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const [hostedRows, invitedRows] = await Promise.all([
+      this.games.listHostedBy(userId),
+      this.games.listInvitedUser(userId),
+    ]);
+
+    const hosted = await Promise.all(
+      hostedRows.map((game) =>
+        toPublicGame(game, this.profiles, userId, { revealInviteToken: true }),
+      ),
+    );
+    const invited = await Promise.all(
+      invitedRows.map((game) =>
+        toPublicGame(game, this.profiles, userId, { revealInviteToken: false }),
+      ),
+    );
+
+    return { hosted, invited };
+  }
+}
+
+export class InviteFriends {
+  constructor(
+    private readonly games: OrganisedGameRepository,
+    private readonly friendships: FriendshipRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    gameId: string;
+    userIds: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const game = await this.games.findById(input.gameId.trim());
+    if (!game) {
+      throw new OrganisedGameNotFoundError();
+    }
+    if (!game.isHost(userId)) {
+      throw new OrganisedGameForbiddenError(
+        "Only the host can invite friends",
+      );
+    }
+
+    const userIds = parseUserIds(input.userIds);
+    if (userIds.length === 0) {
+      throw new DomainError("userIds is required");
+    }
+
+    for (const inviteeId of userIds) {
+      await requireAcceptedFriend(this.friendships, userId, inviteeId);
+      game.addInvitee(inviteeId);
+    }
+
+    const saved = await this.games.persist(game);
+    return {
+      game: await toPublicGame(saved, this.profiles, userId, {
+        revealInviteToken: true,
+      }),
+    };
+  }
+}
+
+export class ListInvites {
+  constructor(
+    private readonly games: OrganisedGameRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string; gameId: string }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const game = await this.games.findById(input.gameId.trim());
+    if (!game || !game.isParticipant(userId)) {
+      throw new OrganisedGameNotFoundError();
+    }
+    const publicGame = await toPublicGame(game, this.profiles, userId, {
+      revealInviteToken: game.isHost(userId),
+    });
+    return { invites: publicGame.invitees };
+  }
+}
+
+export class JoinByInviteToken {
+  constructor(
+    private readonly games: OrganisedGameRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string; token: string }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const game = await this.games.findByInviteToken(input.token);
+    if (!game) {
+      throw new OrganisedGameNotFoundError();
+    }
+    if (game.isHost(userId)) {
+      return {
+        game: await toPublicGame(game, this.profiles, userId, {
+          revealInviteToken: true,
+        }),
+      };
+    }
+
+    game.addInvitee(userId);
+    const saved = await this.games.persist(game);
+    return {
+      game: await toPublicGame(saved, this.profiles, userId, {
+        revealInviteToken: false,
+      }),
+    };
+  }
+}
+
+export class RsvpOrganisedGame {
+  constructor(
+    private readonly games: OrganisedGameRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string; gameId: string; rsvp: unknown }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const game = await this.games.findById(input.gameId.trim());
+    if (!game) {
+      throw new OrganisedGameNotFoundError();
+    }
+
+    game.rsvp(userId, OrganisedGameRsvp.fromDecision(input.rsvp));
+    const saved = await this.games.persist(game);
+    return {
+      game: await toPublicGame(saved, this.profiles, userId, {
+        revealInviteToken: saved.isHost(userId),
+      }),
+    };
+  }
+}
+
+export class CancelOrganisedGame {
+  constructor(
+    private readonly games: OrganisedGameRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string; gameId: string }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const game = await this.games.findById(input.gameId.trim());
+    if (!game) {
+      throw new OrganisedGameNotFoundError();
+    }
+    if (!game.isHost(userId)) {
+      throw new OrganisedGameForbiddenError("Only the host can cancel");
+    }
+    game.cancel();
+    const saved = await this.games.persist(game);
+    return {
+      game: await toPublicGame(saved, this.profiles, userId, {
+        revealInviteToken: true,
+      }),
+    };
+  }
+}
+
+export type StartOrganisedGameInput = {
+  userId: string;
+  gameId: string;
+  ruleset?: unknown;
+  servingTeam?: unknown;
+  pairings?: PairingsInput;
+  holesPlayed?: unknown;
+  startingHole?: unknown;
+  teeName?: string | null;
+  course?: unknown;
+  players?: GolfPlayerInput[];
+};
+
+export class StartOrganisedGame {
+  constructor(
+    private readonly games: OrganisedGameRepository,
+    private readonly profiles: FriendProfileLookup,
+    private readonly createMatch: CreateMatch,
+    private readonly createGolfRound: CreateGolfRound,
+  ) {}
+
+  async execute(input: StartOrganisedGameInput) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const game = await this.games.findById(input.gameId.trim());
+    if (!game) {
+      throw new OrganisedGameNotFoundError();
+    }
+    if (!game.isHost(userId)) {
+      throw new OrganisedGameForbiddenError("Only the host can start");
+    }
+
+    if (game.status.isStarted && game.live) {
+      return {
+        game: await toPublicGame(game, this.profiles, userId, {
+          revealInviteToken: true,
+        }),
+        live: {
+          sport: game.sport.value,
+          id: game.live.id,
+          path: game.live.path,
+        } satisfies PublicLiveScorecard,
+      };
+    }
+
+    const host = await resolveProfile(this.profiles, game.hostUserId);
+    const accepted: FriendProfile[] = [];
+    for (const invite of game.acceptedInvitees()) {
+      accepted.push(await resolveProfile(this.profiles, invite.userId));
+    }
+
+    let liveId: string;
+    if (game.sport.isPadel) {
+      const pairings =
+        input.pairings ??
+        pairingsFromAccepted(game, host, accepted);
+      assertHostSeatedInPairings(pairings, game.hostUserId);
+      const match = await this.createMatch.execute({
+        venueCmsId: game.venueCmsId.value,
+        startsAt: game.startsAt.toIsoString(),
+        ruleset: input.ruleset ?? "golden_point",
+        pairings,
+        servingTeam: input.servingTeam,
+      });
+      liveId = match.id;
+    } else {
+      const players =
+        input.players ?? golfPlayersFromAccepted(game, host, accepted);
+      assertHostSeatedInGolfPlayers(players, game.hostUserId);
+      const holesPlayed = input.holesPlayed ?? 9;
+      const course =
+        input.course ??
+        (holesPlayed === 9 ? defaultNineHoleCourse() : undefined);
+      const round = await this.createGolfRound.execute({
+        venueCmsId: game.venueCmsId.value,
+        startsAt: game.startsAt.toIsoString(),
+        holesPlayed,
+        startingHole: input.startingHole,
+        teeName: input.teeName,
+        course,
+        players,
+      });
+      liveId = round.id;
+    }
+
+    const path = game.sport.livePath(liveId);
+    game.start({ id: liveId, path });
+    const saved = await this.games.persist(game);
+    const publicGame = await toPublicGame(saved, this.profiles, userId, {
+      revealInviteToken: true,
+    });
+    return {
+      game: publicGame,
+      live: publicGame.live!,
+    };
+  }
+}
+
+function parseUserIds(raw: unknown): string[] {
+  if (raw == null) return [];
+  if (!Array.isArray(raw)) {
+    throw new DomainError("userIds must be an array of user ids");
+  }
+  const ids: string[] = [];
+  for (const value of raw) {
+    const id = requiredTrimmed(value, "userId");
+    if (!ids.includes(id)) ids.push(id);
+  }
+  return ids;
+}

--- a/src/modules/organised-games/services/seat-players.ts
+++ b/src/modules/organised-games/services/seat-players.ts
@@ -1,0 +1,114 @@
+import { DomainError } from "../../../lib/domain-error";
+import { FriendProfile } from "../../friends/repositories/friendship.repository";
+import { GolfPlayerInput } from "../../golf-round/entities/golf-player";
+import { MatchPlayerInput } from "../../match/entities/match-player";
+import { PairingsInput } from "../../match/entities/pairings";
+import { OrganisedGame } from "../entities/organised-game";
+
+export type SeatedProfile = Pick<FriendProfile, "userId" | "displayName">;
+
+function guest(displayName: string): MatchPlayerInput {
+  return { displayName, isGuest: true, userId: null };
+}
+
+function named(profile: SeatedProfile): MatchPlayerInput {
+  return {
+    displayName: profile.displayName,
+    isGuest: false,
+    userId: profile.userId,
+  };
+}
+
+/**
+ * Host always A1. Accepted invitees fill A2, B1, B2 in invite order.
+ * Remaining padel slots are guests so CreateMatch's four-player rule holds.
+ */
+export function pairingsFromAccepted(
+  game: OrganisedGame,
+  host: SeatedProfile,
+  accepted: SeatedProfile[],
+): PairingsInput {
+  if (host.userId !== game.hostUserId) {
+    throw new DomainError("Host must be seated");
+  }
+
+  const seats: MatchPlayerInput[] = [named(host)];
+  for (const profile of accepted) {
+    if (seats.length >= 4) break;
+    if (profile.userId === host.userId) continue;
+    seats.push(named(profile));
+  }
+  while (seats.length < 4) {
+    seats.push(guest(`Guest ${seats.length + 1}`));
+  }
+
+  return {
+    teamA: [seats[0]!, seats[1]!],
+    teamB: [seats[2]!, seats[3]!],
+  };
+}
+
+/**
+ * Host always slot 1. Accepted invitees fill slots 2–4. Golf allows 1–4 so
+ * remaining seats are omitted (no guest fill).
+ */
+export function golfPlayersFromAccepted(
+  game: OrganisedGame,
+  host: SeatedProfile,
+  accepted: SeatedProfile[],
+): GolfPlayerInput[] {
+  if (host.userId !== game.hostUserId) {
+    throw new DomainError("Host must be seated");
+  }
+
+  const players: GolfPlayerInput[] = [
+    {
+      slot: 1,
+      displayName: host.displayName,
+      isGuest: false,
+      userId: host.userId,
+    },
+  ];
+
+  let slot = 2 as 2 | 3 | 4;
+  for (const profile of accepted) {
+    if (players.length >= 4) break;
+    if (profile.userId === host.userId) continue;
+    players.push({
+      slot,
+      displayName: profile.displayName,
+      isGuest: false,
+      userId: profile.userId,
+    });
+    slot = (slot + 1) as 2 | 3 | 4;
+  }
+
+  return players;
+}
+
+export function assertHostSeatedInPairings(
+  pairings: PairingsInput,
+  hostUserId: string,
+): void {
+  const seated = [
+    pairings.teamA[0],
+    pairings.teamA[1],
+    pairings.teamB[0],
+    pairings.teamB[1],
+  ].some((player) => player.userId === hostUserId && player.isGuest !== true);
+  if (!seated) {
+    throw new DomainError("Host must be seated in pairings");
+  }
+}
+
+export function assertHostSeatedInGolfPlayers(
+  players: GolfPlayerInput[],
+  hostUserId: string,
+): void {
+  const seated = players.some(
+    (player) => player.userId === hostUserId && player.isGuest !== true,
+  );
+  if (!seated) {
+    throw new DomainError("Host must be seated in players");
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #33.

Play hub third verb: **Organise game** — pick sport (padel/golf v1) → venue + time → invite friends + shareable link → RSVP → host **Start** into a live scorecard.

Related Frontend: [landing-page#149](https://github.com/leaguesports/landing-page/issues/149) (Play v2 shell, open), [landing-page#153](https://github.com/leaguesports/landing-page/issues/153) (Start + Capture). Capture API: #31 / #32.

Do **not** merge — Brandon merges.

## Frontend contract

All routes require session cookie `token` (`credentials: "include"`). Guests → `401 { "error": "Unauthorized" }`.

| Method | Path | Who | Success |
| --- | --- | --- | --- |
| `POST` | `/api/organised-games` | signed-in | `201 { game }` |
| `GET` | `/api/me/organised-games` | signed-in | `200 { hosted, invited }` |
| `GET` | `/api/organised-games/:id` | host or invitee | `200 { game }` |
| `GET` | `/api/organised-games/:id/invites` | host or invitee | `200 { invites }` |
| `POST` | `/api/organised-games/:id/invites` | host | `200 { game }` |
| `POST` | `/api/organised-games/:id/rsvp` | invitee | `200 { game }` |
| `POST` | `/api/organised-games/:id/start` | host | `201 { game, live }` |
| `POST` | `/api/organised-games/:id/cancel` | host | `200 { game }` |
| `GET` | `/api/organised-games/invite/:token` | signed-in | `200 { game }` (preview; no join yet) |
| `POST` | `/api/organised-games/invite/:token/join` | signed-in | `200 { game }` (pending invitee) |

Non-participants `GET /api/organised-games/:id` → **404** (no existence leak). Unknown token → **404**.

### `game` shape

```json
{
  "id": "uuid",
  "sport": "padel",
  "status": "open",
  "venueCmsId": "sanity-court-1",
  "startsAt": "2026-09-07T18:00:00.000Z",
  "notes": "Sunday hit",
  "capacity": 4,
  "host": {
    "id": "user-a",
    "displayName": "Alex",
    "handle": "alex",
    "avatarUrl": null
  },
  "invitees": [
    {
      "id": "user-b",
      "displayName": "Blake",
      "handle": "blake",
      "avatarUrl": null,
      "inviteId": "uuid",
      "rsvp": "pending",
      "invitedAt": "2026-09-07T10:00:00.000Z",
      "respondedAt": null
    }
  ],
  "inviteToken": "a1b2c3d4e5f6…32 hex chars…",
  "viewer": { "role": "host", "rsvp": null },
  "live": null,
  "createdAt": "…",
  "updatedAt": "…"
}
```

| Field | Notes |
| --- | --- |
| `sport` | `padel` \| `golf` |
| `status` | `open` \| `started` \| `cancelled` |
| `capacity` | 2–8, default **4** (includes host). Counts host + non-declined invitees |
| `inviteToken` | **Host only** (32-char hex). Invitees/guests get `null`. FE builds the share URL, e.g. `/play/join/{inviteToken}` |
| `viewer.role` | `host` \| `invitee` \| `guest` (`guest` only on token preview before join) |
| `viewer.rsvp` | `pending` \| `accepted` \| `declined` \| `null` (host with no invite) |
| `live` | `null` until start; then `{ sport, id, path }` |

Hub `GET /api/me/organised-games` uses the same `game` objects: `hosted` (you are host) and `invited` (you have an invite, including declined).

### Create — `POST /api/organised-games`

```json
{
  "sport": "padel",
  "venueCmsId": "sanity-court-1",
  "startsAt": "2026-09-07T18:00:00.000Z",
  "notes": "optional, max 280",
  "capacity": 4,
  "inviteUserIds": ["friend-user-id"]
}
```

| Field | Required | Notes |
| --- | --- | --- |
| `sport` | yes | `padel` \| `golf` |
| `venueCmsId` | yes | Existing Venue `cmsId` — **404** `Venue not found` if unknown |
| `startsAt` | yes | ISO datetime |
| `notes` | no | trimmed; blank → null |
| `capacity` | no | integer 2–8, default 4 |
| `inviteUserIds` | no | each must be an **accepted friend** of the host (`400` otherwise) |

Host is the session user. Host cannot be in `inviteUserIds`.

### Invite friends — `POST /api/organised-games/:id/invites`

Host only.

```json
{ "userIds": ["friend-user-id"] }
```

Must be accepted friends. Idempotent if already invited. **409** if the game is not `open` or is at capacity.

### Shareable link

1. Host reads `game.inviteToken` (only on host responses).
2. Signed-in user `GET /api/organised-games/invite/:token` to preview (`viewer.role` is `guest` until they join; host sees `host`).
3. `POST /api/organised-games/invite/:token/join` adds them as a **pending** invitee (no friendship required). Host joining is a no-op. Idempotent if already invited. **409** if full / not open.

### RSVP — `POST /api/organised-games/:id/rsvp`

Invitee only. Host **cannot** RSVP unless they also have an invite (`403`).

```json
{ "rsvp": "accepted" }
```

`rsvp` is `accepted` \| `declined`. Default on invite/join is `pending`. Game must be `open` (`409` otherwise).

### Start — `POST /api/organised-games/:id/start`

Host only. Game must be `open`. **Start window:** `now` in `[startsAt − 12h, startsAt + 24h]` (`400` outside). Idempotent: if already `started`, returns the same `live` (still `201`).

Empty body is valid. Creates a **live** padel match or golf round via existing `CreateMatch` / `CreateGolfRound` (invitee `userId`s are kept — this does **not** go through HTTP create sanitize).

**Prefill**

- Venue = organised game `venueCmsId`; `startsAt` copied onto the live scorecard
- **Host always seated** (padel A1 / golf slot 1)
- **Accepted** invitees fill remaining seats in invite order (padel up to 4 including host; golf 1–4)
- Padel leftover slots are guests (`Guest 3`, `Guest 4`, …)

**201 response**

```json
{
  "game": { "status": "started", "live": { "sport": "padel", "id": "uuid", "path": "/padel/uuid" } },
  "live": { "sport": "padel", "id": "uuid", "path": "/padel/uuid" }
}
```

Deep-link Frontend: `live.path` → `/padel/{id}` or `/golf/{id}`. Then existing `GET /api/matches/:id` / `GET /api/golf-rounds/:id`.

Optional start body (overrides):

```json
{
  "ruleset": "golden_point",
  "servingTeam": "A",
  "pairings": { "teamA": [/* two players */], "teamB": [/* two */] },
  "holesPlayed": 9,
  "startingHole": 1,
  "teeName": "White",
  "course": { "name": "Links Nine", "holes": [{ "number": 1, "par": 4, "strokeIndex": 1 }] },
  "players": [{ "slot": 1, "displayName": "Alex", "isGuest": false, "userId": "<host>" }]
}
```

| Sport | Defaults if omitted |
| --- | --- |
| Padel | `ruleset: golden_point`; auto pairings as above. Host must remain seated if `pairings` is sent |
| Golf | `holesPlayed: 9`, default 9-hole par-4 course (`strokeIndex` 1–9). **18 holes requires `course`**. Host must remain seated if `players` is sent |

Live link is stored on the organised game (`live.id` + `live.path`). Match/GolfRound rows are **not** given `organisedGameId` in v1 (avoids changing live scorecard snapshots).

### Cancel — `POST /api/organised-games/:id/cancel`

Host only, while `open` (`409` otherwise). Sets `status: cancelled`.

### Errors

| Status | When |
| --- | --- |
| `400` | Invalid payload / domain (`Invalid organised game payload` or message). Non-friend invite: `Can only invite an accepted friend`. Start outside window: `Host can start from 12 hours before startsAt until 24 hours after` |
| `401` | No session |
| `403` | Not host (invite/start/cancel); not invitee (RSVP) |
| `404` | Unknown game / token / non-participant GET by id / unknown `venueCmsId` |
| `409` | Full (`This organised game is full`) or not open (`Organised game is not open`) |
| `503` | Persistence failure |

## Domain bar

`OrganisedGame` aggregate + VOs under `src/modules/organised-games/entities/` (sport, status, RSVP, invite token, notes, capacity, startsAt). Invites are child entities. Commands in `services/`. Thin Zod at the controller. Reuses friends graph (`FriendshipRepository.findBetween` + accepted) and `CreateMatch` / `CreateGolfRound`.

## Migration

`20260907080000_organised_game` — enums `OrganisedGameSport` / `OrganisedGameStatus` / `OrganisedGameRsvp`, tables `OrganisedGame` + `OrganisedGameInvite`. Venue FK on `venueCmsId`. No User FK (same as Friendship / CommunityMember).

## Tests

Entity + service + HTTP. Full suite: **242 passed**. `yarn build` typecheck clean.

## Out of scope v1

Court booking/payments, open public matchmaking, darts/pool, push notifications, Quick Play location, `organisedGameId` on Match/GolfRound.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d324496-18c9-4708-a46f-a61c483dc788?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d324496-18c9-4708-a46f-a61c483dc788&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

