### PR TITLE
feat: community member activity feed (#140)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -136,6 +136,9 @@ export async function createApp(
   const communities = createCommunitiesModule({
     prisma,
     communityRepository: dependencies.communityRepository,
+    matchRepository: match.matchRepository,
+    golfRoundRepository: golfRound.golfRoundRepository,
+    venueRepository: venue.venueRepository,
     friendProfileLookup: friends.friendProfileLookup,
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,

--- a/src/modules/communities/controllers/communities.controller.ts
+++ b/src/modules/communities/controllers/communities.controller.ts
@@ -14,6 +14,7 @@ import {
   ListCommunities,
   ListMyCommunities,
 } from "../services/communities.service";
+import { ListCommunityActivity } from "../services/list-community-activity.service";
 
 const createBodySchema = z.object({
   name: z.string(),
@@ -36,6 +37,7 @@ export function createCommunitiesController(deps: {
   listMyCommunities: ListMyCommunities;
   joinCommunity: JoinCommunity;
   leaveCommunity: LeaveCommunity;
+  listCommunityActivity: ListCommunityActivity;
   tryGetSessionUserId: (req: Request) => string | null;
 }) {
   return {
@@ -116,6 +118,18 @@ export function createCommunitiesController(deps: {
         const { id } = z.parse(communityIdParamSchema, req.params);
         const result = await deps.leaveCommunity.execute({
           userId,
+          communityId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendCommunitiesError(res, error);
+      }
+    },
+
+    async activity(req: Request, res: Response) {
+      try {
+        const { id } = z.parse(communityIdParamSchema, req.params);
+        const result = await deps.listCommunityActivity.execute({
           communityId: id,
         });
         return res.status(200).json(result);

--- a/src/modules/communities/controllers/communities.http.test.ts
+++ b/src/modules/communities/controllers/communities.http.test.ts
@@ -8,6 +8,17 @@ import { createApp } from "../../../app";
 import { Config } from "../../../config";
 import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
 import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { GolfRound } from "../../golf-round/entities/golf-round";
+import { StartsAt as GolfStartsAt } from "../../golf-round/entities/starts-at";
+import { InMemoryGolfRoundRepository } from "../../golf-round/repositories/in-memory-golf-round.repository";
+import { Match } from "../../match/entities/match";
+import { Ruleset } from "../../match/entities/ruleset";
+import { StartsAt } from "../../match/entities/starts-at";
+import { InMemoryMatchRepository } from "../../match/repositories/in-memory-match.repository";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
 import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
 import { InMemoryCommunityRepository } from "../repositories/in-memory-community.repository";
 
@@ -45,12 +56,18 @@ describe("communities HTTP", () => {
   const config = makeConfig();
   let communities: InMemoryCommunityRepository;
   let profiles: InMemoryFriendProfileLookup;
+  let venues: InMemoryVenueRepository;
+  let matches: InMemoryMatchRepository;
+  let golfRounds: InMemoryGolfRoundRepository;
   let app: Express;
   let server: { url: string; close: () => Promise<void> };
 
   beforeEach(async () => {
     communities = new InMemoryCommunityRepository();
     profiles = new InMemoryFriendProfileLookup();
+    venues = new InMemoryVenueRepository();
+    matches = new InMemoryMatchRepository();
+    golfRounds = new InMemoryGolfRoundRepository();
     profiles.seed({
       userId: "user-a",
       displayName: "Alex",
@@ -63,12 +80,30 @@ describe("communities HTTP", () => {
       handle: "blake",
       avatarUrl: null,
     });
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-court-1"),
+        VenueName.from("Padel Club"),
+        Slug.from("padel-club"),
+      ),
+      { refreshDetails: false },
+    );
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-course-1"),
+        VenueName.from("Golf Club"),
+        Slug.from("golf-club"),
+      ),
+      { refreshDetails: false },
+    );
 
     app = await createApp(config, {
-      venueRepository: new InMemoryVenueRepository(),
+      venueRepository: venues,
       friendshipRepository: new InMemoryFriendshipRepository(),
       friendProfileLookup: profiles,
       communityRepository: communities,
+      matchRepository: matches,
+      golfRoundRepository: golfRounds,
     });
     server = await listen(app);
   });
@@ -287,5 +322,141 @@ describe("communities HTTP", () => {
     expect(await notMember.json()).toEqual({
       error: "Community membership not found",
     });
+  });
+
+  test("GET /api/communities/:id/activity is public and lists locked member results", async () => {
+    const created = await fetch(`${server.url}/api/communities`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        name: "Sunday Beers",
+        city: "Cape Town",
+        sport: "multi",
+      }),
+    });
+    const { community } = (await created.json()) as {
+      community: { id: string };
+    };
+
+    const empty = await fetch(
+      `${server.url}/api/communities/${community.id}/activity`,
+    );
+    expect(empty.status).toBe(200);
+    expect(await empty.json()).toEqual({ items: [] });
+
+    const live = Match.create({
+      venueCmsId: CmsId.from("sanity-court-1"),
+      startsAt: StartsAt.from("2026-08-29T10:00:00.000Z"),
+      ruleset: Ruleset.from("golden_point"),
+      pairings: {
+        teamA: [
+          { displayName: "Alex", isGuest: false, userId: "user-a" },
+          { displayName: "Sam", isGuest: true, userId: null },
+        ],
+        teamB: [
+          { displayName: "Jordan", isGuest: true, userId: null },
+          { displayName: "Riley", isGuest: true, userId: null },
+        ],
+      },
+    });
+    await matches.create(live);
+
+    const padel = Match.captureFinished({
+      venueCmsId: CmsId.from("sanity-court-1"),
+      startsAt: StartsAt.from("2026-08-29T09:00:00.000Z"),
+      ruleset: Ruleset.from("golden_point"),
+      pairings: {
+        teamA: [
+          { displayName: "Alex", isGuest: false, userId: "user-a" },
+          { displayName: "Sam", isGuest: true, userId: null },
+        ],
+        teamB: [
+          { displayName: "Jordan", isGuest: true, userId: null },
+          { displayName: "Riley", isGuest: true, userId: null },
+        ],
+      },
+      score: {
+        sets: [{ gamesA: 6, gamesB: 4, tieBreak: null, winner: "A" }],
+      },
+      winner: "A",
+      lockedByUserId: "user-a",
+      lockedAt: new Date("2026-08-29T11:00:00.000Z"),
+    });
+    await matches.create(padel);
+
+    const courseHoles9 = Array.from({ length: 9 }, (_, index) => ({
+      number: index + 1,
+      par: ((index % 3) + 3) as 3 | 4 | 5,
+      strokeIndex: index + 1,
+    }));
+    const golf = GolfRound.captureFinished({
+      venueCmsId: CmsId.from("sanity-course-1"),
+      startsAt: GolfStartsAt.from("2026-09-04T10:00:00.000Z"),
+      holesPlayed: 9,
+      startingHole: 1,
+      teeName: "White",
+      course: { name: "Links Nine", holes: courseHoles9 },
+      players: [
+        { slot: 1, displayName: "Alex", isGuest: false, userId: "user-a" },
+        { slot: 2, displayName: "Casey", isGuest: true, userId: null },
+      ],
+      score: {
+        holes: courseHoles9.map((hole) => ({
+          number: hole.number,
+          strokes: { "1": 4, "2": 5 },
+        })),
+      },
+      lockedByUserId: "user-a",
+      lockedAt: new Date("2026-09-04T12:00:00.000Z"),
+    });
+    await golfRounds.create(golf);
+
+    const activity = await fetch(
+      `${server.url}/api/communities/${community.id}/activity`,
+    );
+    expect(activity.status).toBe(200);
+    expect(await activity.json()).toEqual({
+      items: [
+        {
+          id: golf.id,
+          sport: "golf",
+          kind: "round",
+          lockedAt: "2026-09-04T12:00:00.000Z",
+          venueCmsId: "sanity-course-1",
+          venueName: "Golf Club",
+          path: `/golf/${golf.id}`,
+          summary: "Alex 36 · Casey 45",
+          players: [
+            { userId: "user-a", displayName: "Alex", isGuest: false },
+            { userId: null, displayName: "Casey", isGuest: true },
+          ],
+        },
+        {
+          id: padel.id,
+          sport: "padel",
+          kind: "match",
+          lockedAt: "2026-08-29T11:00:00.000Z",
+          venueCmsId: "sanity-court-1",
+          venueName: "Padel Club",
+          path: `/padel/${padel.id}`,
+          summary: "Alex / Sam vs Jordan / Riley · 6–4",
+          players: [
+            { userId: "user-a", displayName: "Alex", isGuest: false },
+            { userId: null, displayName: "Sam", isGuest: true },
+            { userId: null, displayName: "Jordan", isGuest: true },
+            { userId: null, displayName: "Riley", isGuest: true },
+          ],
+        },
+      ],
+    });
+
+    const missing = await fetch(
+      `${server.url}/api/communities/does-not-exist/activity`,
+    );
+    expect(missing.status).toBe(404);
+    expect(await missing.json()).toEqual({ error: "Community not found" });
   });
 });

--- a/src/modules/communities/index.ts
+++ b/src/modules/communities/index.ts
@@ -7,6 +7,9 @@ import {
 
 import { PrismaClient } from "../../generated/prisma/client";
 import { FriendProfileLookup } from "../friends/repositories/friendship.repository";
+import { GolfRoundRepository } from "../golf-round/repositories/golf-round.repository";
+import { MatchRepository } from "../match/repositories/match.repository";
+import { VenueRepository } from "../venue/repositories/venue.repository";
 import { createCommunitiesController } from "./controllers/communities.controller";
 import { CommunityRepository } from "./repositories/community.repository";
 import { PrismaCommunityRepository } from "./repositories/prisma-community.repository";
@@ -19,10 +22,14 @@ import {
   ListCommunities,
   ListMyCommunities,
 } from "./services/communities.service";
+import { ListCommunityActivity } from "./services/list-community-activity.service";
 
 export type CreateCommunitiesModuleParams = {
   prisma: PrismaClient;
   communityRepository?: CommunityRepository;
+  matchRepository: MatchRepository;
+  golfRoundRepository: GolfRoundRepository;
+  venueRepository: VenueRepository;
   friendProfileLookup: FriendProfileLookup;
   tryGetSessionUserId: (req: Request) => string | null;
   requireAuth: (req: Request, res: Response, next: NextFunction) => void;
@@ -36,6 +43,9 @@ export type CommunitiesModule = {
 export function createCommunitiesModule({
   prisma,
   communityRepository: communityRepositoryOverride,
+  matchRepository,
+  golfRoundRepository,
+  venueRepository,
   friendProfileLookup,
   tryGetSessionUserId,
   requireAuth,
@@ -53,6 +63,12 @@ export function createCommunitiesModule({
     listMyCommunities: new ListMyCommunities(communityRepository),
     joinCommunity: new JoinCommunity(communityRepository, friendProfileLookup),
     leaveCommunity: new LeaveCommunity(communityRepository),
+    listCommunityActivity: new ListCommunityActivity(
+      communityRepository,
+      matchRepository,
+      golfRoundRepository,
+      venueRepository,
+    ),
     tryGetSessionUserId,
   });
 
@@ -84,9 +100,15 @@ export {
   ListCommunities,
   ListMyCommunities,
 } from "./services/communities.service";
+export { ListCommunityActivity } from "./services/list-community-activity.service";
 export type {
   PublicCommunity,
   PublicCommunityMember,
   PublicCommunitySummary,
   PublicMyCommunity,
 } from "./services/communities.service";
+export type {
+  CommunityActivityItem,
+  CommunityActivityPlayer,
+} from "./services/community-activity-item";
+export { COMMUNITY_ACTIVITY_LIMIT } from "./services/community-activity-item";

--- a/src/modules/communities/routes/communities.routes.ts
+++ b/src/modules/communities/routes/communities.routes.ts
@@ -26,6 +26,10 @@ export function createCommunitiesRoutes(
     void controller.get(req, res);
   });
 
+  router.get("/api/communities/:id/activity", (req, res) => {
+    void controller.activity(req, res);
+  });
+
   router.post("/api/communities/:id/join", options.requireAuth, (req, res) => {
     void controller.join(req, res);
   });

--- a/src/modules/communities/services/community-activity-item.ts
+++ b/src/modules/communities/services/community-activity-item.ts
@@ -1,0 +1,136 @@
+import { GolfRound } from "../../golf-round/entities/golf-round";
+import { GolfScoreSnapshot } from "../../golf-round/entities/golf-score";
+import { Match } from "../../match/entities/match";
+import { MatchScoreSnapshot } from "../../match/entities/match-score";
+
+export const COMMUNITY_ACTIVITY_LIMIT = 30;
+
+export type CommunityActivityPlayer = {
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+};
+
+export type CommunityActivityItem = {
+  id: string;
+  sport: "padel" | "golf";
+  kind: "match" | "round";
+  lockedAt: string;
+  venueCmsId: string | null;
+  venueName: string | null;
+  path: string;
+  summary: string;
+  players: CommunityActivityPlayer[];
+};
+
+export function toPadelActivityItem(
+  match: Match,
+  venueName: string | null,
+): CommunityActivityItem {
+  const snapshot = match.toSnapshot();
+  const players = [
+    ...snapshot.pairings.teamA,
+    ...snapshot.pairings.teamB,
+  ].map(toActivityPlayer);
+  const teamA = playerNames(snapshot.pairings.teamA);
+  const teamB = playerNames(snapshot.pairings.teamB);
+  const names = `${teamA} vs ${teamB}`;
+  const score = formatPadelScore(snapshot.score);
+
+  return {
+    id: snapshot.id,
+    sport: "padel",
+    kind: "match",
+    lockedAt: snapshot.lockedAt ?? snapshot.startsAt,
+    venueCmsId: snapshot.venueCmsId || null,
+    venueName,
+    path: `/padel/${snapshot.id}`,
+    summary: score ? `${names} · ${score}` : names,
+    players,
+  };
+}
+
+export function toGolfActivityItem(
+  round: GolfRound,
+  venueName: string | null,
+): CommunityActivityItem {
+  const snapshot = round.toSnapshot();
+  const players = snapshot.players.map(toActivityPlayer);
+
+  return {
+    id: snapshot.id,
+    sport: "golf",
+    kind: "round",
+    lockedAt: snapshot.lockedAt ?? snapshot.startsAt,
+    venueCmsId: snapshot.venueCmsId || null,
+    venueName,
+    path: `/golf/${snapshot.id}`,
+    summary: formatGolfScoreLine(snapshot.players, snapshot.score),
+    players,
+  };
+}
+
+export function compareActivityItemsNewestFirst(
+  a: CommunityActivityItem,
+  b: CommunityActivityItem,
+): number {
+  const byTime = Date.parse(b.lockedAt) - Date.parse(a.lockedAt);
+  if (byTime !== 0) return byTime;
+  return b.id.localeCompare(a.id);
+}
+
+function toActivityPlayer(player: {
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+}): CommunityActivityPlayer {
+  return {
+    userId: player.userId,
+    displayName: player.displayName,
+    isGuest: player.isGuest,
+  };
+}
+
+function firstName(displayName: string): string {
+  return displayName.trim().split(/\s+/)[0] || displayName;
+}
+
+function playerNames(
+  players: Array<{ displayName: string }>,
+): string {
+  return players.map((player) => firstName(player.displayName)).join(" / ");
+}
+
+export function formatPadelScore(
+  score: MatchScoreSnapshot | null,
+): string | null {
+  if (!score?.sets.length) return null;
+  return score.sets
+    .map((set) => {
+      const games = `${set.gamesA}–${set.gamesB}`;
+      if (set.tieBreak) {
+        return `${games} (${set.tieBreak.pointsA}–${set.tieBreak.pointsB})`;
+      }
+      return games;
+    })
+    .join(", ");
+}
+
+export function formatGolfScoreLine(
+  players: Array<{ slot: number; displayName: string }>,
+  score: GolfScoreSnapshot | null,
+): string {
+  if (!players.length) return "Locked round";
+  if (!score?.holes.length) {
+    return players.map((player) => firstName(player.displayName)).join(" · ");
+  }
+
+  return players
+    .map((player) => {
+      const gross = score.holes.reduce((sum, hole) => {
+        return sum + (hole.strokes[String(player.slot)] ?? 0);
+      }, 0);
+      return `${firstName(player.displayName)} ${gross}`;
+    })
+    .join(" · ");
+}

--- a/src/modules/communities/services/list-community-activity.service.test.ts
+++ b/src/modules/communities/services/list-community-activity.service.test.ts
@@ -1,0 +1,351 @@
+import { DomainError } from "../../../lib/domain-error";
+import { InMemoryGolfRoundRepository } from "../../golf-round/repositories/in-memory-golf-round.repository";
+import { GolfRound } from "../../golf-round/entities/golf-round";
+import { StartsAt as GolfStartsAt } from "../../golf-round/entities/starts-at";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { Match } from "../../match/entities/match";
+import { PairingsInput } from "../../match/entities/pairings";
+import { Ruleset } from "../../match/entities/ruleset";
+import { StartsAt } from "../../match/entities/starts-at";
+import { InMemoryMatchRepository } from "../../match/repositories/in-memory-match.repository";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { InMemoryCommunityRepository } from "../repositories/in-memory-community.repository";
+import {
+  CommunityNotFoundError,
+  CreateCommunity,
+  JoinCommunity,
+} from "./communities.service";
+import { COMMUNITY_ACTIVITY_LIMIT } from "./community-activity-item";
+import { ListCommunityActivity } from "./list-community-activity.service";
+
+const padelScore: {
+  sets: Array<{
+    gamesA: number;
+    gamesB: number;
+    tieBreak: { pointsA: number; pointsB: number } | null;
+    winner: "A" | "B";
+  }>;
+} = {
+  sets: [{ gamesA: 6, gamesB: 4, tieBreak: null, winner: "A" }],
+};
+
+const courseHoles9 = Array.from({ length: 9 }, (_, index) => ({
+  number: index + 1,
+  par: ((index % 3) + 3) as 3 | 4 | 5,
+  strokeIndex: index + 1,
+}));
+
+function memberPairings(
+  userId: string,
+  displayName: string,
+): PairingsInput {
+  return {
+    teamA: [
+      { displayName, isGuest: false, userId },
+      { displayName: "Sam Guest", isGuest: true, userId: null },
+    ],
+    teamB: [
+      { displayName: "Jordan Guest", isGuest: true, userId: null },
+      { displayName: "Riley Guest", isGuest: true, userId: null },
+    ],
+  };
+}
+
+function lockedPadel(props: {
+  venueCmsId: string;
+  startsAt: string;
+  lockedAt: string;
+  lockedByUserId: string;
+  pairings: PairingsInput;
+  score?: typeof padelScore;
+}): Match {
+  return Match.captureFinished({
+    venueCmsId: CmsId.from(props.venueCmsId),
+    startsAt: StartsAt.from(props.startsAt),
+    ruleset: Ruleset.from("golden_point"),
+    pairings: props.pairings,
+    score: props.score ?? padelScore,
+    winner: "A",
+    lockedByUserId: props.lockedByUserId,
+    lockedAt: new Date(props.lockedAt),
+  });
+}
+
+function lockedGolf(props: {
+  venueCmsId: string;
+  startsAt: string;
+  lockedAt: string;
+  lockedByUserId: string;
+  players: Array<{
+    slot: 1 | 2 | 3 | 4;
+    displayName: string;
+    isGuest: boolean;
+    userId: string | null;
+  }>;
+}): GolfRound {
+  const slots = props.players.map((player) => player.slot);
+  return GolfRound.captureFinished({
+    venueCmsId: CmsId.from(props.venueCmsId),
+    startsAt: GolfStartsAt.from(props.startsAt),
+    holesPlayed: 9,
+    startingHole: 1,
+    teeName: "White",
+    course: { name: "Links Nine", holes: courseHoles9 },
+    players: props.players,
+    score: {
+      holes: courseHoles9.map((hole) => ({
+        number: hole.number,
+        strokes: Object.fromEntries(slots.map((slot) => [String(slot), 4])),
+      })),
+    },
+    lockedByUserId: props.lockedByUserId,
+    lockedAt: new Date(props.lockedAt),
+  });
+}
+
+describe("ListCommunityActivity", () => {
+  async function setup() {
+    const communities = new InMemoryCommunityRepository();
+    const matches = new InMemoryMatchRepository();
+    const golfRounds = new InMemoryGolfRoundRepository();
+    const venues = new InMemoryVenueRepository();
+    const profiles = new InMemoryFriendProfileLookup();
+    profiles.seed({
+      userId: "user-a",
+      displayName: "Alex",
+      handle: "alex",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-b",
+      displayName: "Blake",
+      handle: "blake",
+      avatarUrl: null,
+    });
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-court-1"),
+        VenueName.from("Padel Club"),
+        Slug.from("padel-club"),
+      ),
+      { refreshDetails: false },
+    );
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-course-1"),
+        VenueName.from("Golf Club"),
+        Slug.from("golf-club"),
+      ),
+      { refreshDetails: false },
+    );
+
+    return {
+      communities,
+      matches,
+      golfRounds,
+      venues,
+      create: new CreateCommunity(communities, profiles),
+      join: new JoinCommunity(communities, profiles),
+      activity: new ListCommunityActivity(
+        communities,
+        matches,
+        golfRounds,
+        venues,
+      ),
+    };
+  }
+
+  test("unknown community is not found", async () => {
+    const { activity } = await setup();
+    await expect(
+      activity.execute({ communityId: "missing" }),
+    ).rejects.toBeInstanceOf(CommunityNotFoundError);
+    await expect(activity.execute({ communityId: "  " })).rejects.toBeInstanceOf(
+      DomainError,
+    );
+  });
+
+  test("returns empty items when members have no locked results", async () => {
+    const { create, matches, activity } = await setup();
+    const created = await create.execute({
+      userId: "user-a",
+      name: "Sunday Beers",
+      city: "Cape Town",
+      sport: "padel",
+    });
+
+    const live = Match.create({
+      venueCmsId: CmsId.from("sanity-court-1"),
+      startsAt: StartsAt.from("2026-08-29T10:00:00.000Z"),
+      ruleset: Ruleset.from("golden_point"),
+      pairings: memberPairings("user-a", "Alex"),
+    });
+    await matches.create(live);
+
+    const outsider = lockedPadel({
+      venueCmsId: "sanity-court-1",
+      startsAt: "2026-08-29T09:00:00.000Z",
+      lockedAt: "2026-08-29T11:00:00.000Z",
+      lockedByUserId: "user-outsider",
+      pairings: memberPairings("user-outsider", "Outsider"),
+    });
+    await matches.create(outsider);
+
+    const result = await activity.execute({
+      communityId: created.community.id,
+    });
+    expect(result).toEqual({ items: [] });
+  });
+
+  test("lists locked padel and golf results involving members, newest lockedAt first", async () => {
+    const { create, join, matches, golfRounds, activity } = await setup();
+    const created = await create.execute({
+      userId: "user-a",
+      name: "Multi Sport Sundays",
+      city: "Joburg",
+      sport: "multi",
+    });
+    await join.execute({
+      userId: "user-b",
+      communityId: created.community.id,
+    });
+
+    const olderPadel = lockedPadel({
+      venueCmsId: "sanity-court-1",
+      startsAt: "2026-08-29T10:00:00.000Z",
+      lockedAt: "2026-08-29T11:00:00.000Z",
+      lockedByUserId: "user-a",
+      pairings: memberPairings("user-a", "Alex"),
+    });
+    const bothMembers = lockedPadel({
+      venueCmsId: "sanity-court-1",
+      startsAt: "2026-08-30T10:00:00.000Z",
+      lockedAt: "2026-08-30T12:00:00.000Z",
+      lockedByUserId: "user-a",
+      pairings: {
+        teamA: [
+          { displayName: "Alex Lange", isGuest: false, userId: "user-a" },
+          { displayName: "Sam Guest", isGuest: true, userId: null },
+        ],
+        teamB: [
+          { displayName: "Blake Rivers", isGuest: false, userId: "user-b" },
+          { displayName: "Riley Guest", isGuest: true, userId: null },
+        ],
+      },
+      score: {
+        sets: [
+          { gamesA: 6, gamesB: 4, tieBreak: null, winner: "A" },
+          {
+            gamesA: 7,
+            gamesB: 6,
+            tieBreak: { pointsA: 7, pointsB: 5 },
+            winner: "A",
+          },
+        ],
+      },
+    });
+    const golf = lockedGolf({
+      venueCmsId: "sanity-course-1",
+      startsAt: "2026-09-04T10:00:00.000Z",
+      lockedAt: "2026-09-04T12:00:00.000Z",
+      lockedByUserId: "user-b",
+      players: [
+        {
+          slot: 1,
+          displayName: "Blake",
+          isGuest: false,
+          userId: "user-b",
+        },
+        { slot: 2, displayName: "Casey Guest", isGuest: true, userId: null },
+      ],
+    });
+
+    await matches.create(olderPadel);
+    await matches.create(bothMembers);
+    await golfRounds.create(golf);
+
+    const live = Match.create({
+      venueCmsId: CmsId.from("sanity-court-1"),
+      startsAt: StartsAt.from("2026-09-05T10:00:00.000Z"),
+      ruleset: Ruleset.from("golden_point"),
+      pairings: memberPairings("user-a", "Alex"),
+    });
+    await matches.create(live);
+
+    const result = await activity.execute({
+      communityId: created.community.id,
+    });
+
+    expect(result.items.map((item) => item.id)).toEqual([
+      golf.id,
+      bothMembers.id,
+      olderPadel.id,
+    ]);
+    expect(result.items[0]).toMatchObject({
+      id: golf.id,
+      sport: "golf",
+      kind: "round",
+      lockedAt: "2026-09-04T12:00:00.000Z",
+      venueCmsId: "sanity-course-1",
+      venueName: "Golf Club",
+      path: `/golf/${golf.id}`,
+      summary: "Blake 36 · Casey 36",
+      players: [
+        { userId: "user-b", displayName: "Blake", isGuest: false },
+        { userId: null, displayName: "Casey Guest", isGuest: true },
+      ],
+    });
+    expect(result.items[1]).toMatchObject({
+      id: bothMembers.id,
+      sport: "padel",
+      kind: "match",
+      lockedAt: "2026-08-30T12:00:00.000Z",
+      venueCmsId: "sanity-court-1",
+      venueName: "Padel Club",
+      path: `/padel/${bothMembers.id}`,
+      summary: "Alex / Sam vs Blake / Riley · 6–4, 7–6 (7–5)",
+    });
+    expect(result.items[1]?.players).toEqual([
+      { userId: "user-a", displayName: "Alex Lange", isGuest: false },
+      { userId: null, displayName: "Sam Guest", isGuest: true },
+      { userId: "user-b", displayName: "Blake Rivers", isGuest: false },
+      { userId: null, displayName: "Riley Guest", isGuest: true },
+    ]);
+  });
+
+  test("caps the feed at the 30 most recent locked items", async () => {
+    const { create, matches, activity } = await setup();
+    const created = await create.execute({
+      userId: "user-a",
+      name: "Busy League",
+      city: "Cape Town",
+    });
+
+    const createdMatches: Match[] = [];
+    for (let index = 0; index < COMMUNITY_ACTIVITY_LIMIT + 5; index += 1) {
+      const lockedAt = new Date(Date.UTC(2026, 7, 1, 10, index)).toISOString();
+      const match = lockedPadel({
+        venueCmsId: "sanity-court-1",
+        startsAt: lockedAt,
+        lockedAt,
+        lockedByUserId: "user-a",
+        pairings: memberPairings("user-a", "Alex"),
+      });
+      createdMatches.push(match);
+      await matches.create(match);
+    }
+
+    const result = await activity.execute({
+      communityId: created.community.id,
+    });
+    expect(result.items).toHaveLength(COMMUNITY_ACTIVITY_LIMIT);
+    expect(result.items[0]?.id).toBe(createdMatches.at(-1)?.id);
+    expect(result.items.at(-1)?.id).toBe(
+      createdMatches[createdMatches.length - COMMUNITY_ACTIVITY_LIMIT]?.id,
+    );
+  });
+});

--- a/src/modules/communities/services/list-community-activity.service.ts
+++ b/src/modules/communities/services/list-community-activity.service.ts
@@ -1,0 +1,97 @@
+import { DomainError } from "../../../lib/domain-error";
+import { GolfRoundRepository } from "../../golf-round/repositories/golf-round.repository";
+import { MatchRepository } from "../../match/repositories/match.repository";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Venue } from "../../venue/entities/venue";
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { CommunityNotFoundError } from "../entities/community-not-found-error";
+import { CommunityRepository } from "../repositories/community.repository";
+import {
+  COMMUNITY_ACTIVITY_LIMIT,
+  CommunityActivityItem,
+  compareActivityItemsNewestFirst,
+  toGolfActivityItem,
+  toPadelActivityItem,
+} from "./community-activity-item";
+
+export class ListCommunityActivity {
+  constructor(
+    private readonly communities: CommunityRepository,
+    private readonly matches: MatchRepository,
+    private readonly golfRounds: GolfRoundRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async execute(input: {
+    communityId: string;
+  }): Promise<{ items: CommunityActivityItem[] }> {
+    const communityId = input.communityId.trim();
+    if (!communityId) throw new DomainError("community id is required");
+
+    const community = await this.communities.findById(communityId);
+    if (!community) throw new CommunityNotFoundError();
+
+    const memberIds = community.members.map((member) => member.userId);
+    if (memberIds.length === 0) {
+      return { items: [] };
+    }
+
+    const [matchLists, roundLists] = await Promise.all([
+      Promise.all(
+        memberIds.map((userId) => this.matches.listLockedByPlayerUserId(userId)),
+      ),
+      Promise.all(
+        memberIds.map((userId) =>
+          this.golfRounds.listLockedByPlayerUserId(userId),
+        ),
+      ),
+    ]);
+
+    const matchesById = new Map(
+      matchLists.flat().map((match) => [match.id, match]),
+    );
+    const roundsById = new Map(
+      roundLists.flat().map((round) => [round.id, round]),
+    );
+
+    const venuesByCmsId = await loadVenuesByCmsId(this.venues, [
+      ...[...matchesById.values()].map((match) => match.venueCmsId),
+      ...[...roundsById.values()].map((round) => round.venueCmsId),
+    ]);
+
+    const items: CommunityActivityItem[] = [
+      ...[...matchesById.values()].map((match) =>
+        toPadelActivityItem(
+          match,
+          venuesByCmsId.get(match.venueCmsId.value)?.name.value ?? null,
+        ),
+      ),
+      ...[...roundsById.values()].map((round) =>
+        toGolfActivityItem(
+          round,
+          venuesByCmsId.get(round.venueCmsId.value)?.name.value ?? null,
+        ),
+      ),
+    ];
+
+    items.sort(compareActivityItemsNewestFirst);
+    return { items: items.slice(0, COMMUNITY_ACTIVITY_LIMIT) };
+  }
+}
+
+async function loadVenuesByCmsId(
+  venues: VenueRepository,
+  cmsIds: CmsId[],
+): Promise<Map<string, Venue>> {
+  const unique = [
+    ...new Map(cmsIds.map((cmsId) => [cmsId.value, cmsId])).values(),
+  ];
+  const found = unique.length === 0 ? [] : await venues.findByCmsIds(unique);
+  return new Map(found.map((venue) => [venue.cmsId.value, venue]));
+}
+
+export { COMMUNITY_ACTIVITY_LIMIT } from "./community-activity-item";
+export type {
+  CommunityActivityItem,
+  CommunityActivityPlayer,
+} from "./community-activity-item";


### PR DESCRIPTION
API slice for [landing-page#140](https://github.com/leaguesports/landing-page/issues/140) (Communities v3). Frontend feed + challenge CTA should follow in a second PR after this contract exists.

**Do not merge — Brandon merges.**

## HTTP contract (for landing-page)

### `GET /api/communities/:id/activity`

Public read. Same visibility as `GET /api/communities/:id` — no session cookie required. Open/public communities stay readable without auth.

**Success `200`**

```json
{
  "items": [
    {
      "id": "uuid",
      "sport": "padel",
      "kind": "match",
      "lockedAt": "2026-08-29T11:00:00.000Z",
      "venueCmsId": "string-or-null",
      "venueName": "string-or-null",
      "path": "/padel/{id}",
      "summary": "Alex / Sam vs Jordan / Riley · 6–4",
      "players": [
        { "userId": "string-or-null", "displayName": "Alex", "isGuest": false }
      ]
    }
  ]
}
```

Golf items:

- `sport: "golf"`
- `kind: "round"`
- `path: "/golf/{id}"`
- `summary` example: `"Alex 36 · Casey 45"` (first name + gross strokes)

Empty community / no locked results: `{ "items": [] }` (still `200`).

**Errors**

| Status | Body | When |
| --- | --- | --- |
| 404 | `{ "error": "Community not found" }` | Unknown `:id` (same as GET community) |
| 400 | `{ "error": "community id is required" }` | Blank id |
| 400 | `{ "error": "Invalid communities payload" }` | Invalid params |

**Rules**

- Locked padel matches and locked golf rounds only. Live/unlocked scorecards are omitted.
- A result is included when **any** community member `userId` is seated on it (guests still appear in `players`).
- Deduped if two members shared the same match/round.
- Newest `lockedAt` first, cap **30**.
- `path` is the landing-page deep link (`/padel/{id}` or `/golf/{id}`).
- Padel `summary` uses first names + set scores with an en-dash (`6–4, 7–6 (7–5)`).
- No join-event chrome (`Sarah joined 2h ago`).

## Implementation

Reuses existing `listLockedByPlayerUserId` on Match / GolfRound, scoped to member user ids. Venue names come from the venue repo. **No Prisma migration** — derived from Match, GolfRound, and CommunityMember. Do not run `prisma migrate deploy` for this PR.

## Tests

```bash
yarn test
yarn build
```

Local run: 44 suites, 247 tests passed; `yarn build` (tsc) passed.
