### PR TITLE
Require teeName before a golf round starts

### DIFF
--- a/src/modules/golf-round/controllers/golf-round.controller.ts
+++ b/src/modules/golf-round/controllers/golf-round.controller.ts
@@ -34,7 +34,7 @@ const createGolfRoundBodySchema = z.object({
   startsAt: z.string(),
   holesPlayed: z.union([z.literal(9), z.literal(18)]),
   startingHole: z.number().optional(),
-  teeName: z.string().nullable().optional(),
+  teeName: z.string(),
   course: z.object({
     name: z.string().nullable().optional(),
     holes: z.array(courseHoleSchema).min(1),
@@ -71,7 +71,7 @@ const captureGolfRoundBodySchema = z.object({
   playedAt: z.string().optional(),
   holesPlayed: z.union([z.literal(9), z.literal(18)]),
   startingHole: z.number().optional(),
-  teeName: z.string().nullable().optional(),
+  teeName: z.string(),
   course: z.object({
     name: z.string().nullable().optional(),
     holes: z.array(courseHoleSchema).min(1),

--- a/src/modules/golf-round/controllers/golf-rounds.http.test.ts
+++ b/src/modules/golf-round/controllers/golf-rounds.http.test.ts
@@ -333,6 +333,50 @@ describe("golf rounds HTTP", () => {
     expect(await response.json()).toEqual({ error: "Golf round not found" });
   });
 
+  test("POST create and capture require a trimmed teeName", async () => {
+    const { teeName: _ignored, ...createBodyWithoutTee } = createBody;
+
+    const omitted = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(createBodyWithoutTee),
+    });
+    expect(omitted.status).toBe(400);
+
+    const blank = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...createBody, teeName: "   " }),
+    });
+    expect(blank.status).toBe(400);
+    expect(await blank.json()).toEqual({ error: "teeName must not be blank" });
+
+    const created = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...createBody, teeName: "  Yellow  " }),
+    });
+    expect(created.status).toBe(201);
+    expect(await created.json()).toMatchObject({ teeName: "Yellow" });
+
+    const captureMissing = await fetch(`${server.url}/api/golf-rounds/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBodyWithoutTee,
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 3, displayName: "Riley", isGuest: false, userId: null },
+        ],
+        score: scoreForPlayers([1, 2, 3, 4, 5, 6, 7, 8, 9], [1, 3], 4),
+      }),
+    });
+    expect(captureMissing.status).toBe(400);
+  });
+
   test("POST rejects unknown venue and invalid course length", async () => {
     const missingVenue = await fetch(`${server.url}/api/golf-rounds`, {
       method: "POST",

--- a/src/modules/golf-round/entities/golf-round.test.ts
+++ b/src/modules/golf-round/entities/golf-round.test.ts
@@ -1,5 +1,6 @@
+import { DomainError } from "../../../lib/domain-error";
 import { CmsId } from "../../venue/entities/cms-id";
-import { GolfRound } from "./golf-round";
+import { GolfRound, TEE_NAME_MAX_LENGTH } from "./golf-round";
 import { StartsAt } from "./starts-at";
 
 const courseHoles9 = Array.from({ length: 9 }, (_, index) => ({
@@ -15,7 +16,40 @@ const score = {
   })),
 };
 
+const createProps = {
+  venueCmsId: CmsId.from("sanity-course-1"),
+  startsAt: StartsAt.from("2026-09-04T10:00:00.000Z"),
+  holesPlayed: 9,
+  startingHole: 1,
+  teeName: "White",
+  course: { name: "Links Nine", holes: courseHoles9 },
+  players: [
+    { slot: 1 as const, displayName: "Alex", isGuest: false, userId: "user-1" },
+    { slot: 2 as const, displayName: "Sam", isGuest: true, userId: null },
+  ],
+};
+
 describe(GolfRound, () => {
+  test("create stores a trimmed required teeName", () => {
+    const round = GolfRound.create({ ...createProps, teeName: "  Blue  " });
+    expect(round.toSnapshot().teeName).toBe("Blue");
+  });
+
+  test("create rejects missing, blank, and overlong teeName", () => {
+    expect(() => GolfRound.create({ ...createProps, teeName: undefined })).toThrow(
+      DomainError,
+    );
+    expect(() => GolfRound.create({ ...createProps, teeName: "   " })).toThrow(
+      DomainError,
+    );
+    expect(() =>
+      GolfRound.create({
+        ...createProps,
+        teeName: "W".repeat(TEE_NAME_MAX_LENGTH + 1),
+      }),
+    ).toThrow(DomainError);
+  });
+
   test("captureFinished creates a locked round without a live session", () => {
     const lockedAt = new Date("2026-09-04T12:00:00.000Z");
     const round = GolfRound.captureFinished({

--- a/src/modules/golf-round/entities/golf-round.ts
+++ b/src/modules/golf-round/entities/golf-round.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { DomainError } from "../../../lib/domain-error";
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
 import { CmsId } from "../../venue/entities/cms-id";
 import {
   CourseSnapshot,
@@ -27,12 +27,14 @@ export type GolfRoundSnapshot = {
   lockedAt: string | null;
 };
 
+export const TEE_NAME_MAX_LENGTH = 40;
+
 export type CreateGolfRoundProps = {
   venueCmsId: CmsId;
   startsAt: StartsAt;
   holesPlayed: number;
   startingHole?: number;
-  teeName?: string | null;
+  teeName: unknown;
   course: unknown;
   players: GolfPlayerInput[];
 };
@@ -56,7 +58,7 @@ export class GolfRound {
   static create(props: CreateGolfRoundProps): GolfRound {
     const holesPlayed = parseHolesPlayed(props.holesPlayed);
     const startingHole = parseStartingHole(props.startingHole ?? 1);
-    const teeName = parseOptionalTeeName(props.teeName);
+    const teeName = parseRequiredTeeName(props.teeName);
     const course = CourseSnapshot.from(props.course, {
       holesPlayed,
       startingHole,
@@ -232,15 +234,12 @@ function parseStartingHole(raw: unknown): number {
   return raw;
 }
 
-function parseOptionalTeeName(raw: unknown): string | null {
-  if (raw === undefined || raw === null) {
-    return null;
+export function parseRequiredTeeName(raw: unknown): string {
+  const value = requiredTrimmed(raw, "teeName");
+  if (value.length > TEE_NAME_MAX_LENGTH) {
+    throw new DomainError(
+      `teeName must be at most ${TEE_NAME_MAX_LENGTH} characters`,
+    );
   }
-
-  if (typeof raw !== "string") {
-    throw new DomainError("teeName must be a string");
-  }
-
-  const value = raw.trim();
-  return value.length === 0 ? null : value;
+  return value;
 }

--- a/src/modules/golf-round/services/capture-finished-golf-round.service.ts
+++ b/src/modules/golf-round/services/capture-finished-golf-round.service.ts
@@ -11,7 +11,7 @@ export type CaptureFinishedGolfRoundInput = {
   startsAt: unknown;
   holesPlayed: unknown;
   startingHole?: unknown;
-  teeName?: string | null;
+  teeName: unknown;
   course: unknown;
   players: GolfPlayerInput[];
   score: unknown;

--- a/src/modules/golf-round/services/create-golf-round.service.ts
+++ b/src/modules/golf-round/services/create-golf-round.service.ts
@@ -11,7 +11,7 @@ export type CreateGolfRoundInput = {
   startsAt: unknown;
   holesPlayed: unknown;
   startingHole?: unknown;
-  teeName?: string | null;
+  teeName: unknown;
   course: unknown;
   players: GolfPlayerInput[];
 };

--- a/src/modules/organised-games/controllers/organised-games.controller.ts
+++ b/src/modules/organised-games/controllers/organised-games.controller.ts
@@ -81,7 +81,7 @@ const startBodySchema = z
     pairings: pairingsSchema.optional(),
     holesPlayed: z.union([z.literal(9), z.literal(18)]).optional(),
     startingHole: z.number().optional(),
-    teeName: z.string().nullable().optional(),
+    teeName: z.string().optional(),
     course: z
       .object({
         name: z.string().nullable().optional(),

--- a/src/modules/organised-games/controllers/organised-games.http.test.ts
+++ b/src/modules/organised-games/controllers/organised-games.http.test.ts
@@ -322,7 +322,7 @@ describe("organised games HTTP", () => {
     });
   });
 
-  test("golf start uses default 9-hole course and seats host", async () => {
+  test("golf start requires teeName, uses default 9-hole course, and seats host", async () => {
     const created = await fetch(`${server.url}/api/organised-games`, {
       method: "POST",
       headers: {
@@ -343,9 +343,23 @@ describe("organised games HTTP", () => {
     );
     expect(notHost.status).toBe(403);
 
-    const start = await fetch(
+    const missingTee = await fetch(
       `${server.url}/api/organised-games/${game.id}/start`,
       { method: "POST", headers: { Cookie: cookie("user-a") } },
+    );
+    expect(missingTee.status).toBe(400);
+    expect(await missingTee.json()).toEqual({ error: "teeName is required" });
+
+    const start = await fetch(
+      `${server.url}/api/organised-games/${game.id}/start`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({ teeName: "  White  " }),
+      },
     );
     expect(start.status).toBe(201);
     const started = (await start.json()) as {
@@ -363,6 +377,7 @@ describe("organised games HTTP", () => {
       status: "live",
       venueCmsId: "sanity-course-1",
       holesPlayed: 9,
+      teeName: "White",
       players: [{ slot: 1, userId: "user-a", isGuest: false }],
     });
   });

--- a/src/modules/organised-games/services/organised-games.service.test.ts
+++ b/src/modules/organised-games/services/organised-games.service.test.ts
@@ -1,3 +1,4 @@
+import { DomainError } from "../../../lib/domain-error";
 import { CmsId } from "../../venue/entities/cms-id";
 import { Slug } from "../../venue/entities/slug";
 import { Venue } from "../../venue/entities/venue";
@@ -265,6 +266,56 @@ describe("organised games application", () => {
 
     const again = await start.execute({ userId: "host-1", gameId: game.id });
     expect(again.live.id).toBe(started.live.id);
+  });
+
+  test("host start golf requires teeName and seats the host", async () => {
+    const venues = new InMemoryVenueRepository();
+    const games = new InMemoryOrganisedGameRepository();
+    const friendships = new InMemoryFriendshipRepository();
+    const profiles = new InMemoryFriendProfileLookup();
+    const rounds = new InMemoryGolfRoundRepository();
+    seedProfiles(profiles);
+    await seedVenue(venues, "sanity-course-1");
+
+    const create = new CreateOrganisedGame(
+      games,
+      venues,
+      friendships,
+      profiles,
+    );
+    const { game } = await create.execute({
+      userId: "host-1",
+      sport: "golf",
+      venueCmsId: "sanity-course-1",
+      startsAt: new Date().toISOString(),
+    });
+
+    const start = new StartOrganisedGame(
+      games,
+      profiles,
+      new CreateMatch(new InMemoryMatchRepository(), venues),
+      new CreateGolfRound(rounds, venues),
+    );
+
+    await expect(
+      start.execute({ userId: "host-1", gameId: game.id }),
+    ).rejects.toBeInstanceOf(DomainError);
+
+    const started = await start.execute({
+      userId: "host-1",
+      gameId: game.id,
+      teeName: "Red",
+    });
+    expect(started.live.sport).toBe("golf");
+    expect(started.live.path).toBe(`/golf/${started.live.id}`);
+
+    const round = await rounds.findById(started.live.id);
+    expect(round?.toSnapshot()).toMatchObject({
+      status: "live",
+      teeName: "Red",
+      holesPlayed: 9,
+      players: [{ slot: 1, userId: "host-1", isGuest: false }],
+    });
   });
 
   test("start outside the window is rejected", async () => {

--- a/src/modules/organised-games/services/organised-games.service.ts
+++ b/src/modules/organised-games/services/organised-games.service.ts
@@ -465,7 +465,7 @@ export type StartOrganisedGameInput = {
   pairings?: PairingsInput;
   holesPlayed?: unknown;
   startingHole?: unknown;
-  teeName?: string | null;
+  teeName?: unknown;
   course?: unknown;
   players?: GolfPlayerInput[];
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #38.

Users must pick a Sanity tee set (Yellow / White / Blue / Red, etc.) before a golf round starts. The API already stored `teeName` on the round and returned it on GET, but create / capture / organise→start treated it as optional and persisted `null`.

## Changes
- `POST /api/golf-rounds` and `POST /api/golf-rounds/capture` require `teeName`
- `POST /api/organised-games/:id/start` requires `teeName` when the game sport is golf (including the default 9-hole path). Padel start is unchanged
- Validation: trim, non-empty, max 40 characters. Stores the string the frontend sends — no CMS tee lookup
- Prisma `teeName` stays nullable so historical rounds without a tee remain readable
- GET `/api/golf-rounds/:id` and locked history already return `teeName` (confirmed)

## Frontend contract
| Surface | Field | Notes |
|---|---|---|
| Create / capture request | `teeName` (string, required) | Trimmed Sanity tee name, 1–40 chars |
| Organise→start (golf) | `teeName` (string, required) | Same validation. Empty start body is no longer valid for golf |
| Organise→start (padel) | omit `teeName` | Unchanged |
| GET `/api/golf-rounds/:id` | `teeName` | `string` on new rounds; `null` possible on older rows |
| History lists | `teeName` | Same |

Do not merge until frontend is ready to send `teeName` on all three write paths.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-920c80e8-4df0-4e3b-b9d2-65b26727818a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-920c80e8-4df0-4e3b-b9d2-65b26727818a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

