### PR TITLE
feat: in-app notifications for organised-game invites

### DIFF
--- a/prisma/migrations/20260907140000_in_app_notification/migration.sql
+++ b/prisma/migrations/20260907140000_in_app_notification/migration.sql
@@ -1,0 +1,25 @@
+-- CreateEnum
+CREATE TYPE "NotificationType" AS ENUM ('organised_game_invite');
+
+-- CreateTable
+CREATE TABLE "Notification" (
+    "id" TEXT NOT NULL,
+    "recipientId" TEXT NOT NULL,
+    "actorId" TEXT NOT NULL,
+    "type" "NotificationType" NOT NULL,
+    "resourceId" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "readAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Notification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Notification_recipientId_type_resourceId_key" ON "Notification"("recipientId", "type", "resourceId");
+
+-- CreateIndex
+CREATE INDEX "Notification_recipientId_createdAt_idx" ON "Notification"("recipientId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Notification_recipientId_readAt_idx" ON "Notification"("recipientId", "readAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -366,6 +366,27 @@ model OrganisedGameInvite {
   @@index([gameId])
 }
 
+enum NotificationType {
+  organised_game_invite
+}
+
+// In-app inbox. No User FK — same as Friendship / OrganisedGameInvite.
+// Unique (recipientId, type, resourceId) keeps invite notices idempotent.
+model Notification {
+  id          String           @id @default(uuid())
+  recipientId String
+  actorId     String
+  type        NotificationType
+  resourceId  String
+  payload     Json
+  readAt      DateTime?
+  createdAt   DateTime         @default(now())
+
+  @@unique([recipientId, type, resourceId])
+  @@index([recipientId, createdAt])
+  @@index([recipientId, readAt])
+}
+
 model GolfRound {
   id           String          @id @default(uuid())
   venueCmsId   String

--- a/src/app.ts
+++ b/src/app.ts
@@ -50,6 +50,10 @@ import {
   createOrganisedGamesModule,
   OrganisedGameRepository,
 } from "./modules/organised-games";
+import {
+  createNotificationsModule,
+  NotificationRepository,
+} from "./modules/notifications";
 
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
@@ -65,6 +69,7 @@ export type CreateAppDependencies = {
   integrationConnectionRepository?: IntegrationConnectionRepository;
   poolRepository?: PoolRepository;
   organisedGameRepository?: OrganisedGameRepository;
+  notificationRepository?: NotificationRepository;
 };
 
 export async function createApp(
@@ -161,6 +166,13 @@ export async function createApp(
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
+  const notifications = createNotificationsModule({
+    prisma,
+    notificationRepository: dependencies.notificationRepository,
+    friendProfileLookup: friends.friendProfileLookup,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
   const organisedGames = createOrganisedGamesModule({
     prisma,
     venueRepository: venue.venueRepository,
@@ -169,6 +181,7 @@ export async function createApp(
     matchRepository: match.matchRepository,
     golfRoundRepository: golfRound.golfRoundRepository,
     organisedGameRepository: dependencies.organisedGameRepository,
+    inviteNotifier: notifications.organisedGameInviteNotifier,
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
@@ -184,6 +197,7 @@ export async function createApp(
   app.use(training.router);
   app.use(integrations.router);
   app.use(pools.router);
+  app.use(notifications.router);
   app.use(organisedGames.router);
 
   app.use(

--- a/src/modules/notifications/controllers/notifications.controller.ts
+++ b/src/modules/notifications/controllers/notifications.controller.ts
@@ -1,0 +1,104 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { NotificationNotFoundError } from "../entities/notification-not-found-error";
+import { NotificationPersistenceError } from "../entities/notification-persistence-error";
+import {
+  ListMyNotifications,
+  MarkAllNotificationsRead,
+  MarkNotificationRead,
+} from "../services/notifications.service";
+
+const listQuerySchema = z.object({
+  limit: z.string().optional(),
+  cursor: z.string().optional(),
+});
+
+const notificationIdParamSchema = z.object({
+  id: z.string(),
+});
+
+export function createNotificationsController(deps: {
+  listMyNotifications: ListMyNotifications;
+  markNotificationRead: MarkNotificationRead;
+  markAllNotificationsRead: MarkAllNotificationsRead;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async list(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const query = z.parse(listQuerySchema, req.query ?? {});
+        const limitRaw = query.limit
+          ? Number.parseInt(query.limit, 10)
+          : undefined;
+        const result = await deps.listMyNotifications.execute({
+          userId,
+          limit: limitRaw,
+          cursor: query.cursor,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendNotificationsError(res, error);
+      }
+    },
+
+    async markRead(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(notificationIdParamSchema, req.params);
+        const result = await deps.markNotificationRead.execute({
+          userId,
+          notificationId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendNotificationsError(res, error);
+      }
+    },
+
+    async markAllRead(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const result = await deps.markAllNotificationsRead.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendNotificationsError(res, error);
+      }
+    },
+  };
+}
+
+function sendNotificationsError(res: Response, error: unknown) {
+  if (error instanceof NotificationNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid notifications payload" });
+  }
+
+  if (error instanceof NotificationPersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/notifications/controllers/notifications.http.test.ts
+++ b/src/modules/notifications/controllers/notifications.http.test.ts
@@ -1,0 +1,280 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { signAuthenticationToken } from "../../identity/utils/jwt";
+import { InMemoryOrganisedGameRepository } from "../../organised-games/repositories/in-memory-organised-game.repository";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { InMemoryNotificationRepository } from "../repositories/in-memory-notification.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function becomeFriends(
+  friendships: InMemoryFriendshipRepository,
+  a: string,
+  b: string,
+) {
+  const pending = await friendships.createPending(a, b);
+  await friendships.accept(pending.id);
+}
+
+type NotificationListBody = {
+  notifications: Array<{
+    id: string;
+    type: string;
+    actor: { id: string; handle: string };
+    payload: {
+      organisedGameId: string;
+      sport: string;
+      startsAt: string;
+      venueCmsId: string | null;
+    };
+    readAt: string | null;
+    createdAt: string;
+  }>;
+  unreadCount: number;
+  nextCursor: string | null;
+};
+
+describe("notifications HTTP", () => {
+  const config = makeConfig();
+  let venues: InMemoryVenueRepository;
+  let friendships: InMemoryFriendshipRepository;
+  let profiles: InMemoryFriendProfileLookup;
+  let games: InMemoryOrganisedGameRepository;
+  let notifications: InMemoryNotificationRepository;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  function cookie(userId: string) {
+    return `token=${signAuthenticationToken(config, { userId })}`;
+  }
+
+  beforeEach(async () => {
+    venues = new InMemoryVenueRepository();
+    friendships = new InMemoryFriendshipRepository();
+    profiles = new InMemoryFriendProfileLookup();
+    games = new InMemoryOrganisedGameRepository();
+    notifications = new InMemoryNotificationRepository();
+
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-court-1"),
+        VenueName.from("Padel Club"),
+        Slug.from("padel-club"),
+      ),
+      { refreshDetails: false },
+    );
+
+    profiles.seed({
+      userId: "user-a",
+      displayName: "Alex",
+      handle: "alex",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-b",
+      displayName: "Blake",
+      handle: "blake",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-c",
+      displayName: "Casey",
+      handle: "casey",
+      avatarUrl: null,
+    });
+
+    await becomeFriends(friendships, "user-a", "user-b");
+
+    app = await createApp(config, {
+      venueRepository: venues,
+      friendshipRepository: friendships,
+      friendProfileLookup: profiles,
+      organisedGameRepository: games,
+      notificationRepository: notifications,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("invite and share-link join create in-app notices; list/read are recipient-only", async () => {
+    const unauth = await fetch(`${server.url}/api/me/notifications`);
+    expect(unauth.status).toBe(401);
+
+    const created = await fetch(`${server.url}/api/organised-games`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        sport: "padel",
+        venueCmsId: "sanity-court-1",
+        startsAt: "2026-09-07T18:00:00.000Z",
+        inviteUserIds: ["user-b"],
+      }),
+    });
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as {
+      game: { id: string; inviteToken: string };
+    };
+
+    const hostInbox = await fetch(`${server.url}/api/me/notifications`, {
+      headers: { Cookie: cookie("user-a") },
+    });
+    expect(hostInbox.status).toBe(200);
+    expect(await hostInbox.json()).toEqual({
+      notifications: [],
+      unreadCount: 0,
+      nextCursor: null,
+    });
+
+    const inviteeInbox = await fetch(`${server.url}/api/me/notifications`, {
+      headers: { Cookie: cookie("user-b") },
+    });
+    expect(inviteeInbox.status).toBe(200);
+    const inviteeBody = (await inviteeInbox.json()) as NotificationListBody;
+    expect(inviteeBody.unreadCount).toBe(1);
+    expect(inviteeBody.notifications).toEqual([
+      expect.objectContaining({
+        type: "organised_game_invite",
+        actor: expect.objectContaining({ id: "user-a", handle: "alex" }),
+        payload: {
+          organisedGameId: createdBody.game.id,
+          sport: "padel",
+          startsAt: "2026-09-07T18:00:00.000Z",
+          venueCmsId: "sanity-court-1",
+        },
+        readAt: null,
+      }),
+    ]);
+
+    const joined = await fetch(
+      `${server.url}/api/organised-games/invite/${createdBody.game.inviteToken}/join`,
+      { method: "POST", headers: { Cookie: cookie("user-c") } },
+    );
+    expect(joined.status).toBe(200);
+
+    const joinerInbox = await fetch(`${server.url}/api/me/notifications`, {
+      headers: { Cookie: cookie("user-c") },
+    });
+    const joinerBody = (await joinerInbox.json()) as NotificationListBody;
+    expect(joinerBody.unreadCount).toBe(1);
+    expect(joinerBody.notifications[0]?.payload.organisedGameId).toBe(
+      createdBody.game.id,
+    );
+
+    const noticeId = inviteeBody.notifications[0]!.id;
+    const asOther = await fetch(
+      `${server.url}/api/me/notifications/${noticeId}/read`,
+      { method: "POST", headers: { Cookie: cookie("user-c") } },
+    );
+    expect(asOther.status).toBe(404);
+
+    const marked = await fetch(
+      `${server.url}/api/me/notifications/${noticeId}/read`,
+      { method: "POST", headers: { Cookie: cookie("user-b") } },
+    );
+    expect(marked.status).toBe(200);
+    expect(await marked.json()).toMatchObject({
+      notification: { id: noticeId, readAt: expect.any(String) },
+    });
+
+    const afterRead = await fetch(`${server.url}/api/me/notifications`, {
+      headers: { Cookie: cookie("user-b") },
+    });
+    expect(await afterRead.json()).toMatchObject({ unreadCount: 0 });
+
+    await fetch(
+      `${server.url}/api/organised-games/invite/${createdBody.game.inviteToken}/join`,
+      { method: "POST", headers: { Cookie: cookie("user-c") } },
+    );
+    const joinerAgain = await fetch(`${server.url}/api/me/notifications`, {
+      headers: { Cookie: cookie("user-c") },
+    });
+    expect((await joinerAgain.json() as NotificationListBody).notifications).toHaveLength(
+      1,
+    );
+
+    const readAll = await fetch(`${server.url}/api/me/notifications/read-all`, {
+      method: "POST",
+      headers: { Cookie: cookie("user-c") },
+    });
+    expect(readAll.status).toBe(200);
+    expect(await readAll.json()).toEqual({ ok: true, unreadCount: 0 });
+  });
+
+  test("opening organised-game detail marks the invite notice read", async () => {
+    const created = await fetch(`${server.url}/api/organised-games`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        sport: "padel",
+        venueCmsId: "sanity-court-1",
+        startsAt: "2026-09-07T18:00:00.000Z",
+        inviteUserIds: ["user-b"],
+      }),
+    });
+    const { game } = (await created.json()) as { game: { id: string } };
+
+    const before = await fetch(`${server.url}/api/me/notifications`, {
+      headers: { Cookie: cookie("user-b") },
+    });
+    expect((await before.json() as NotificationListBody).unreadCount).toBe(1);
+
+    const detail = await fetch(`${server.url}/api/organised-games/${game.id}`, {
+      headers: { Cookie: cookie("user-b") },
+    });
+    expect(detail.status).toBe(200);
+
+    const after = await fetch(`${server.url}/api/me/notifications`, {
+      headers: { Cookie: cookie("user-b") },
+    });
+    expect(await after.json()).toMatchObject({ unreadCount: 0 });
+  });
+});

--- a/src/modules/notifications/entities/notification-not-found-error.ts
+++ b/src/modules/notifications/entities/notification-not-found-error.ts
@@ -1,0 +1,6 @@
+export class NotificationNotFoundError extends Error {
+  constructor(message = "Notification not found") {
+    super(message);
+    this.name = "NotificationNotFoundError";
+  }
+}

--- a/src/modules/notifications/entities/notification-persistence-error.ts
+++ b/src/modules/notifications/entities/notification-persistence-error.ts
@@ -1,0 +1,9 @@
+export class NotificationPersistenceError extends Error {
+  constructor(
+    message = "Unable to save notification",
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "NotificationPersistenceError";
+  }
+}

--- a/src/modules/notifications/entities/notification-type.ts
+++ b/src/modules/notifications/entities/notification-type.ts
@@ -1,0 +1,33 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const NOTIFICATION_TYPES = ["organised_game_invite"] as const;
+export type NotificationTypeValue = (typeof NOTIFICATION_TYPES)[number];
+
+export class NotificationType {
+  static readonly ORGANISED_GAME_INVITE = new NotificationType(
+    "organised_game_invite",
+  );
+
+  private constructor(readonly value: NotificationTypeValue) {}
+
+  static from(raw: unknown): NotificationType {
+    if (typeof raw !== "string") {
+      throw new DomainError("notification type is required");
+    }
+
+    const type = raw.trim().toLowerCase();
+    if (type === "organised_game_invite") {
+      return NotificationType.ORGANISED_GAME_INVITE;
+    }
+
+    throw new DomainError("Unknown notification type");
+  }
+
+  get isOrganisedGameInvite(): boolean {
+    return this.value === "organised_game_invite";
+  }
+
+  equals(other: NotificationType): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/notifications/entities/notification.test.ts
+++ b/src/modules/notifications/entities/notification.test.ts
@@ -1,0 +1,60 @@
+import { Notification } from "./notification";
+import { OrganisedGameInvitePayload } from "./organised-game-invite-payload";
+
+describe("Notification", () => {
+  test("organised-game invite is unread and cannot notify the actor", () => {
+    const notification = Notification.organisedGameInvite({
+      recipientId: "friend-a",
+      actorId: "host-1",
+      organisedGameId: "game-1",
+      sport: "padel",
+      startsAt: "2026-09-07T18:00:00.000Z",
+      venueCmsId: "sanity-court-1",
+    });
+
+    expect(notification.isUnread).toBe(true);
+    expect(notification.type.value).toBe("organised_game_invite");
+    expect(notification.resourceId).toBe("game-1");
+    expect(notification.payload.toSnapshot()).toEqual({
+      organisedGameId: "game-1",
+      sport: "padel",
+      startsAt: "2026-09-07T18:00:00.000Z",
+      venueCmsId: "sanity-court-1",
+    });
+
+    expect(() =>
+      Notification.organisedGameInvite({
+        recipientId: "host-1",
+        actorId: "host-1",
+        organisedGameId: "game-1",
+        sport: "golf",
+        startsAt: "2026-09-07T18:00:00.000Z",
+      }),
+    ).toThrow("Cannot notify the actor");
+  });
+
+  test("markRead is idempotent and round-trips through a snapshot", () => {
+    const notification = Notification.organisedGameInvite({
+      recipientId: "friend-a",
+      actorId: "host-1",
+      organisedGameId: "game-1",
+      sport: "golf",
+      startsAt: "2026-09-07T18:00:00.000Z",
+      venueCmsId: null,
+    });
+
+    const at = new Date("2026-09-07T12:00:00.000Z");
+    notification.markRead(at);
+    notification.markRead(new Date("2026-09-07T13:00:00.000Z"));
+    expect(notification.readAt?.toISOString()).toBe(at.toISOString());
+
+    const restored = Notification.fromSnapshot(notification.toSnapshot());
+    expect(restored.toSnapshot()).toEqual(notification.toSnapshot());
+  });
+
+  test("payload rejects unknown sport", () => {
+    expect(() => OrganisedGameInvitePayload.from({ organisedGameId: "g" })).toThrow(
+      "sport must be padel or golf",
+    );
+  });
+});

--- a/src/modules/notifications/entities/notification.ts
+++ b/src/modules/notifications/entities/notification.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import {
+  OrganisedGameInvitePayload,
+  OrganisedGameInvitePayloadSnapshot,
+} from "./organised-game-invite-payload";
+import { NotificationType } from "./notification-type";
+
+export type NotificationSnapshot = {
+  id: string;
+  recipientId: string;
+  actorId: string;
+  type: "organised_game_invite";
+  resourceId: string;
+  payload: OrganisedGameInvitePayloadSnapshot;
+  readAt: string | null;
+  createdAt: string;
+};
+
+export type CreateOrganisedGameInviteNotificationProps = {
+  recipientId: string;
+  actorId: string;
+  organisedGameId: string;
+  sport: unknown;
+  startsAt: unknown;
+  venueCmsId?: unknown;
+};
+
+export class Notification {
+  private constructor(
+    readonly id: string,
+    readonly recipientId: string,
+    readonly actorId: string,
+    readonly type: NotificationType,
+    readonly resourceId: string,
+    readonly payload: OrganisedGameInvitePayload,
+    readonly createdAt: Date,
+    private readAtValue: Date | null,
+  ) {}
+
+  static organisedGameInvite(
+    props: CreateOrganisedGameInviteNotificationProps,
+  ): Notification {
+    const recipientId = requiredTrimmed(props.recipientId, "recipientId");
+    const actorId = requiredTrimmed(props.actorId, "actorId");
+    if (recipientId === actorId) {
+      throw new DomainError("Cannot notify the actor");
+    }
+
+    const payload = OrganisedGameInvitePayload.from({
+      organisedGameId: props.organisedGameId,
+      sport: props.sport,
+      startsAt: props.startsAt,
+      venueCmsId: props.venueCmsId,
+    });
+
+    return new Notification(
+      randomUUID(),
+      recipientId,
+      actorId,
+      NotificationType.ORGANISED_GAME_INVITE,
+      payload.organisedGameId,
+      payload,
+      new Date(),
+      null,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    recipientId: string;
+    actorId: string;
+    type: NotificationType;
+    resourceId: string;
+    payload: OrganisedGameInvitePayload;
+    createdAt: Date;
+    readAt: Date | null;
+  }): Notification {
+    return new Notification(
+      props.id,
+      props.recipientId,
+      props.actorId,
+      props.type,
+      props.resourceId,
+      props.payload,
+      props.createdAt,
+      props.readAt,
+    );
+  }
+
+  static fromSnapshot(snapshot: NotificationSnapshot): Notification {
+    return Notification.rehydrate({
+      id: snapshot.id,
+      recipientId: snapshot.recipientId,
+      actorId: snapshot.actorId,
+      type: NotificationType.from(snapshot.type),
+      resourceId: snapshot.resourceId,
+      payload: OrganisedGameInvitePayload.from(snapshot.payload),
+      createdAt: new Date(snapshot.createdAt),
+      readAt: snapshot.readAt ? new Date(snapshot.readAt) : null,
+    });
+  }
+
+  get readAt(): Date | null {
+    return this.readAtValue;
+  }
+
+  get isUnread(): boolean {
+    return this.readAtValue == null;
+  }
+
+  markRead(now = new Date()): void {
+    if (this.readAtValue) return;
+    this.readAtValue = now;
+  }
+
+  toSnapshot(): NotificationSnapshot {
+    return {
+      id: this.id,
+      recipientId: this.recipientId,
+      actorId: this.actorId,
+      type: this.type.value,
+      resourceId: this.resourceId,
+      payload: this.payload.toSnapshot(),
+      readAt: this.readAtValue?.toISOString() ?? null,
+      createdAt: this.createdAt.toISOString(),
+    };
+  }
+}

--- a/src/modules/notifications/entities/organised-game-invite-payload.ts
+++ b/src/modules/notifications/entities/organised-game-invite-payload.ts
@@ -1,0 +1,86 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const SPORTS = ["padel", "golf"] as const;
+export type OrganisedGameInviteSport = (typeof SPORTS)[number];
+
+export type OrganisedGameInvitePayloadSnapshot = {
+  organisedGameId: string;
+  sport: OrganisedGameInviteSport;
+  startsAt: string;
+  venueCmsId: string | null;
+};
+
+export class OrganisedGameInvitePayload {
+  private constructor(
+    readonly organisedGameId: string,
+    readonly sport: OrganisedGameInviteSport,
+    readonly startsAt: Date,
+    readonly venueCmsId: string | null,
+  ) {}
+
+  static from(raw: unknown): OrganisedGameInvitePayload {
+    if (!raw || typeof raw !== "object") {
+      throw new DomainError("notification payload is required");
+    }
+
+    const record = raw as Record<string, unknown>;
+    const organisedGameId = requiredTrimmed(
+      record.organisedGameId,
+      "organisedGameId",
+    );
+    const sport = parseSport(record.sport);
+    const startsAt = parseStartsAt(record.startsAt);
+    const venueCmsId = parseOptionalCmsId(record.venueCmsId);
+
+    return new OrganisedGameInvitePayload(
+      organisedGameId,
+      sport,
+      startsAt,
+      venueCmsId,
+    );
+  }
+
+  toSnapshot(): OrganisedGameInvitePayloadSnapshot {
+    return {
+      organisedGameId: this.organisedGameId,
+      sport: this.sport,
+      startsAt: this.startsAt.toISOString(),
+      venueCmsId: this.venueCmsId,
+    };
+  }
+}
+
+function parseSport(raw: unknown): OrganisedGameInviteSport {
+  if (typeof raw !== "string") {
+    throw new DomainError("sport must be padel or golf");
+  }
+  const sport = raw.trim().toLowerCase();
+  if (sport === "padel" || sport === "golf") return sport;
+  throw new DomainError("sport must be padel or golf");
+}
+
+function parseStartsAt(raw: unknown): Date {
+  if (raw instanceof Date) {
+    if (Number.isNaN(raw.getTime())) {
+      throw new DomainError("startsAt must be a valid date");
+    }
+    return raw;
+  }
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new DomainError("startsAt is required");
+  }
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new DomainError("startsAt must be a valid date");
+  }
+  return parsed;
+}
+
+function parseOptionalCmsId(raw: unknown): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") {
+    throw new DomainError("venueCmsId must be a string");
+  }
+  const value = raw.trim();
+  return value.length === 0 ? null : value;
+}

--- a/src/modules/notifications/index.ts
+++ b/src/modules/notifications/index.ts
@@ -1,0 +1,93 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { FriendProfileLookup } from "../friends/repositories/friendship.repository";
+import { createNotificationsController } from "./controllers/notifications.controller";
+import { NotificationRepository } from "./repositories/notification.repository";
+import { PrismaNotificationRepository } from "./repositories/prisma-notification.repository";
+import { createNotificationsRoutes } from "./routes/notifications.routes";
+import {
+  ListMyNotifications,
+  MarkAllNotificationsRead,
+  MarkNotificationRead,
+  NotifyOrganisedGameInvite,
+  OrganisedGameInviteNotifier,
+} from "./services/notifications.service";
+
+export type CreateNotificationsModuleParams = {
+  prisma: PrismaClient;
+  notificationRepository?: NotificationRepository;
+  friendProfileLookup: FriendProfileLookup;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type NotificationsModule = {
+  router: Router;
+  notificationRepository: NotificationRepository;
+  organisedGameInviteNotifier: OrganisedGameInviteNotifier;
+};
+
+export function createNotificationsModule({
+  prisma,
+  notificationRepository: notificationRepositoryOverride,
+  friendProfileLookup,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreateNotificationsModuleParams): NotificationsModule {
+  const notificationRepository =
+    notificationRepositoryOverride ?? new PrismaNotificationRepository(prisma);
+
+  const organisedGameInviteNotifier = new NotifyOrganisedGameInvite(
+    notificationRepository,
+  );
+
+  const controller = createNotificationsController({
+    listMyNotifications: new ListMyNotifications(
+      notificationRepository,
+      friendProfileLookup,
+    ),
+    markNotificationRead: new MarkNotificationRead(
+      notificationRepository,
+      friendProfileLookup,
+    ),
+    markAllNotificationsRead: new MarkAllNotificationsRead(
+      notificationRepository,
+    ),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createNotificationsRoutes(controller, { requireAuth }),
+    notificationRepository,
+    organisedGameInviteNotifier,
+  };
+}
+
+export { createNotificationsController } from "./controllers/notifications.controller";
+export { InMemoryNotificationRepository } from "./repositories/in-memory-notification.repository";
+export { PrismaNotificationRepository } from "./repositories/prisma-notification.repository";
+export type { NotificationRepository } from "./repositories/notification.repository";
+export { Notification } from "./entities/notification";
+export { NotificationType } from "./entities/notification-type";
+export { OrganisedGameInvitePayload } from "./entities/organised-game-invite-payload";
+export { NotificationNotFoundError } from "./entities/notification-not-found-error";
+export { NotificationPersistenceError } from "./entities/notification-persistence-error";
+export {
+  ListMyNotifications,
+  MarkAllNotificationsRead,
+  MarkNotificationRead,
+  NotifyOrganisedGameInvite,
+} from "./services/notifications.service";
+export type {
+  OrganisedGameInviteNotice,
+  OrganisedGameInviteNotifier,
+  PublicNotification,
+  PublicNotificationActor,
+  PublicOrganisedGameInvitePayload,
+} from "./services/notifications.service";

--- a/src/modules/notifications/repositories/in-memory-notification.repository.ts
+++ b/src/modules/notifications/repositories/in-memory-notification.repository.ts
@@ -1,0 +1,138 @@
+import { Notification } from "../entities/notification";
+import { NotificationPersistenceError } from "../entities/notification-persistence-error";
+import { NotificationType } from "../entities/notification-type";
+import {
+  NotificationCursor,
+  NotificationListPage,
+  NotificationListQuery,
+  NotificationRepository,
+} from "./notification.repository";
+
+export class InMemoryNotificationRepository implements NotificationRepository {
+  private readonly byId = new Map<string, Notification>();
+
+  async create(notification: Notification): Promise<Notification> {
+    const existing = this.findByUnique(
+      notification.recipientId,
+      notification.type,
+      notification.resourceId,
+    );
+    if (existing) return clone(existing)!;
+
+    const stored = clone(notification)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async findById(id: string): Promise<Notification | null> {
+    return clone(this.byId.get(id) ?? null);
+  }
+
+  async persist(notification: Notification): Promise<Notification> {
+    if (!this.byId.has(notification.id)) {
+      throw new NotificationPersistenceError("Unable to save notification");
+    }
+    const stored = clone(notification)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async listPage(query: NotificationListQuery): Promise<NotificationListPage> {
+    const recipientId = query.recipientId.trim();
+    const all = [...this.byId.values()].filter(
+      (notification) => notification.recipientId === recipientId,
+    );
+    const unreadCount = all.filter((notification) => notification.isUnread).length;
+    const ordered = all.sort(compareNotifications);
+    const afterCursor = query.cursor
+      ? ordered.filter((notification) => isAfterCursor(notification, query.cursor!))
+      : ordered;
+    const window = afterCursor.slice(0, query.limit + 1);
+    const hasMore = window.length > query.limit;
+    return {
+      items: window.slice(0, query.limit).map((notification) => clone(notification)!),
+      unreadCount,
+      hasMore,
+    };
+  }
+
+  async markAllRead(recipientId: string, now = new Date()): Promise<number> {
+    let marked = 0;
+    for (const notification of this.byId.values()) {
+      if (notification.recipientId !== recipientId.trim()) continue;
+      if (!notification.isUnread) continue;
+      notification.markRead(now);
+      marked += 1;
+    }
+    return marked;
+  }
+
+  async markReadByResource(
+    recipientId: string,
+    type: NotificationType,
+    resourceId: string,
+    now = new Date(),
+  ): Promise<number> {
+    let marked = 0;
+    for (const notification of this.byId.values()) {
+      if (notification.recipientId !== recipientId.trim()) continue;
+      if (!notification.type.equals(type)) continue;
+      if (notification.resourceId !== resourceId.trim()) continue;
+      if (!notification.isUnread) continue;
+      notification.markRead(now);
+      marked += 1;
+    }
+    return marked;
+  }
+
+  private findByUnique(
+    recipientId: string,
+    type: NotificationType,
+    resourceId: string,
+  ): Notification | null {
+    for (const notification of this.byId.values()) {
+      if (
+        notification.recipientId === recipientId &&
+        notification.type.equals(type) &&
+        notification.resourceId === resourceId
+      ) {
+        return notification;
+      }
+    }
+    return null;
+  }
+}
+
+function clone(notification: Notification | null): Notification | null {
+  if (!notification) return null;
+  return Notification.fromSnapshot(notification.toSnapshot());
+}
+
+type SortableNotification = {
+  id: string;
+  isUnread: boolean;
+  createdAt: Date;
+};
+
+function compareNotifications(
+  a: SortableNotification,
+  b: SortableNotification,
+): number {
+  if (a.isUnread !== b.isUnread) return a.isUnread ? -1 : 1;
+  const byTime = b.createdAt.getTime() - a.createdAt.getTime();
+  if (byTime !== 0) return byTime;
+  return b.id.localeCompare(a.id);
+}
+
+function isAfterCursor(
+  notification: Notification,
+  cursor: NotificationCursor,
+): boolean {
+  return (
+    compareNotifications(notification, {
+      id: cursor.id,
+      isUnread: cursor.unread,
+      createdAt: cursor.createdAt,
+    }) > 0
+  );
+}

--- a/src/modules/notifications/repositories/notification.repository.ts
+++ b/src/modules/notifications/repositories/notification.repository.ts
@@ -1,0 +1,34 @@
+import { Notification } from "../entities/notification";
+import { NotificationType } from "../entities/notification-type";
+
+export type NotificationCursor = {
+  unread: boolean;
+  createdAt: Date;
+  id: string;
+};
+
+export type NotificationListQuery = {
+  recipientId: string;
+  limit: number;
+  cursor?: NotificationCursor;
+};
+
+export type NotificationListPage = {
+  items: Notification[];
+  unreadCount: number;
+  hasMore: boolean;
+};
+
+export interface NotificationRepository {
+  create(notification: Notification): Promise<Notification>;
+  findById(id: string): Promise<Notification | null>;
+  persist(notification: Notification): Promise<Notification>;
+  listPage(query: NotificationListQuery): Promise<NotificationListPage>;
+  markAllRead(recipientId: string, now?: Date): Promise<number>;
+  markReadByResource(
+    recipientId: string,
+    type: NotificationType,
+    resourceId: string,
+    now?: Date,
+  ): Promise<number>;
+}

--- a/src/modules/notifications/repositories/prisma-notification.repository.ts
+++ b/src/modules/notifications/repositories/prisma-notification.repository.ts
@@ -1,0 +1,214 @@
+import { Prisma, PrismaClient } from "../../../generated/prisma/client";
+import { Notification } from "../entities/notification";
+import { NotificationPersistenceError } from "../entities/notification-persistence-error";
+import { NotificationType } from "../entities/notification-type";
+import { OrganisedGameInvitePayload } from "../entities/organised-game-invite-payload";
+import {
+  NotificationListPage,
+  NotificationListQuery,
+  NotificationRepository,
+} from "./notification.repository";
+
+type NotificationRow = {
+  id: string;
+  recipientId: string;
+  actorId: string;
+  type: "organised_game_invite";
+  resourceId: string;
+  payload: Prisma.JsonValue;
+  readAt: Date | null;
+  createdAt: Date;
+};
+
+function prismaErrorCode(error: unknown): string {
+  if (error && typeof error === "object" && "code" in error) {
+    return String((error as { code?: unknown }).code);
+  }
+  return "";
+}
+
+function toDomain(row: NotificationRow): Notification {
+  return Notification.rehydrate({
+    id: row.id,
+    recipientId: row.recipientId,
+    actorId: row.actorId,
+    type: NotificationType.from(row.type),
+    resourceId: row.resourceId,
+    payload: OrganisedGameInvitePayload.from(row.payload),
+    createdAt: row.createdAt,
+    readAt: row.readAt,
+  });
+}
+
+export class PrismaNotificationRepository implements NotificationRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(notification: Notification): Promise<Notification> {
+    const snapshot = notification.toSnapshot();
+    try {
+      const row = await this.prisma.notification.create({
+        data: {
+          id: snapshot.id,
+          recipientId: snapshot.recipientId,
+          actorId: snapshot.actorId,
+          type: snapshot.type,
+          resourceId: snapshot.resourceId,
+          payload: snapshot.payload as Prisma.InputJsonValue,
+          readAt: notification.readAt,
+          createdAt: notification.createdAt,
+        },
+      });
+      return toDomain(row);
+    } catch (error) {
+      if (prismaErrorCode(error) === "P2002") {
+        const existing = await this.findByUnique(
+          snapshot.recipientId,
+          snapshot.type,
+          snapshot.resourceId,
+        );
+        if (existing) return existing;
+      }
+      throw new NotificationPersistenceError("Failed to create notification", {
+        cause: error,
+      });
+    }
+  }
+
+  async findById(id: string): Promise<Notification | null> {
+    try {
+      const row = await this.prisma.notification.findUnique({ where: { id } });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new NotificationPersistenceError("Failed to load notification", {
+        cause: error,
+      });
+    }
+  }
+
+  async persist(notification: Notification): Promise<Notification> {
+    const snapshot = notification.toSnapshot();
+    try {
+      const row = await this.prisma.notification.update({
+        where: { id: snapshot.id },
+        data: { readAt: notification.readAt },
+      });
+      return toDomain(row);
+    } catch (error) {
+      throw new NotificationPersistenceError("Failed to save notification", {
+        cause: error,
+      });
+    }
+  }
+
+  async listPage(query: NotificationListQuery): Promise<NotificationListPage> {
+    const recipientId = query.recipientId.trim();
+    const take = query.limit + 1;
+    try {
+      const unreadCount = await this.prisma.notification.count({
+        where: { recipientId, readAt: null },
+      });
+
+      const items: Notification[] = [];
+      if (!query.cursor || query.cursor.unread) {
+        const unreadRows = await this.prisma.notification.findMany({
+          where: {
+            recipientId,
+            readAt: null,
+            ...(query.cursor?.unread ? afterCursorWhere(query.cursor) : {}),
+          },
+          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+          take,
+        });
+        items.push(...unreadRows.map(toDomain));
+      }
+
+      if (items.length < take) {
+        const readRows = await this.prisma.notification.findMany({
+          where: {
+            recipientId,
+            readAt: { not: null },
+            ...(query.cursor && !query.cursor.unread
+              ? afterCursorWhere(query.cursor)
+              : {}),
+          },
+          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+          take: take - items.length,
+        });
+        items.push(...readRows.map(toDomain));
+      }
+
+      const hasMore = items.length > query.limit;
+      return {
+        items: hasMore ? items.slice(0, query.limit) : items,
+        unreadCount,
+        hasMore,
+      };
+    } catch (error) {
+      throw new NotificationPersistenceError("Failed to list notifications", {
+        cause: error,
+      });
+    }
+  }
+
+  async markAllRead(recipientId: string, now = new Date()): Promise<number> {
+    try {
+      const result = await this.prisma.notification.updateMany({
+        where: { recipientId: recipientId.trim(), readAt: null },
+        data: { readAt: now },
+      });
+      return result.count;
+    } catch (error) {
+      throw new NotificationPersistenceError(
+        "Failed to mark notifications read",
+        { cause: error },
+      );
+    }
+  }
+
+  async markReadByResource(
+    recipientId: string,
+    type: NotificationType,
+    resourceId: string,
+    now = new Date(),
+  ): Promise<number> {
+    try {
+      const result = await this.prisma.notification.updateMany({
+        where: {
+          recipientId: recipientId.trim(),
+          type: type.value,
+          resourceId: resourceId.trim(),
+          readAt: null,
+        },
+        data: { readAt: now },
+      });
+      return result.count;
+    } catch (error) {
+      throw new NotificationPersistenceError(
+        "Failed to mark notifications read",
+        { cause: error },
+      );
+    }
+  }
+
+  private async findByUnique(
+    recipientId: string,
+    type: "organised_game_invite",
+    resourceId: string,
+  ): Promise<Notification | null> {
+    const row = await this.prisma.notification.findUnique({
+      where: {
+        recipientId_type_resourceId: { recipientId, type, resourceId },
+      },
+    });
+    return row ? toDomain(row) : null;
+  }
+}
+
+function afterCursorWhere(cursor: { createdAt: Date; id: string }) {
+  return {
+    OR: [
+      { createdAt: { lt: cursor.createdAt } },
+      { createdAt: cursor.createdAt, id: { lt: cursor.id } },
+    ],
+  };
+}

--- a/src/modules/notifications/routes/notifications.routes.ts
+++ b/src/modules/notifications/routes/notifications.routes.ts
@@ -1,0 +1,38 @@
+import { Router } from "express";
+
+import { createNotificationsController } from "../controllers/notifications.controller";
+
+export function createNotificationsRoutes(
+  controller: ReturnType<typeof createNotificationsController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.get("/api/me/notifications", options.requireAuth, (req, res) => {
+    void controller.list(req, res);
+  });
+
+  router.post(
+    "/api/me/notifications/read-all",
+    options.requireAuth,
+    (req, res) => {
+      void controller.markAllRead(req, res);
+    },
+  );
+
+  router.post(
+    "/api/me/notifications/:id/read",
+    options.requireAuth,
+    (req, res) => {
+      void controller.markRead(req, res);
+    },
+  );
+
+  return router;
+}

--- a/src/modules/notifications/services/notifications.service.test.ts
+++ b/src/modules/notifications/services/notifications.service.test.ts
@@ -1,0 +1,203 @@
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { Notification } from "../entities/notification";
+import { NotificationNotFoundError } from "../entities/notification-not-found-error";
+import { InMemoryNotificationRepository } from "../repositories/in-memory-notification.repository";
+import {
+  ListMyNotifications,
+  MarkAllNotificationsRead,
+  MarkNotificationRead,
+  NotifyOrganisedGameInvite,
+} from "./notifications.service";
+
+function seedProfiles(profiles: InMemoryFriendProfileLookup) {
+  profiles.seed({
+    userId: "host-1",
+    displayName: "Alex",
+    handle: "alex",
+    avatarUrl: null,
+  });
+  profiles.seed({
+    userId: "friend-a",
+    displayName: "Blake",
+    handle: "blake",
+    avatarUrl: "https://cdn.example/blake.png",
+  });
+  profiles.seed({
+    userId: "friend-b",
+    displayName: "Casey",
+    handle: "casey",
+    avatarUrl: null,
+  });
+}
+
+describe("notifications application", () => {
+  test("invite notice is idempotent and listed unread-first for the recipient only", async () => {
+    const notifications = new InMemoryNotificationRepository();
+    const profiles = new InMemoryFriendProfileLookup();
+    seedProfiles(profiles);
+    const notify = new NotifyOrganisedGameInvite(notifications);
+    const list = new ListMyNotifications(notifications, profiles);
+
+    const notice = {
+      recipientId: "friend-a",
+      actorId: "host-1",
+      organisedGameId: "game-1",
+      sport: "padel" as const,
+      startsAt: "2026-09-07T18:00:00.000Z",
+      venueCmsId: "sanity-court-1",
+    };
+
+    await notify.notifyInviteCreated(notice);
+    await notify.notifyInviteCreated(notice);
+
+    const forInvitee = await list.execute({ userId: "friend-a" });
+    expect(forInvitee.unreadCount).toBe(1);
+    expect(forInvitee.notifications).toEqual([
+      expect.objectContaining({
+        type: "organised_game_invite",
+        actor: { id: "host-1", displayName: "Alex", handle: "alex", avatarUrl: null },
+        payload: {
+          organisedGameId: "game-1",
+          sport: "padel",
+          startsAt: "2026-09-07T18:00:00.000Z",
+          venueCmsId: "sanity-court-1",
+        },
+        readAt: null,
+      }),
+    ]);
+    expect(forInvitee.nextCursor).toBeNull();
+
+    const forHost = await list.execute({ userId: "host-1" });
+    expect(forHost).toEqual({
+      notifications: [],
+      unreadCount: 0,
+      nextCursor: null,
+    });
+
+    await expect(
+      list.execute({ userId: "friend-a", cursor: "not-a-cursor" }),
+    ).rejects.toThrow("cursor is invalid");
+  });
+
+  test("list pages unread first then read, and mark-read is recipient-only", async () => {
+    const notifications = new InMemoryNotificationRepository();
+    const profiles = new InMemoryFriendProfileLookup();
+    seedProfiles(profiles);
+    const list = new ListMyNotifications(notifications, profiles);
+    const markRead = new MarkNotificationRead(notifications, profiles);
+    const markAll = new MarkAllNotificationsRead(notifications);
+
+    await notifications.create(
+      Notification.fromSnapshot({
+        id: "n-old",
+        recipientId: "friend-a",
+        actorId: "host-1",
+        type: "organised_game_invite",
+        resourceId: "game-old",
+        payload: {
+          organisedGameId: "game-old",
+          sport: "golf",
+          startsAt: "2026-09-01T10:00:00.000Z",
+          venueCmsId: null,
+        },
+        createdAt: "2026-09-01T11:00:00.000Z",
+        readAt: "2026-09-06T10:00:00.000Z",
+      }),
+    );
+    await notifications.create(
+      Notification.fromSnapshot({
+        id: "n-new",
+        recipientId: "friend-a",
+        actorId: "host-1",
+        type: "organised_game_invite",
+        resourceId: "game-new",
+        payload: {
+          organisedGameId: "game-new",
+          sport: "padel",
+          startsAt: "2026-09-08T18:00:00.000Z",
+          venueCmsId: "sanity-court-1",
+        },
+        createdAt: "2026-09-07T12:00:00.000Z",
+        readAt: null,
+      }),
+    );
+    await notifications.create(
+      Notification.fromSnapshot({
+        id: "n-mid",
+        recipientId: "friend-a",
+        actorId: "host-1",
+        type: "organised_game_invite",
+        resourceId: "game-mid",
+        payload: {
+          organisedGameId: "game-mid",
+          sport: "golf",
+          startsAt: "2026-09-07T12:00:00.000Z",
+          venueCmsId: "sanity-course-1",
+        },
+        createdAt: "2026-09-07T13:00:00.000Z",
+        readAt: null,
+      }),
+    );
+
+    const firstPage = await list.execute({ userId: "friend-a", limit: 2 });
+    expect(firstPage.unreadCount).toBe(2);
+    expect(firstPage.notifications.map((row) => row.payload.organisedGameId)).toEqual(
+      ["game-mid", "game-new"],
+    );
+    expect(firstPage.notifications.every((row) => row.readAt == null)).toBe(true);
+    expect(firstPage.nextCursor).toEqual(expect.any(String));
+
+    const secondPage = await list.execute({
+      userId: "friend-a",
+      limit: 2,
+      cursor: firstPage.nextCursor,
+    });
+    expect(secondPage.notifications).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({ organisedGameId: "game-old" }),
+        readAt: expect.any(String),
+      }),
+    ]);
+    expect(secondPage.nextCursor).toBeNull();
+
+    await expect(
+      markRead.execute({ userId: "friend-b", notificationId: firstPage.notifications[0]!.id }),
+    ).rejects.toBeInstanceOf(NotificationNotFoundError);
+
+    const marked = await markRead.execute({
+      userId: "friend-a",
+      notificationId: firstPage.notifications[0]!.id,
+    });
+    expect(marked.notification.readAt).toEqual(expect.any(String));
+
+    await markAll.execute({ userId: "friend-a" });
+    const afterAll = await list.execute({ userId: "friend-a" });
+    expect(afterAll.unreadCount).toBe(0);
+    expect(afterAll.notifications.every((row) => row.readAt != null)).toBe(true);
+  });
+
+  test("mark invite notifications read by organised game id", async () => {
+    const notifications = new InMemoryNotificationRepository();
+    const notify = new NotifyOrganisedGameInvite(notifications);
+    await notify.notifyInviteCreated({
+      recipientId: "friend-a",
+      actorId: "host-1",
+      organisedGameId: "game-1",
+      sport: "padel",
+      startsAt: "2026-09-07T18:00:00.000Z",
+      venueCmsId: "sanity-court-1",
+    });
+
+    await notify.markInviteNotificationsRead({
+      recipientId: "friend-a",
+      organisedGameId: "game-1",
+    });
+
+    const listed = await new ListMyNotifications(
+      notifications,
+      new InMemoryFriendProfileLookup(),
+    ).execute({ userId: "friend-a" });
+    expect(listed.unreadCount).toBe(0);
+    expect(listed.notifications[0]?.readAt).toEqual(expect.any(String));
+  });
+});

--- a/src/modules/notifications/services/notifications.service.ts
+++ b/src/modules/notifications/services/notifications.service.ts
@@ -1,0 +1,240 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import {
+  FriendProfile,
+  FriendProfileLookup,
+} from "../../friends/repositories/friendship.repository";
+import { Notification } from "../entities/notification";
+import { NotificationNotFoundError } from "../entities/notification-not-found-error";
+import { NotificationType } from "../entities/notification-type";
+import {
+  NotificationCursor,
+  NotificationRepository,
+} from "../repositories/notification.repository";
+
+export type PublicNotificationActor = {
+  id: string;
+  displayName: string;
+  handle: string;
+  avatarUrl: string | null;
+};
+
+export type PublicOrganisedGameInvitePayload = {
+  organisedGameId: string;
+  sport: "padel" | "golf";
+  startsAt: string;
+  venueCmsId: string | null;
+};
+
+export type PublicNotification = {
+  id: string;
+  type: "organised_game_invite";
+  actor: PublicNotificationActor;
+  payload: PublicOrganisedGameInvitePayload;
+  readAt: string | null;
+  createdAt: string;
+};
+
+export type OrganisedGameInviteNotice = {
+  recipientId: string;
+  actorId: string;
+  organisedGameId: string;
+  sport: "padel" | "golf";
+  startsAt: string;
+  venueCmsId: string | null;
+};
+
+export interface OrganisedGameInviteNotifier {
+  notifyInviteCreated(input: OrganisedGameInviteNotice): Promise<void>;
+  markInviteNotificationsRead(input: {
+    recipientId: string;
+    organisedGameId: string;
+  }): Promise<void>;
+}
+
+const DEFAULT_LIST_LIMIT = 20;
+const MAX_LIST_LIMIT = 50;
+
+function parseLimit(raw?: number): number {
+  if (raw == null || Number.isNaN(raw)) return DEFAULT_LIST_LIMIT;
+  return Math.min(Math.max(Math.trunc(raw), 1), MAX_LIST_LIMIT);
+}
+
+function encodeCursor(cursor: NotificationCursor): string {
+  return Buffer.from(
+    JSON.stringify({
+      u: cursor.unread ? 1 : 0,
+      t: cursor.createdAt.toISOString(),
+      i: cursor.id,
+    }),
+    "utf8",
+  ).toString("base64url");
+}
+
+function decodeCursor(raw: string): NotificationCursor {
+  try {
+    const parsed = JSON.parse(
+      Buffer.from(raw, "base64url").toString("utf8"),
+    ) as { u?: unknown; t?: unknown; i?: unknown };
+    if (parsed.u !== 0 && parsed.u !== 1) {
+      throw new Error("unread");
+    }
+    if (typeof parsed.i !== "string" || parsed.i.trim().length === 0) {
+      throw new Error("id");
+    }
+    if (typeof parsed.t !== "string") {
+      throw new Error("createdAt");
+    }
+    const createdAt = new Date(parsed.t);
+    if (Number.isNaN(createdAt.getTime())) {
+      throw new Error("createdAt");
+    }
+    return { unread: parsed.u === 1, createdAt, id: parsed.i };
+  } catch {
+    throw new DomainError("cursor is invalid");
+  }
+}
+
+async function resolveProfile(
+  lookup: FriendProfileLookup,
+  userId: string,
+): Promise<FriendProfile> {
+  const profile = await lookup.findByUserId(userId);
+  if (profile) return profile;
+  return {
+    userId,
+    displayName: "Player",
+    handle: userId.slice(0, 8),
+    avatarUrl: null,
+  };
+}
+
+async function toPublic(
+  notification: Notification,
+  lookup: FriendProfileLookup,
+): Promise<PublicNotification> {
+  const snapshot = notification.toSnapshot();
+  const actor = await resolveProfile(lookup, notification.actorId);
+  return {
+    id: snapshot.id,
+    type: snapshot.type,
+    actor: {
+      id: actor.userId,
+      displayName: actor.displayName,
+      handle: actor.handle,
+      avatarUrl: actor.avatarUrl,
+    },
+    payload: snapshot.payload,
+    readAt: snapshot.readAt,
+    createdAt: snapshot.createdAt,
+  };
+}
+
+export class NotifyOrganisedGameInvite implements OrganisedGameInviteNotifier {
+  constructor(private readonly notifications: NotificationRepository) {}
+
+  async notifyInviteCreated(input: OrganisedGameInviteNotice): Promise<void> {
+    await this.notifications.create(
+      Notification.organisedGameInvite({
+        recipientId: input.recipientId,
+        actorId: input.actorId,
+        organisedGameId: input.organisedGameId,
+        sport: input.sport,
+        startsAt: input.startsAt,
+        venueCmsId: input.venueCmsId,
+      }),
+    );
+  }
+
+  async markInviteNotificationsRead(input: {
+    recipientId: string;
+    organisedGameId: string;
+  }): Promise<void> {
+    await this.notifications.markReadByResource(
+      input.recipientId,
+      NotificationType.ORGANISED_GAME_INVITE,
+      input.organisedGameId,
+    );
+  }
+}
+
+export class ListMyNotifications {
+  constructor(
+    private readonly notifications: NotificationRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    limit?: number;
+    cursor?: unknown;
+  }): Promise<{
+    notifications: PublicNotification[];
+    unreadCount: number;
+    nextCursor: string | null;
+  }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const limit = parseLimit(input.limit);
+    const cursor =
+      input.cursor == null || input.cursor === ""
+        ? undefined
+        : decodeCursor(requiredTrimmed(input.cursor, "cursor"));
+
+    const page = await this.notifications.listPage({
+      recipientId: userId,
+      limit,
+      cursor,
+    });
+
+    const last = page.items[page.items.length - 1];
+    return {
+      notifications: await Promise.all(
+        page.items.map((notification) => toPublic(notification, this.profiles)),
+      ),
+      unreadCount: page.unreadCount,
+      nextCursor:
+        page.hasMore && last
+          ? encodeCursor({
+              unread: last.isUnread,
+              createdAt: last.createdAt,
+              id: last.id,
+            })
+          : null,
+    };
+  }
+}
+
+export class MarkNotificationRead {
+  constructor(
+    private readonly notifications: NotificationRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string; notificationId: string }): Promise<{
+    notification: PublicNotification;
+  }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const notification = await this.notifications.findById(
+      input.notificationId.trim(),
+    );
+    if (!notification || notification.recipientId !== userId) {
+      throw new NotificationNotFoundError();
+    }
+
+    notification.markRead();
+    const saved = await this.notifications.persist(notification);
+    return { notification: await toPublic(saved, this.profiles) };
+  }
+}
+
+export class MarkAllNotificationsRead {
+  constructor(private readonly notifications: NotificationRepository) {}
+
+  async execute(input: { userId: string }): Promise<{
+    ok: true;
+    unreadCount: 0;
+  }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    await this.notifications.markAllRead(userId);
+    return { ok: true, unreadCount: 0 };
+  }
+}

--- a/src/modules/organised-games/controllers/organised-games.http.test.ts
+++ b/src/modules/organised-games/controllers/organised-games.http.test.ts
@@ -10,6 +10,7 @@ import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memo
 import { InMemoryGolfRoundRepository } from "../../golf-round/repositories/in-memory-golf-round.repository";
 import { signAuthenticationToken } from "../../identity/utils/jwt";
 import { InMemoryMatchRepository } from "../../match/repositories/in-memory-match.repository";
+import { InMemoryNotificationRepository } from "../../notifications/repositories/in-memory-notification.repository";
 import { CmsId } from "../../venue/entities/cms-id";
 import { Slug } from "../../venue/entities/slug";
 import { Venue } from "../../venue/entities/venue";
@@ -62,6 +63,7 @@ describe("organised games HTTP", () => {
   let friendships: InMemoryFriendshipRepository;
   let profiles: InMemoryFriendProfileLookup;
   let games: InMemoryOrganisedGameRepository;
+  let notifications: InMemoryNotificationRepository;
   let matches: InMemoryMatchRepository;
   let rounds: InMemoryGolfRoundRepository;
   let app: Express;
@@ -76,6 +78,7 @@ describe("organised games HTTP", () => {
     friendships = new InMemoryFriendshipRepository();
     profiles = new InMemoryFriendProfileLookup();
     games = new InMemoryOrganisedGameRepository();
+    notifications = new InMemoryNotificationRepository();
     matches = new InMemoryMatchRepository();
     rounds = new InMemoryGolfRoundRepository();
 
@@ -122,6 +125,7 @@ describe("organised games HTTP", () => {
       friendshipRepository: friendships,
       friendProfileLookup: profiles,
       organisedGameRepository: games,
+      notificationRepository: notifications,
       matchRepository: matches,
       golfRoundRepository: rounds,
     });

--- a/src/modules/organised-games/index.ts
+++ b/src/modules/organised-games/index.ts
@@ -14,6 +14,7 @@ import { GolfRoundRepository } from "../golf-round/repositories/golf-round.repos
 import { CreateGolfRound } from "../golf-round/services/create-golf-round.service";
 import { MatchRepository } from "../match/repositories/match.repository";
 import { CreateMatch } from "../match/services/create-match.service";
+import { OrganisedGameInviteNotifier } from "../notifications/services/notifications.service";
 import { VenueRepository } from "../venue/repositories/venue.repository";
 import { createOrganisedGamesController } from "./controllers/organised-games.controller";
 import { OrganisedGameRepository } from "./repositories/organised-game.repository";
@@ -40,6 +41,7 @@ export type CreateOrganisedGamesModuleParams = {
   matchRepository: MatchRepository;
   golfRoundRepository: GolfRoundRepository;
   organisedGameRepository?: OrganisedGameRepository;
+  inviteNotifier?: OrganisedGameInviteNotifier;
   tryGetSessionUserId: (req: Request) => string | null;
   requireAuth: (req: Request, res: Response, next: NextFunction) => void;
 };
@@ -57,6 +59,7 @@ export function createOrganisedGamesModule({
   matchRepository,
   golfRoundRepository,
   organisedGameRepository: organisedGameRepositoryOverride,
+  inviteNotifier,
   tryGetSessionUserId,
   requireAuth,
 }: CreateOrganisedGamesModuleParams): OrganisedGamesModule {
@@ -70,14 +73,17 @@ export function createOrganisedGamesModule({
       venueRepository,
       friendshipRepository,
       friendProfileLookup,
+      inviteNotifier,
     ),
     getOrganisedGame: new GetOrganisedGame(
       organisedGameRepository,
       friendProfileLookup,
+      inviteNotifier,
     ),
     getOrganisedGameByToken: new GetOrganisedGameByToken(
       organisedGameRepository,
       friendProfileLookup,
+      inviteNotifier,
     ),
     listMyOrganisedGames: new ListMyOrganisedGames(
       organisedGameRepository,
@@ -87,15 +93,18 @@ export function createOrganisedGamesModule({
       organisedGameRepository,
       friendshipRepository,
       friendProfileLookup,
+      inviteNotifier,
     ),
     listInvites: new ListInvites(organisedGameRepository, friendProfileLookup),
     joinByInviteToken: new JoinByInviteToken(
       organisedGameRepository,
       friendProfileLookup,
+      inviteNotifier,
     ),
     rsvpOrganisedGame: new RsvpOrganisedGame(
       organisedGameRepository,
       friendProfileLookup,
+      inviteNotifier,
     ),
     cancelOrganisedGame: new CancelOrganisedGame(
       organisedGameRepository,

--- a/src/modules/organised-games/services/organised-games.service.test.ts
+++ b/src/modules/organised-games/services/organised-games.service.test.ts
@@ -9,6 +9,8 @@ import { InMemoryGolfRoundRepository } from "../../golf-round/repositories/in-me
 import { CreateGolfRound } from "../../golf-round/services/create-golf-round.service";
 import { InMemoryMatchRepository } from "../../match/repositories/in-memory-match.repository";
 import { CreateMatch } from "../../match/services/create-match.service";
+import { InMemoryNotificationRepository } from "../../notifications/repositories/in-memory-notification.repository";
+import { NotifyOrganisedGameInvite } from "../../notifications/services/notifications.service";
 import { OrganisedGameNotFriendError } from "../entities/organised-game-not-friend-error";
 import { OrganisedGameForbiddenError } from "../entities/organised-game-forbidden-error";
 import { OrganisedGameNotFoundError } from "../entities/organised-game-not-found-error";
@@ -296,5 +298,87 @@ describe("organised games application", () => {
     await expect(
       start.execute({ userId: "host-1", gameId: game.id }),
     ).rejects.toBeInstanceOf(OrganisedGameStartWindowError);
+  });
+
+  test("create, invite, and join notify the invitee; GET and RSVP mark the notice read", async () => {
+    const venues = new InMemoryVenueRepository();
+    const games = new InMemoryOrganisedGameRepository();
+    const friendships = new InMemoryFriendshipRepository();
+    const profiles = new InMemoryFriendProfileLookup();
+    const notifications = new InMemoryNotificationRepository();
+    const notifier = new NotifyOrganisedGameInvite(notifications);
+    seedProfiles(profiles);
+    await seedVenue(venues);
+    await becomeFriends(friendships, "host-1", "friend-a");
+    await becomeFriends(friendships, "host-1", "friend-b");
+
+    const create = new CreateOrganisedGame(
+      games,
+      venues,
+      friendships,
+      profiles,
+      notifier,
+    );
+    const { game } = await create.execute({
+      userId: "host-1",
+      sport: "padel",
+      venueCmsId: "sanity-court-1",
+      startsAt: STARTS_AT,
+      inviteUserIds: ["friend-a"],
+    });
+
+    const forFriendA = await notifications.listPage({
+      recipientId: "friend-a",
+      limit: 10,
+    });
+    expect(forFriendA.unreadCount).toBe(1);
+    expect(forFriendA.items[0]?.payload.toSnapshot()).toEqual({
+      organisedGameId: game.id,
+      sport: "padel",
+      startsAt: STARTS_AT,
+      venueCmsId: "sanity-court-1",
+    });
+
+    const invite = new InviteFriends(games, friendships, profiles, notifier);
+    await invite.execute({
+      userId: "host-1",
+      gameId: game.id,
+      userIds: ["friend-b"],
+    });
+    expect(
+      (await notifications.listPage({ recipientId: "friend-b", limit: 10 }))
+        .unreadCount,
+    ).toBe(1);
+
+    const join = new JoinByInviteToken(games, profiles, notifier);
+    await join.execute({ userId: "stranger", token: game.inviteToken! });
+    expect(
+      (await notifications.listPage({ recipientId: "stranger", limit: 10 }))
+        .unreadCount,
+    ).toBe(1);
+
+    await join.execute({ userId: "stranger", token: game.inviteToken! });
+    expect(
+      (await notifications.listPage({ recipientId: "stranger", limit: 10 }))
+        .items,
+    ).toHaveLength(1);
+
+    const get = new GetOrganisedGame(games, profiles, notifier);
+    await get.execute({ userId: "friend-a", gameId: game.id });
+    expect(
+      (await notifications.listPage({ recipientId: "friend-a", limit: 10 }))
+        .unreadCount,
+    ).toBe(0);
+
+    const rsvp = new RsvpOrganisedGame(games, profiles, notifier);
+    await rsvp.execute({
+      userId: "friend-b",
+      gameId: game.id,
+      rsvp: "accepted",
+    });
+    expect(
+      (await notifications.listPage({ recipientId: "friend-b", limit: 10 }))
+        .unreadCount,
+    ).toBe(0);
   });
 });

--- a/src/modules/organised-games/services/organised-games.service.ts
+++ b/src/modules/organised-games/services/organised-games.service.ts
@@ -20,6 +20,7 @@ import { OrganisedGameRsvp } from "../entities/organised-game-rsvp";
 import { OrganisedGameSport } from "../entities/organised-game-sport";
 import { OrganisedGameVenueNotFoundError } from "../entities/organised-game-venue-not-found-error";
 import { StartsAt } from "../entities/starts-at";
+import { OrganisedGameInviteNotifier } from "../../notifications/services/notifications.service";
 import { OrganisedGameRepository } from "../repositories/organised-game.repository";
 import { defaultNineHoleCourse } from "./default-golf-course";
 import {
@@ -155,12 +156,43 @@ async function requireAcceptedFriend(
   }
 }
 
+async function notifyInvitees(
+  notifier: OrganisedGameInviteNotifier | undefined,
+  game: OrganisedGame,
+  inviteeIds: string[],
+): Promise<void> {
+  if (!notifier || inviteeIds.length === 0) return;
+  for (const inviteeId of inviteeIds) {
+    await notifier.notifyInviteCreated({
+      recipientId: inviteeId,
+      actorId: game.hostUserId,
+      organisedGameId: game.id,
+      sport: game.sport.value,
+      startsAt: game.startsAt.toIsoString(),
+      venueCmsId: game.venueCmsId.value,
+    });
+  }
+}
+
+async function markInviteNotificationRead(
+  notifier: OrganisedGameInviteNotifier | undefined,
+  game: OrganisedGame,
+  userId: string,
+): Promise<void> {
+  if (!notifier || !game.inviteOf(userId)) return;
+  await notifier.markInviteNotificationsRead({
+    recipientId: userId,
+    organisedGameId: game.id,
+  });
+}
+
 export class CreateOrganisedGame {
   constructor(
     private readonly games: OrganisedGameRepository,
     private readonly venues: VenueRepository,
     private readonly friendships: FriendshipRepository,
     private readonly profiles: FriendProfileLookup,
+    private readonly inviteNotifier?: OrganisedGameInviteNotifier,
   ) {}
 
   async execute(input: {
@@ -199,6 +231,7 @@ export class CreateOrganisedGame {
     }
 
     const saved = await this.games.create(game);
+    await notifyInvitees(this.inviteNotifier, saved, inviteUserIds);
     return {
       game: await toPublicGame(saved, this.profiles, userId, {
         revealInviteToken: true,
@@ -211,6 +244,7 @@ export class GetOrganisedGame {
   constructor(
     private readonly games: OrganisedGameRepository,
     private readonly profiles: FriendProfileLookup,
+    private readonly inviteNotifier?: OrganisedGameInviteNotifier,
   ) {}
 
   async execute(input: { userId: string; gameId: string }) {
@@ -219,6 +253,7 @@ export class GetOrganisedGame {
     if (!game || !game.isParticipant(userId)) {
       throw new OrganisedGameNotFoundError();
     }
+    await markInviteNotificationRead(this.inviteNotifier, game, userId);
     return {
       game: await toPublicGame(game, this.profiles, userId, {
         revealInviteToken: game.isHost(userId),
@@ -231,6 +266,7 @@ export class GetOrganisedGameByToken {
   constructor(
     private readonly games: OrganisedGameRepository,
     private readonly profiles: FriendProfileLookup,
+    private readonly inviteNotifier?: OrganisedGameInviteNotifier,
   ) {}
 
   async execute(input: { userId: string; token: string }) {
@@ -239,6 +275,7 @@ export class GetOrganisedGameByToken {
     if (!game) {
       throw new OrganisedGameNotFoundError();
     }
+    await markInviteNotificationRead(this.inviteNotifier, game, userId);
     return {
       game: await toPublicGame(game, this.profiles, userId, {
         revealInviteToken: game.isHost(userId),
@@ -280,6 +317,7 @@ export class InviteFriends {
     private readonly games: OrganisedGameRepository,
     private readonly friendships: FriendshipRepository,
     private readonly profiles: FriendProfileLookup,
+    private readonly inviteNotifier?: OrganisedGameInviteNotifier,
   ) {}
 
   async execute(input: {
@@ -309,6 +347,7 @@ export class InviteFriends {
     }
 
     const saved = await this.games.persist(game);
+    await notifyInvitees(this.inviteNotifier, saved, userIds);
     return {
       game: await toPublicGame(saved, this.profiles, userId, {
         revealInviteToken: true,
@@ -340,6 +379,7 @@ export class JoinByInviteToken {
   constructor(
     private readonly games: OrganisedGameRepository,
     private readonly profiles: FriendProfileLookup,
+    private readonly inviteNotifier?: OrganisedGameInviteNotifier,
   ) {}
 
   async execute(input: { userId: string; token: string }) {
@@ -358,6 +398,7 @@ export class JoinByInviteToken {
 
     game.addInvitee(userId);
     const saved = await this.games.persist(game);
+    await notifyInvitees(this.inviteNotifier, saved, [userId]);
     return {
       game: await toPublicGame(saved, this.profiles, userId, {
         revealInviteToken: false,
@@ -370,6 +411,7 @@ export class RsvpOrganisedGame {
   constructor(
     private readonly games: OrganisedGameRepository,
     private readonly profiles: FriendProfileLookup,
+    private readonly inviteNotifier?: OrganisedGameInviteNotifier,
   ) {}
 
   async execute(input: { userId: string; gameId: string; rsvp: unknown }) {
@@ -381,6 +423,7 @@ export class RsvpOrganisedGame {
 
     game.rsvp(userId, OrganisedGameRsvp.fromDecision(input.rsvp));
     const saved = await this.games.persist(game);
+    await markInviteNotificationRead(this.inviteNotifier, saved, userId);
     return {
       game: await toPublicGame(saved, this.profiles, userId, {
         revealInviteToken: saved.isHost(userId),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #36.

When a user is invited to an organised game (friend invite **or** join-via-share-link), they get an **in-app notification**. Frontend can list / mark read on `/api/me/notifications`.

Related: organised-game API [#33](https://github.com/leaguesports/league-sports-api/issues/33) / [#34](https://github.com/leaguesports/league-sports-api/pull/34); Play UI [landing-page#157](https://github.com/leaguesports/landing-page/issues/157), [landing-page#153](https://github.com/leaguesports/landing-page/issues/153), [landing-page#155](https://github.com/leaguesports/landing-page/issues/155).

Do **not merge** — Brandon merges.

## Frontend contract

All routes require session cookie `token` (`credentials: "include"`). Guests → `401 { "error": "Unauthorized" }`. Only the **recipient** can list or mark their notifications. Someone else’s id → **404** (no existence leak).

Organised-game HTTP shapes are **unchanged**. Notices are a side effect of invite/join.

| Method | Path | Who | Success |
| --- | --- | --- | --- |
| `GET` | `/api/me/notifications` | signed-in | `200 { notifications, unreadCount, nextCursor }` |
| `POST` | `/api/me/notifications/:id/read` | recipient | `200 { notification }` |
| `POST` | `/api/me/notifications/read-all` | signed-in | `200 { ok: true, unreadCount: 0 }` |

### List — `GET /api/me/notifications`

Query:

| Param | Required | Notes |
| --- | --- | --- |
| `limit` | no | 1–50, default **20** |
| `cursor` | no | opaque `nextCursor` from the previous page |

Unread first, then newest `createdAt`. `unreadCount` is the **total** unread (not the page). `nextCursor` is `null` on the last page.

```json
{
  "notifications": [
    {
      "id": "uuid",
      "type": "organised_game_invite",
      "actor": {
        "id": "host-user-id",
        "displayName": "Alex",
        "handle": "alex",
        "avatarUrl": null
      },
      "payload": {
        "organisedGameId": "uuid",
        "sport": "padel",
        "startsAt": "2026-09-07T18:00:00.000Z",
        "venueCmsId": "sanity-court-1"
      },
      "readAt": null,
      "createdAt": "2026-09-07T10:00:00.000Z"
    }
  ],
  "unreadCount": 1,
  "nextCursor": null
}
```

| Field | Notes |
| --- | --- |
| `type` | v1: `organised_game_invite` only (extensible) |
| `actor` | host of the organised game |
| `payload.sport` | `padel` \| `golf` |
| `payload.startsAt` | ISO datetime |
| `payload.venueCmsId` | string or `null` |
| `readAt` | `null` = unread |

Deep-link Frontend: organised game detail via `payload.organisedGameId` (existing `GET /api/organised-games/:id`).

### Mark read — `POST /api/me/notifications/:id/read`

Empty body. Idempotent if already read. Returns the updated `notification` (same shape as list items) with `readAt` set.

### Mark all read — `POST /api/me/notifications/read-all`

Empty body.

```json
{ "ok": true, "unreadCount": 0 }
```

### When notices are created (side effect)

| Trigger | Who is notified |
| --- | --- |
| `POST /api/organised-games` with `inviteUserIds` | each invited friend |
| `POST /api/organised-games/:id/invites` `{ userIds }` | each invited friend |
| `POST /api/organised-games/invite/:token/join` | the joining user (pending invitee) |

Actor = host. Idempotent per `(recipient, type, organisedGameId)` — retry / re-join does **not** duplicate. Host is never notified of their own game. Existing organised-game responses are unchanged.

### Auto-read (v1 extra)

Invitee `GET /api/organised-games/:id` (or token preview once they are already an invitee) and `POST /api/organised-games/:id/rsvp` mark that game’s `organised_game_invite` notice read. Host GET does nothing. Share-link **preview as guest** does not create or read a notice.

### Errors

| Status | When |
| --- | --- |
| `400` | Invalid query (`cursor is invalid`) / domain |
| `401` | No session |
| `404` | Unknown notification, or not yours |
| `503` | Persistence failure |

## Domain bar

`Notification` aggregate + VOs under `src/modules/notifications/entities/` (type, organised-game invite payload). Commands in `services/`. Thin Zod at the controller. Organised-games invite/join/get/RSVP call `OrganisedGameInviteNotifier` after persist — no change to the organised-game HTTP contract.

## Migration

`20260907140000_in_app_notification` — enum `NotificationType` (`organised_game_invite`), table `Notification` (`recipientId`, `actorId`, `type`, `resourceId`, `payload` JSONB, `readAt`). Unique `(recipientId, type, resourceId)`. No User FK (same as Friendship / OrganisedGameInvite).

## Tests

Entity + service + HTTP (list/read isolation, invite + share-link join, GET detail auto-read). Full suite: **251 passed**. `yarn build` typecheck clean.

## Out of scope v1

Email, push, SMS. Notices for RSVP / start / cancel.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-765a17a8-ba26-4d04-8a37-aa05f56dc8cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-765a17a8-ba26-4d04-8a37-aa05f56dc8cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

