### PR TITLE
feat: darts 501 live + capture (double-out)

### DIFF
--- a/prisma/migrations/20260907180000_darts_501_match/migration.sql
+++ b/prisma/migrations/20260907180000_darts_501_match/migration.sql
@@ -1,0 +1,56 @@
+-- Darts 501 (double-out) live + capture.
+-- Additive only. venueCmsId is nullable so pub/home games skip Venue.
+
+CREATE TYPE "DartsMatchStatus" AS ENUM ('live', 'locked');
+
+CREATE TABLE "DartsMatch" (
+    "id" TEXT NOT NULL,
+    "venueCmsId" TEXT,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "startingScore" INTEGER NOT NULL DEFAULT 501,
+    "status" "DartsMatchStatus" NOT NULL DEFAULT 'live',
+    "winnerSlot" INTEGER,
+    "lockedAt" TIMESTAMP(3),
+    "lockedByUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DartsMatch_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "DartsMatchPlayer" (
+    "id" TEXT NOT NULL,
+    "matchId" TEXT NOT NULL,
+    "slot" INTEGER NOT NULL,
+    "userId" TEXT,
+    "displayName" TEXT NOT NULL,
+    "isGuest" BOOLEAN NOT NULL,
+    "remaining" INTEGER NOT NULL,
+
+    CONSTRAINT "DartsMatchPlayer_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "DartsTurn" (
+    "id" TEXT NOT NULL,
+    "matchId" TEXT NOT NULL,
+    "turnNumber" INTEGER NOT NULL,
+    "playerSlot" INTEGER NOT NULL,
+    "score" INTEGER NOT NULL,
+    "bust" BOOLEAN NOT NULL,
+    "checkout" BOOLEAN NOT NULL,
+    "remainingAfter" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DartsTurn_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "DartsMatch_venueCmsId_idx" ON "DartsMatch"("venueCmsId");
+CREATE INDEX "DartsMatch_status_startsAt_idx" ON "DartsMatch"("status", "startsAt");
+CREATE INDEX "DartsMatch_lockedByUserId_idx" ON "DartsMatch"("lockedByUserId");
+CREATE UNIQUE INDEX "DartsMatchPlayer_matchId_slot_key" ON "DartsMatchPlayer"("matchId", "slot");
+CREATE INDEX "DartsMatchPlayer_userId_idx" ON "DartsMatchPlayer"("userId");
+CREATE UNIQUE INDEX "DartsTurn_matchId_turnNumber_key" ON "DartsTurn"("matchId", "turnNumber");
+CREATE INDEX "DartsTurn_matchId_idx" ON "DartsTurn"("matchId");
+
+ALTER TABLE "DartsMatch" ADD CONSTRAINT "DartsMatch_venueCmsId_fkey" FOREIGN KEY ("venueCmsId") REFERENCES "Venue"("cmsId") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "DartsMatchPlayer" ADD CONSTRAINT "DartsMatchPlayer_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "DartsMatch"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "DartsTurn" ADD CONSTRAINT "DartsTurn_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "DartsMatch"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,7 @@ model Venue {
   slug            String
   matches         Match[]
   golfRounds      GolfRound[]
+  dartsMatches    DartsMatch[]
   follows         VenueFollow[]
   organisedGames  OrganisedGame[]
 }
@@ -419,4 +420,61 @@ model GolfRoundPlayer {
 
   @@unique([roundId, slot])
   @@index([userId])
+}
+
+enum DartsMatchStatus {
+  live
+  locked
+}
+
+// 501 double-out, single leg. venueCmsId is nullable so pub/home games
+// do not need a registered Venue. startingScore is stored for history
+// even though v1 is always 501.
+model DartsMatch {
+  id             String           @id @default(uuid())
+  venueCmsId     String?
+  venue          Venue?           @relation(fields: [venueCmsId], references: [cmsId])
+  startsAt       DateTime
+  startingScore  Int              @default(501)
+  status         DartsMatchStatus @default(live)
+  winnerSlot     Int?
+  lockedAt       DateTime?
+  lockedByUserId String?
+  createdAt      DateTime         @default(now())
+  players        DartsMatchPlayer[]
+  turns          DartsTurn[]
+
+  @@index([venueCmsId])
+  @@index([status, startsAt])
+  @@index([lockedByUserId])
+}
+
+model DartsMatchPlayer {
+  id          String     @id @default(uuid())
+  matchId     String
+  match       DartsMatch @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  slot        Int
+  userId      String?
+  displayName String
+  isGuest     Boolean
+  remaining   Int
+
+  @@unique([matchId, slot])
+  @@index([userId])
+}
+
+model DartsTurn {
+  id             String     @id @default(uuid())
+  matchId        String
+  match          DartsMatch @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  turnNumber     Int
+  playerSlot     Int
+  score          Int
+  bust           Boolean
+  checkout       Boolean
+  remainingAfter Int
+  createdAt      DateTime   @default(now())
+
+  @@unique([matchId, turnNumber])
+  @@index([matchId])
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,10 @@ import express from "express";
 import { Config, corsReflectOrigin } from "./config";
 import { createPrismaClient } from "./lib/prisma";
 import {
+  createDartsModule,
+  DartsMatchRepository,
+} from "./modules/darts";
+import {
   createGolfRoundModule,
   GolfRoundRepository,
 } from "./modules/golf-round";
@@ -62,6 +66,7 @@ export type CreateAppDependencies = {
   friendProfileLookup?: FriendProfileLookup;
   matchRepository?: MatchRepository;
   golfRoundRepository?: GolfRoundRepository;
+  dartsMatchRepository?: DartsMatchRepository;
   badgeAwardRepository?: BadgeAwardRepository;
   preferencesRepository?: PreferencesRepository;
   communityRepository?: CommunityRepository;
@@ -114,6 +119,12 @@ export async function createApp(
     prisma,
     venueRepository: venue.venueRepository,
     golfRoundRepository: dependencies.golfRoundRepository,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+  });
+  const darts = createDartsModule({
+    prisma,
+    venueRepository: venue.venueRepository,
+    dartsMatchRepository: dependencies.dartsMatchRepository,
     tryGetSessionUserId: identity.tryGetSessionUserId,
   });
   const friends = createFriendsModule({
@@ -190,6 +201,7 @@ export async function createApp(
   app.use(venue.router);
   app.use(match.router);
   app.use(golfRound.router);
+  app.use(darts.router);
   app.use(friends.router);
   app.use(preferences.router);
   app.use(badges.router);

--- a/src/modules/darts/controllers/darts-match.controller.ts
+++ b/src/modules/darts/controllers/darts-match.controller.ts
@@ -1,0 +1,215 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { DartsMatchLockConflictError } from "../entities/darts-match-lock-conflict-error";
+import { DartsMatchPersistenceError } from "../entities/darts-match-persistence-error";
+import { DartsMatchVenueNotFoundError } from "../entities/darts-match-venue-not-found-error";
+import { CaptureFinishedDartsMatch } from "../services/capture-finished-darts-match.service";
+import { CreateDartsMatch } from "../services/create-darts-match.service";
+import { GetDartsMatchById } from "../services/get-darts-match-by-id.service";
+import {
+  ListLockedDartsMatchesByPlayer,
+  ListLockedDartsMatchesByVenue,
+} from "../services/list-locked-darts-matches.service";
+import { SubmitDartsTurn } from "../services/submit-darts-turn.service";
+import { sanitizePlayersForCreate } from "../utils/bind-session-user";
+import { resolvePlayedAt } from "../utils/played-at";
+
+const playerSchema = z.object({
+  slot: z.number().int().min(1).max(8),
+  userId: z.string().nullable().optional(),
+  displayName: z.string(),
+  isGuest: z.boolean(),
+});
+
+const turnInputSchema = z
+  .object({
+    playerSlot: z.number().int().min(1).max(8).optional(),
+    userId: z.string().optional(),
+    score: z.number().int().min(0).max(180),
+    checkout: z.boolean().optional(),
+  })
+  .refine(
+    (value) => value.playerSlot !== undefined || value.userId !== undefined,
+    { message: "playerSlot or userId is required" },
+  );
+
+const createDartsMatchBodySchema = z.object({
+  venueCmsId: z.string().nullable().optional(),
+  startsAt: z.string(),
+  players: z.array(playerSchema).min(2).max(8),
+});
+
+const captureDartsMatchBodySchema = z.object({
+  venueCmsId: z.string().nullable().optional(),
+  startsAt: z.string().optional(),
+  playedAt: z.string().optional(),
+  players: z.array(playerSchema).min(2).max(8),
+  turns: z.array(turnInputSchema).optional(),
+  remaining: z.record(z.string(), z.number().int()).optional(),
+  winnerSlot: z.number().int().min(1).max(8).optional(),
+  winnerUserId: z.string().optional(),
+});
+
+const matchIdParamSchema = z.object({
+  id: z.string(),
+});
+
+const venueCmsIdParamSchema = z.object({
+  cmsId: z.string(),
+});
+
+const playerQuerySchema = z.object({
+  playerUserId: z.string(),
+});
+
+export function createDartsMatchController(deps: {
+  createDartsMatch: CreateDartsMatch;
+  captureFinishedDartsMatch: CaptureFinishedDartsMatch;
+  getDartsMatchById: GetDartsMatchById;
+  submitDartsTurn: SubmitDartsTurn;
+  listLockedDartsMatchesByPlayer: ListLockedDartsMatchesByPlayer;
+  listLockedDartsMatchesByVenue: ListLockedDartsMatchesByVenue;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async create(req: Request, res: Response) {
+      try {
+        const body = z.parse(createDartsMatchBodySchema, req.body ?? {});
+        const sessionUserId = deps.tryGetSessionUserId(req);
+        const players = sanitizePlayersForCreate(body.players, sessionUserId);
+        const match = await deps.createDartsMatch.execute({
+          ...body,
+          players,
+        });
+        return res.status(201).json(match.toSnapshot());
+      } catch (error) {
+        return sendDartsError(res, error);
+      }
+    },
+
+    async capture(req: Request, res: Response) {
+      try {
+        const sessionUserId = deps.tryGetSessionUserId(req);
+        if (!sessionUserId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const body = z.parse(captureDartsMatchBodySchema, req.body ?? {});
+        const startsAt = resolvePlayedAt(body);
+        if (!startsAt) {
+          return res.status(400).json({ error: "startsAt or playedAt is required" });
+        }
+
+        const players = sanitizePlayersForCreate(body.players, sessionUserId);
+        if (!players.some((player) => player.userId === sessionUserId)) {
+          return res.status(403).json({
+            error: "Only a seated player can capture this darts match",
+          });
+        }
+
+        const match = await deps.captureFinishedDartsMatch.execute({
+          venueCmsId: body.venueCmsId,
+          startsAt,
+          players,
+          turns: body.turns,
+          remaining: body.remaining,
+          winnerSlot: body.winnerSlot,
+          winnerUserId: body.winnerUserId,
+          lockedByUserId: sessionUserId,
+        });
+
+        return res.status(201).json(match.toSnapshot());
+      } catch (error) {
+        return sendDartsError(res, error);
+      }
+    },
+
+    async getById(req: Request, res: Response) {
+      try {
+        const { id } = z.parse(matchIdParamSchema, req.params);
+        const match = await deps.getDartsMatchById.execute(id);
+
+        if (!match) {
+          return res.status(404).json({ error: "Darts match not found" });
+        }
+
+        return res.status(200).json(match.toSnapshot());
+      } catch (error) {
+        return sendDartsError(res, error);
+      }
+    },
+
+    async submitTurn(req: Request, res: Response) {
+      try {
+        const { id } = z.parse(matchIdParamSchema, req.params);
+        const body = z.parse(turnInputSchema, req.body ?? {});
+        const sessionUserId = deps.tryGetSessionUserId(req);
+
+        const match = await deps.submitDartsTurn.execute({
+          matchId: id,
+          playerSlot: body.playerSlot,
+          userId: body.userId,
+          score: body.score,
+          checkout: body.checkout,
+          lockedByUserId: sessionUserId,
+        });
+
+        if (!match) {
+          return res.status(404).json({ error: "Darts match not found" });
+        }
+
+        return res.status(200).json(match.toSnapshot());
+      } catch (error) {
+        return sendDartsError(res, error);
+      }
+    },
+
+    async listByPlayer(req: Request, res: Response) {
+      try {
+        const { playerUserId } = z.parse(playerQuerySchema, req.query);
+        const items =
+          await deps.listLockedDartsMatchesByPlayer.execute(playerUserId);
+        return res.status(200).json(items);
+      } catch (error) {
+        return sendDartsError(res, error);
+      }
+    },
+
+    async listByVenue(req: Request, res: Response) {
+      try {
+        const { cmsId } = z.parse(venueCmsIdParamSchema, req.params);
+        const items = await deps.listLockedDartsMatchesByVenue.execute(cmsId);
+        return res.status(200).json(items);
+      } catch (error) {
+        return sendDartsError(res, error);
+      }
+    },
+  };
+}
+
+function sendDartsError(res: Response, error: unknown) {
+  if (error instanceof DartsMatchLockConflictError) {
+    return res.status(409).json({ error: error.message });
+  }
+
+  if (error instanceof DartsMatchVenueNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid darts match payload" });
+  }
+
+  if (error instanceof DartsMatchPersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/darts/controllers/darts-matches.http.test.ts
+++ b/src/modules/darts/controllers/darts-matches.http.test.ts
@@ -182,7 +182,17 @@ describe("darts matches HTTP", () => {
           body: JSON.stringify(body),
         },
       );
-      return { status: response.status, body: await response.json() };
+      return {
+        status: response.status,
+        body: (await response.json()) as {
+          error?: string;
+          status?: string;
+          winnerSlot?: number;
+          winnerUserId?: string | null;
+          players: { slot: number; remaining: number }[];
+          turns: { turnNumber: number; bust: boolean; score: number }[];
+        },
+      };
     };
 
     expect((await score({ playerSlot: 1, score: 180 })).status).toBe(200);
@@ -190,11 +200,20 @@ describe("darts matches HTTP", () => {
     const leaveOne = await score({ playerSlot: 1, score: 140 });
     expect(leaveOne.status).toBe(200);
     expect(leaveOne.body).toMatchObject({
-      players: [{ slot: 1, remaining: 141 }],
-      turns: [expect.objectContaining({ turnNumber: 3, bust: true, score: 140 })],
+      players: [
+        { slot: 1, remaining: 141 },
+        { slot: 2, remaining: 501 },
+      ],
+    });
+    expect(leaveOne.body.turns[2]).toMatchObject({
+      turnNumber: 3,
+      bust: true,
+      score: 140,
     });
 
-    const illegalFinish = await score({ playerSlot: 2, score: 501 });
+    await score({ playerSlot: 2, score: 180 });
+    await score({ playerSlot: 2, score: 180 });
+    const illegalFinish = await score({ playerSlot: 2, score: 141 });
     expect(illegalFinish.status).toBe(400);
     expect(illegalFinish.body).toEqual({
       error: "checkout must be true to finish on 0",
@@ -202,7 +221,7 @@ describe("darts matches HTTP", () => {
 
     const checkout = await score({
       playerSlot: 2,
-      score: 501,
+      score: 141,
       checkout: true,
     });
     expect(checkout.status).toBe(200);

--- a/src/modules/darts/controllers/darts-matches.http.test.ts
+++ b/src/modules/darts/controllers/darts-matches.http.test.ts
@@ -1,0 +1,430 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { signAuthenticationToken } from "../../identity/utils/jwt";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { DartsMatchPersistenceError } from "../entities/darts-match-persistence-error";
+import { InMemoryDartsMatchRepository } from "../repositories/in-memory-darts-match.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+const players = [
+  { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+  { slot: 2, displayName: "Riley", isGuest: false, userId: "user-riley" },
+];
+
+const createBody = {
+  venueCmsId: "sanity-pub-1",
+  startsAt: "2026-09-07T18:00:00.000Z",
+  players,
+};
+
+describe("darts matches HTTP", () => {
+  const config = makeConfig();
+  let venues: InMemoryVenueRepository;
+  let matches: InMemoryDartsMatchRepository;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  function sessionCookie(userId: string) {
+    return `token=${signAuthenticationToken(config, { userId })}`;
+  }
+
+  beforeEach(async () => {
+    venues = new InMemoryVenueRepository();
+    matches = new InMemoryDartsMatchRepository();
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-pub-1"),
+        VenueName.from("The Dartboard"),
+        Slug.from("the-dartboard"),
+      ),
+      { refreshDetails: false },
+    );
+    app = await createApp(config, {
+      venueRepository: venues,
+      dartsMatchRepository: matches,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("POST creates anonymously at a venue, GET returns 501 remaining, history omits live", async () => {
+    const created = await fetch(`${server.url}/api/darts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(createBody),
+    });
+    const createdBody = (await created.json()) as { id: string; status: string };
+
+    expect(created.status).toBe(201);
+    expect(createdBody.status).toBe("live");
+
+    const read = await fetch(`${server.url}/api/darts/${createdBody.id}`);
+    expect(read.status).toBe(200);
+    expect(await read.json()).toMatchObject({
+      id: createdBody.id,
+      venueCmsId: "sanity-pub-1",
+      startingScore: 501,
+      checkoutRule: "double_out",
+      status: "live",
+      nextSuggestedSlot: 1,
+      players: [
+        { slot: 1, displayName: "Alex", isGuest: true, userId: null, remaining: 501 },
+        {
+          slot: 2,
+          displayName: "Riley",
+          isGuest: true,
+          userId: null,
+          remaining: 501,
+        },
+      ],
+      turns: [],
+    });
+
+    const playerHistory = await fetch(
+      `${server.url}/api/darts?playerUserId=user-riley`,
+    );
+    const venueHistory = await fetch(
+      `${server.url}/api/venues/sanity-pub-1/darts`,
+    );
+    expect(await playerHistory.json()).toEqual([]);
+    expect(await venueHistory.json()).toEqual([]);
+  });
+
+  test("POST creates a home game with a null venue", async () => {
+    const created = await fetch(`${server.url}/api/darts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        startsAt: "2026-09-07T18:00:00.000Z",
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+        ],
+      }),
+    });
+    expect(created.status).toBe(201);
+    expect(await created.json()).toMatchObject({
+      venueCmsId: null,
+      status: "live",
+    });
+  });
+
+  test("authenticated create binds the session user, turns bust and checkout, then history lists", async () => {
+    const created = await fetch(`${server.url}/api/darts`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Riley", isGuest: false, userId: null },
+        ],
+      }),
+    });
+    const createdBody = (await created.json()) as {
+      id: string;
+      players: { slot: number; userId: string | null }[];
+    };
+    expect(created.status).toBe(201);
+    expect(createdBody.players[1].userId).toBe("user-riley");
+
+    const score = async (body: object) => {
+      const response = await fetch(
+        `${server.url}/api/darts/${createdBody.id}/turns`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+      );
+      return { status: response.status, body: await response.json() };
+    };
+
+    expect((await score({ playerSlot: 1, score: 180 })).status).toBe(200);
+    expect((await score({ playerSlot: 1, score: 180 })).status).toBe(200);
+    const leaveOne = await score({ playerSlot: 1, score: 140 });
+    expect(leaveOne.status).toBe(200);
+    expect(leaveOne.body).toMatchObject({
+      players: [{ slot: 1, remaining: 141 }],
+      turns: [expect.objectContaining({ turnNumber: 3, bust: true, score: 140 })],
+    });
+
+    const illegalFinish = await score({ playerSlot: 2, score: 501 });
+    expect(illegalFinish.status).toBe(400);
+    expect(illegalFinish.body).toEqual({
+      error: "checkout must be true to finish on 0",
+    });
+
+    const checkout = await score({
+      playerSlot: 2,
+      score: 501,
+      checkout: true,
+    });
+    expect(checkout.status).toBe(200);
+    expect(checkout.body).toMatchObject({
+      status: "locked",
+      winnerSlot: 2,
+      winnerUserId: "user-riley",
+      players: [
+        { slot: 1, remaining: 141 },
+        { slot: 2, remaining: 0 },
+      ],
+    });
+
+    const afterLock = await score({ playerSlot: 1, score: 20 });
+    expect(afterLock.status).toBe(409);
+
+    const history = await fetch(
+      `${server.url}/api/darts?playerUserId=user-riley`,
+    );
+    const items = (await history.json()) as { id: string }[];
+    expect(items.map((item) => item.id)).toEqual([createdBody.id]);
+  });
+
+  test("POST /api/darts/capture writes a locked match from turns", async () => {
+    const captured = await fetch(`${server.url}/api/darts/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        playedAt: "2026-09-07T18:00:00.000Z",
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Riley", isGuest: false, userId: null },
+        ],
+        turns: [
+          { playerSlot: 2, score: 180 },
+          { playerSlot: 2, score: 180 },
+          { playerSlot: 2, score: 141, checkout: true },
+        ],
+      }),
+    });
+    const capturedBody = (await captured.json()) as {
+      id: string;
+      status: string;
+      venueCmsId: string | null;
+      turns: unknown[];
+    };
+
+    expect(captured.status).toBe(201);
+    expect(capturedBody.status).toBe("locked");
+    expect(capturedBody.venueCmsId).toBeNull();
+    expect(capturedBody.turns).toHaveLength(3);
+
+    const history = await fetch(
+      `${server.url}/api/darts?playerUserId=user-riley`,
+    );
+    const items = (await history.json()) as { id: string }[];
+    expect(items.map((item) => item.id)).toEqual([capturedBody.id]);
+  });
+
+  test("POST /api/darts/capture accepts remaining + winner without turns", async () => {
+    const captured = await fetch(`${server.url}/api/darts/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        venueCmsId: "sanity-pub-1",
+        startsAt: "2026-09-07T18:00:00.000Z",
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Riley", isGuest: false, userId: null },
+        ],
+        remaining: { "1": 220, "2": 0 },
+        winnerSlot: 2,
+      }),
+    });
+    expect(captured.status).toBe(201);
+    expect(await captured.json()).toMatchObject({
+      status: "locked",
+      winnerSlot: 2,
+      venueCmsId: "sanity-pub-1",
+      turns: [],
+      players: [
+        { slot: 1, remaining: 220 },
+        { slot: 2, remaining: 0 },
+      ],
+    });
+  });
+
+  test("POST /api/darts/capture requires a seated session player", async () => {
+    const unauth = await fetch(`${server.url}/api/darts/capture`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...createBody,
+        remaining: { "1": 0, "2": 100 },
+        winnerSlot: 1,
+      }),
+    });
+    expect(unauth.status).toBe(401);
+
+    const guestsOnly = await fetch(`${server.url}/api/darts/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        startsAt: "2026-09-07T18:00:00.000Z",
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+        ],
+        remaining: { "1": 0, "2": 100 },
+        winnerSlot: 1,
+      }),
+    });
+    expect(guestsOnly.status).toBe(403);
+
+    const missingVenue = await fetch(`${server.url}/api/darts/capture`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        venueCmsId: "no-such-pub",
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 2, displayName: "Riley", isGuest: false, userId: null },
+        ],
+        remaining: { "1": 100, "2": 0 },
+        winnerSlot: 2,
+      }),
+    });
+    expect(missingVenue.status).toBe(404);
+  });
+
+  test("GET missing darts match is 404", async () => {
+    const response = await fetch(`${server.url}/api/darts/missing`);
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Darts match not found" });
+  });
+
+  test("POST rejects unknown venue and a single player", async () => {
+    const missingVenue = await fetch(`${server.url}/api/darts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...createBody, venueCmsId: "no-such-pub" }),
+    });
+    expect(missingVenue.status).toBe(404);
+
+    const onePlayer = await fetch(`${server.url}/api/darts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        startsAt: "2026-09-07T18:00:00.000Z",
+        players: [{ slot: 1, displayName: "Alex", isGuest: true, userId: null }],
+      }),
+    });
+    expect(onePlayer.status).toBe(400);
+  });
+
+  test("turn submit is 404 for an unknown match and 400 for a score above 180", async () => {
+    const missing = await fetch(`${server.url}/api/darts/missing/turns`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ playerSlot: 1, score: 20 }),
+    });
+    expect(missing.status).toBe(404);
+
+    const created = await fetch(`${server.url}/api/darts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(createBody),
+    });
+    const { id } = (await created.json()) as { id: string };
+    const tooHigh = await fetch(`${server.url}/api/darts/${id}/turns`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ playerSlot: 1, score: 181 }),
+    });
+    expect(tooHigh.status).toBe(400);
+  });
+
+  test("maps persistence failures to 503", async () => {
+    const failing = {
+      findById: async () => {
+        throw new DartsMatchPersistenceError("Unable to load darts match");
+      },
+      create: async () => {
+        throw new DartsMatchPersistenceError("Unable to save darts match");
+      },
+      persist: async () => {
+        throw new DartsMatchPersistenceError("Unable to save darts match");
+      },
+      listLockedByPlayerUserId: async () => {
+        throw new DartsMatchPersistenceError("Unable to load darts match");
+      },
+      listLockedByVenueCmsId: async () => {
+        throw new DartsMatchPersistenceError("Unable to load darts match");
+      },
+    };
+    const failingApp = await createApp(config, {
+      venueRepository: venues,
+      dartsMatchRepository: failing,
+    });
+    const failingServer = await listen(failingApp);
+
+    const response = await fetch(`${failingServer.url}/api/darts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(createBody),
+    });
+    expect(response.status).toBe(503);
+
+    await failingServer.close();
+    await failingApp.locals.prisma?.$disconnect();
+  });
+});

--- a/src/modules/darts/entities/darts-match-lock-conflict-error.ts
+++ b/src/modules/darts/entities/darts-match-lock-conflict-error.ts
@@ -1,0 +1,8 @@
+export class DartsMatchLockConflictError extends Error {
+  constructor(
+    message = "Darts match is already locked with a different result",
+  ) {
+    super(message);
+    this.name = "DartsMatchLockConflictError";
+  }
+}

--- a/src/modules/darts/entities/darts-match-persistence-error.ts
+++ b/src/modules/darts/entities/darts-match-persistence-error.ts
@@ -1,0 +1,6 @@
+export class DartsMatchPersistenceError extends Error {
+  constructor(message = "Unable to save darts match", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "DartsMatchPersistenceError";
+  }
+}

--- a/src/modules/darts/entities/darts-match-venue-not-found-error.ts
+++ b/src/modules/darts/entities/darts-match-venue-not-found-error.ts
@@ -1,0 +1,6 @@
+export class DartsMatchVenueNotFoundError extends Error {
+  constructor(message = "Venue not found") {
+    super(message);
+    this.name = "DartsMatchVenueNotFoundError";
+  }
+}

--- a/src/modules/darts/entities/darts-match.test.ts
+++ b/src/modules/darts/entities/darts-match.test.ts
@@ -1,0 +1,260 @@
+import { DomainError } from "../../../lib/domain-error";
+import { CmsId } from "../../venue/entities/cms-id";
+import { DartsMatch, DARTS_STARTING_SCORE } from "./darts-match";
+import { DartsMatchLockConflictError } from "./darts-match-lock-conflict-error";
+import { DartsPlayer } from "./darts-player";
+import { StartsAt } from "./starts-at";
+
+const twoPlayers = [
+  { slot: 1, displayName: "Alex", isGuest: false, userId: "user-alex" },
+  { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+];
+
+function createLive(venueCmsId: CmsId | null = CmsId.from("sanity-pub-1")) {
+  return DartsMatch.create({
+    venueCmsId,
+    startsAt: StartsAt.from("2026-09-07T18:00:00.000Z"),
+    players: twoPlayers,
+  });
+}
+
+describe("darts players", () => {
+  test("requires two to eight unique slots", () => {
+    expect(() => DartsPlayer.fromPlayers([twoPlayers[0]])).toThrow(DomainError);
+    expect(() =>
+      DartsPlayer.fromPlayers([
+        twoPlayers[0],
+        { ...twoPlayers[1], slot: 1 },
+      ]),
+    ).toThrow(DomainError);
+  });
+
+  test("named players require a userId and guests cannot carry one", () => {
+    expect(() =>
+      DartsPlayer.from({
+        slot: 1,
+        displayName: "Alex",
+        isGuest: false,
+        userId: null,
+      }),
+    ).toThrow(DomainError);
+    expect(() =>
+      DartsPlayer.from({
+        slot: 1,
+        displayName: "Alex",
+        isGuest: true,
+        userId: "user-1",
+      }),
+    ).toThrow(DomainError);
+  });
+});
+
+describe(DartsMatch, () => {
+  test("create starts live at 501 with optional venue", () => {
+    const match = createLive(null);
+
+    expect(match.toSnapshot()).toMatchObject({
+      venueCmsId: null,
+      startingScore: DARTS_STARTING_SCORE,
+      checkoutRule: "double_out",
+      status: "live",
+      winnerSlot: null,
+      nextSuggestedSlot: 1,
+      players: [
+        { slot: 1, remaining: 501, userId: "user-alex", isGuest: false },
+        { slot: 2, remaining: 501, userId: null, isGuest: true },
+      ],
+      turns: [],
+    });
+  });
+
+  test("a scoring visit reduces remaining and records the turn", () => {
+    const match = createLive();
+    const turn = match.submitTurn({ playerSlot: 1, score: 60 });
+
+    expect(turn.toSnapshot()).toEqual({
+      turnNumber: 1,
+      playerSlot: 1,
+      score: 60,
+      bust: false,
+      checkout: false,
+      remainingAfter: 441,
+    });
+    expect(match.remainingFor(1)).toBe(441);
+    expect(match.toSnapshot().nextSuggestedSlot).toBe(2);
+  });
+
+  test("identifies the thrower by userId", () => {
+    const match = createLive();
+    match.submitTurn({ userId: "user-alex", score: 26 });
+    expect(match.remainingFor(1)).toBe(475);
+  });
+
+  test("busts when the visit exceeds remaining and leaves the score unchanged", () => {
+    const match = createLive();
+    match.submitTurn({ playerSlot: 1, score: 180 });
+    match.submitTurn({ playerSlot: 1, score: 180 });
+    match.submitTurn({ playerSlot: 1, score: 101 });
+    expect(match.remainingFor(1)).toBe(40);
+
+    const bust = match.submitTurn({ playerSlot: 1, score: 60 });
+    expect(bust.bust).toBe(true);
+    expect(bust.remainingAfter).toBe(40);
+    expect(match.remainingFor(1)).toBe(40);
+    expect(match.status).toBe("live");
+  });
+
+  test("busts when remaining minus score is 1 and never stores remaining 1", () => {
+    const match = createLive();
+    match.submitTurn({ playerSlot: 2, score: 180 });
+    match.submitTurn({ playerSlot: 2, score: 180 });
+    expect(match.remainingFor(2)).toBe(141);
+
+    const bust = match.submitTurn({ playerSlot: 2, score: 140 });
+    expect(bust.bust).toBe(true);
+    expect(bust.remainingAfter).toBe(141);
+    expect(match.remainingFor(2)).toBe(141);
+  });
+
+  test("finishing on 0 without checkout is rejected", () => {
+    const match = createLive();
+    match.submitTurn({ playerSlot: 1, score: 180 });
+    match.submitTurn({ playerSlot: 1, score: 180 });
+    match.submitTurn({ playerSlot: 1, score: 101 });
+    expect(match.remainingFor(1)).toBe(40);
+
+    expect(() => match.submitTurn({ playerSlot: 1, score: 40 })).toThrow(
+      DomainError,
+    );
+    expect(match.remainingFor(1)).toBe(40);
+    expect(match.status).toBe("live");
+  });
+
+  test("checkout true on a visit that reaches 0 locks the match", () => {
+    const match = createLive();
+    match.submitTurn({ playerSlot: 1, score: 180 });
+    match.submitTurn({ playerSlot: 1, score: 180 });
+    match.submitTurn({ playerSlot: 1, score: 101 });
+    const finish = match.submitTurn({
+      playerSlot: 1,
+      score: 40,
+      checkout: true,
+      lockedByUserId: "user-alex",
+    });
+
+    expect(finish.checkout).toBe(true);
+    expect(finish.remainingAfter).toBe(0);
+    expect(match.toSnapshot()).toMatchObject({
+      status: "locked",
+      winnerSlot: 1,
+      winnerUserId: "user-alex",
+      nextSuggestedSlot: null,
+    });
+    expect(match.lockedByUserId).toBe("user-alex");
+  });
+
+  test("checkout is rejected unless the visit reaches 0", () => {
+    const match = createLive();
+    expect(() =>
+      match.submitTurn({ playerSlot: 1, score: 60, checkout: true }),
+    ).toThrow(DomainError);
+    expect(() =>
+      match.submitTurn({ playerSlot: 1, score: 180, checkout: true }),
+    ).toThrow(DomainError);
+  });
+
+  test("rejects turns after lock", () => {
+    const match = createLive();
+    match.submitTurn({ playerSlot: 1, score: 180 });
+    match.submitTurn({ playerSlot: 1, score: 180 });
+    match.submitTurn({ playerSlot: 1, score: 101 });
+    match.submitTurn({ playerSlot: 1, score: 40, checkout: true });
+
+    expect(() => match.submitTurn({ playerSlot: 2, score: 20 })).toThrow(
+      DartsMatchLockConflictError,
+    );
+  });
+
+  test("rejects illegal visit scores", () => {
+    const match = createLive();
+    expect(() => match.submitTurn({ playerSlot: 1, score: 181 })).toThrow(
+      DomainError,
+    );
+    expect(() => match.submitTurn({ playerSlot: 1, score: -1 })).toThrow(
+      DomainError,
+    );
+    expect(() => match.submitTurn({ playerSlot: 1, score: 20.5 })).toThrow(
+      DomainError,
+    );
+  });
+
+  test("captureFinished replays turns and locks with a winner", () => {
+    const lockedAt = new Date("2026-09-07T19:00:00.000Z");
+    const match = DartsMatch.captureFinished({
+      venueCmsId: null,
+      startsAt: StartsAt.from("2026-09-07T18:00:00.000Z"),
+      players: twoPlayers,
+      turns: [
+        { playerSlot: 1, score: 180 },
+        { playerSlot: 2, score: 26 },
+        { playerSlot: 1, score: 180 },
+        { playerSlot: 1, score: 141, checkout: true },
+      ],
+      winnerSlot: 1,
+      lockedByUserId: "user-alex",
+      lockedAt,
+    });
+
+    expect(match.toSnapshot()).toMatchObject({
+      status: "locked",
+      venueCmsId: null,
+      winnerSlot: 1,
+      lockedAt: "2026-09-07T19:00:00.000Z",
+      players: [
+        { slot: 1, remaining: 0 },
+        { slot: 2, remaining: 475 },
+      ],
+    });
+    expect(match.turns).toHaveLength(4);
+  });
+
+  test("captureFinished accepts remaining + winner without a turn log", () => {
+    const match = DartsMatch.captureFinished({
+      venueCmsId: CmsId.from("sanity-pub-1"),
+      startsAt: StartsAt.from("2026-09-07T18:00:00.000Z"),
+      players: twoPlayers,
+      remaining: { "1": 0, "2": 140 },
+      winnerSlot: 1,
+      lockedByUserId: "user-alex",
+    });
+
+    expect(match.status).toBe("locked");
+    expect(match.remainingFor(1)).toBe(0);
+    expect(match.remainingFor(2)).toBe(140);
+    expect(match.turns).toHaveLength(0);
+  });
+
+  test("captureFinished rejects leftover 1 and a winner who has not checked out", () => {
+    expect(() =>
+      DartsMatch.captureFinished({
+        venueCmsId: null,
+        startsAt: StartsAt.from("2026-09-07T18:00:00.000Z"),
+        players: twoPlayers,
+        remaining: { "1": 0, "2": 1 },
+        winnerSlot: 1,
+        lockedByUserId: "user-alex",
+      }),
+    ).toThrow(DomainError);
+
+    expect(() =>
+      DartsMatch.captureFinished({
+        venueCmsId: null,
+        startsAt: StartsAt.from("2026-09-07T18:00:00.000Z"),
+        players: twoPlayers,
+        remaining: { "1": 40, "2": 80 },
+        winnerSlot: 1,
+        lockedByUserId: "user-alex",
+      }),
+    ).toThrow(DomainError);
+  });
+});

--- a/src/modules/darts/entities/darts-match.ts
+++ b/src/modules/darts/entities/darts-match.ts
@@ -1,0 +1,508 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError } from "../../../lib/domain-error";
+import { CmsId } from "../../venue/entities/cms-id";
+import { DartsMatchLockConflictError } from "./darts-match-lock-conflict-error";
+import {
+  DartsPlayer,
+  DartsPlayerInput,
+  DartsPlayerSnapshot,
+} from "./darts-player";
+import { DartsTurn, DartsTurnInput, DartsTurnSnapshot } from "./darts-turn";
+import { StartsAt } from "./starts-at";
+
+export const DARTS_STARTING_SCORE = 501;
+export const DARTS_CHECKOUT_RULE = "double_out" as const;
+
+export type DartsMatchStatusValue = "live" | "locked";
+export type DartsCheckoutRule = typeof DARTS_CHECKOUT_RULE;
+
+export type DartsMatchSnapshot = {
+  id: string;
+  venueCmsId: string | null;
+  startsAt: string;
+  startingScore: number;
+  checkoutRule: DartsCheckoutRule;
+  status: DartsMatchStatusValue;
+  players: DartsPlayerSnapshot[];
+  turns: DartsTurnSnapshot[];
+  winnerSlot: number | null;
+  winnerUserId: string | null;
+  lockedAt: string | null;
+  nextSuggestedSlot: number | null;
+};
+
+export type CreateDartsMatchProps = {
+  venueCmsId: CmsId | null;
+  startsAt: StartsAt;
+  players: DartsPlayerInput[];
+};
+
+export type SubmitDartsTurnInput = DartsTurnInput & {
+  lockedByUserId?: string | null;
+};
+
+export class DartsMatch {
+  private constructor(
+    readonly id: string,
+    readonly venueCmsId: CmsId | null,
+    readonly startsAt: StartsAt,
+    readonly startingScore: number,
+    private statusValue: DartsMatchStatusValue,
+    readonly players: readonly DartsPlayer[],
+    private remainingBySlot: Map<number, number>,
+    private turnsValue: DartsTurn[],
+    private winnerSlotValue: number | null,
+    private lockedAtValue: Date | null,
+    private lockedByUserIdValue: string | null,
+  ) {}
+
+  static create(props: CreateDartsMatchProps): DartsMatch {
+    const players = DartsPlayer.fromPlayers(props.players);
+    const remainingBySlot = new Map(
+      players.map((player) => [player.slot, DARTS_STARTING_SCORE]),
+    );
+
+    return new DartsMatch(
+      randomUUID(),
+      props.venueCmsId,
+      props.startsAt,
+      DARTS_STARTING_SCORE,
+      "live",
+      players,
+      remainingBySlot,
+      [],
+      null,
+      null,
+      null,
+    );
+  }
+
+  static captureFinished(
+    props: CreateDartsMatchProps & {
+      turns?: DartsTurnInput[];
+      remaining?: unknown;
+      winnerSlot?: unknown;
+      winnerUserId?: unknown;
+      lockedByUserId: string;
+      lockedAt?: Date;
+    },
+  ): DartsMatch {
+    const match = DartsMatch.create(props);
+    const turns = Array.isArray(props.turns) ? props.turns : [];
+
+    if (turns.length > 0) {
+      for (const turn of turns) {
+        match.submitTurn({
+          ...turn,
+          lockedByUserId: props.lockedByUserId,
+        });
+      }
+      if (!match.isLocked) {
+        throw new DomainError(
+          "captured turns must include a checkout that finishes the match",
+        );
+      }
+      match.assertCapturedWinner(props.winnerSlot, props.winnerUserId);
+      if (props.remaining !== undefined) {
+        match.assertCapturedRemaining(props.remaining);
+      }
+      if (props.lockedAt) {
+        match.lockedAtValue = props.lockedAt;
+      }
+      match.lockedByUserIdValue = normalizeLockedByUserId(props.lockedByUserId);
+      return match;
+    }
+
+    match.applyCapturedRemaining(props.remaining);
+    match.lockFromCapture(
+      props.winnerSlot,
+      props.winnerUserId,
+      props.lockedByUserId,
+      props.lockedAt ?? new Date(),
+    );
+    return match;
+  }
+
+  static rehydrate(props: {
+    id: string;
+    venueCmsId: CmsId | null;
+    startsAt: StartsAt;
+    startingScore?: number;
+    status: DartsMatchStatusValue;
+    players: DartsPlayer[];
+    remainingBySlot: Map<number, number>;
+    turns: DartsTurn[];
+    winnerSlot: number | null;
+    lockedAt: Date | null;
+    lockedByUserId?: string | null;
+  }): DartsMatch {
+    return new DartsMatch(
+      props.id,
+      props.venueCmsId,
+      props.startsAt,
+      props.startingScore ?? DARTS_STARTING_SCORE,
+      props.status,
+      props.players,
+      props.remainingBySlot,
+      [...props.turns].sort((a, b) => a.turnNumber - b.turnNumber),
+      props.winnerSlot,
+      props.lockedAt,
+      normalizeLockedByUserId(props.lockedByUserId),
+    );
+  }
+
+  get status(): DartsMatchStatusValue {
+    return this.statusValue;
+  }
+
+  get turns(): readonly DartsTurn[] {
+    return this.turnsValue;
+  }
+
+  get winnerSlot(): number | null {
+    return this.winnerSlotValue;
+  }
+
+  get lockedAt(): Date | null {
+    return this.lockedAtValue;
+  }
+
+  get lockedByUserId(): string | null {
+    return this.lockedByUserIdValue;
+  }
+
+  get isLocked(): boolean {
+    return this.statusValue === "locked";
+  }
+
+  remainingFor(slot: number): number {
+    const remaining = this.remainingBySlot.get(slot);
+    if (remaining === undefined) {
+      throw new DomainError(`unknown player slot ${slot}`);
+    }
+    return remaining;
+  }
+
+  hasPlayerUserId(userId: string): boolean {
+    return this.players.some((player) => player.hasUserId(userId));
+  }
+
+  playerSlots(): number[] {
+    return this.players.map((player) => player.slot);
+  }
+
+  submitTurn(input: SubmitDartsTurnInput): DartsTurn {
+    if (this.statusValue === "locked") {
+      throw new DartsMatchLockConflictError(
+        "Cannot submit a turn to a locked darts match",
+      );
+    }
+
+    const player = this.resolvePlayer(input.playerSlot, input.userId);
+    const score = DartsTurn.parseVisitScore(input.score);
+    const checkout = input.checkout === true;
+    const remaining = this.remainingFor(player.slot);
+    const leftover = remaining - score;
+
+    if (leftover < 0 || leftover === 1) {
+      if (checkout) {
+        throw new DomainError("checkout is not allowed on a bust");
+      }
+
+      const turn = DartsTurn.record({
+        turnNumber: this.turnsValue.length + 1,
+        playerSlot: player.slot,
+        score,
+        bust: true,
+        checkout: false,
+        remainingAfter: remaining,
+      });
+      this.turnsValue.push(turn);
+      return turn;
+    }
+
+    if (leftover === 0) {
+      if (!checkout) {
+        throw new DomainError("checkout must be true to finish on 0");
+      }
+
+      const turn = DartsTurn.record({
+        turnNumber: this.turnsValue.length + 1,
+        playerSlot: player.slot,
+        score,
+        bust: false,
+        checkout: true,
+        remainingAfter: 0,
+      });
+      this.turnsValue.push(turn);
+      this.remainingBySlot.set(player.slot, 0);
+      this.lock(
+        player.slot,
+        new Date(),
+        normalizeLockedByUserId(input.lockedByUserId),
+      );
+      return turn;
+    }
+
+    if (checkout) {
+      throw new DomainError("checkout is only valid when the visit reaches 0");
+    }
+
+    const turn = DartsTurn.record({
+      turnNumber: this.turnsValue.length + 1,
+      playerSlot: player.slot,
+      score,
+      bust: false,
+      checkout: false,
+      remainingAfter: leftover,
+    });
+    this.turnsValue.push(turn);
+    this.remainingBySlot.set(player.slot, leftover);
+    return turn;
+  }
+
+  hasSameLockedResult(other: DartsMatch): boolean {
+    if (!this.isLocked || !other.isLocked) {
+      return false;
+    }
+    if (this.winnerSlotValue !== other.winnerSlotValue) {
+      return false;
+    }
+    if (this.players.length !== other.players.length) {
+      return false;
+    }
+    return this.players.every(
+      (player) =>
+        this.remainingFor(player.slot) === other.remainingFor(player.slot),
+    );
+  }
+
+  toSnapshot(): DartsMatchSnapshot {
+    return {
+      id: this.id,
+      venueCmsId: this.venueCmsId?.value ?? null,
+      startsAt: this.startsAt.toIsoString(),
+      startingScore: this.startingScore,
+      checkoutRule: DARTS_CHECKOUT_RULE,
+      status: this.statusValue,
+      players: this.players.map((player) =>
+        player.toSnapshot(this.remainingFor(player.slot)),
+      ),
+      turns: this.turnsValue.map((turn) => turn.toSnapshot()),
+      winnerSlot: this.winnerSlotValue,
+      winnerUserId: this.winnerUserId(),
+      lockedAt: this.lockedAtValue?.toISOString() ?? null,
+      nextSuggestedSlot: this.nextSuggestedSlot(),
+    };
+  }
+
+  private lock(
+    winnerSlot: number,
+    lockedAt: Date,
+    lockedByUserId: string | null,
+  ): void {
+    if (this.statusValue === "locked") {
+      if (this.winnerSlotValue === winnerSlot) {
+        return;
+      }
+      throw new DartsMatchLockConflictError();
+    }
+
+    this.statusValue = "locked";
+    this.winnerSlotValue = winnerSlot;
+    this.lockedAtValue = lockedAt;
+    this.lockedByUserIdValue = lockedByUserId;
+  }
+
+  private applyCapturedRemaining(raw: unknown): void {
+    const remaining = parseRemainingBySlot(raw, this.playerSlots());
+    for (const player of this.players) {
+      const value = remaining.get(player.slot);
+      if (value === undefined) {
+        throw new DomainError(`remaining is required for slot ${player.slot}`);
+      }
+      if (value === 1) {
+        throw new DomainError(
+          `remaining for slot ${player.slot} cannot be 1 under double-out`,
+        );
+      }
+      if (value < 0 || value > DARTS_STARTING_SCORE) {
+        throw new DomainError(
+          `remaining for slot ${player.slot} must be between 0 and ${DARTS_STARTING_SCORE}`,
+        );
+      }
+      this.remainingBySlot.set(player.slot, value);
+    }
+  }
+
+  private lockFromCapture(
+    winnerSlotRaw: unknown,
+    winnerUserIdRaw: unknown,
+    lockedByUserId: string,
+    lockedAt: Date,
+  ): void {
+    const winner = this.resolveWinner(winnerSlotRaw, winnerUserIdRaw);
+    if (this.remainingFor(winner.slot) !== 0) {
+      throw new DomainError("winner remaining must be 0");
+    }
+    const otherWinners = this.players.filter(
+      (player) =>
+        player.slot !== winner.slot && this.remainingFor(player.slot) === 0,
+    );
+    if (otherWinners.length > 0) {
+      throw new DomainError("exactly one player can finish on 0");
+    }
+    this.lock(winner.slot, lockedAt, normalizeLockedByUserId(lockedByUserId));
+  }
+
+  private assertCapturedWinner(
+    winnerSlotRaw: unknown,
+    winnerUserIdRaw: unknown,
+  ): void {
+    if (winnerSlotRaw === undefined && winnerUserIdRaw === undefined) {
+      return;
+    }
+    const winner = this.resolveWinner(winnerSlotRaw, winnerUserIdRaw);
+    if (winner.slot !== this.winnerSlotValue) {
+      throw new DomainError("winner does not match the captured checkout");
+    }
+  }
+
+  private assertCapturedRemaining(raw: unknown): void {
+    const remaining = parseRemainingBySlot(raw, this.playerSlots());
+    for (const player of this.players) {
+      const expected = remaining.get(player.slot);
+      if (
+        expected !== undefined &&
+        expected !== this.remainingFor(player.slot)
+      ) {
+        throw new DomainError(
+          `remaining for slot ${player.slot} does not match the captured turns`,
+        );
+      }
+    }
+  }
+
+  private resolveWinner(
+    winnerSlotRaw: unknown,
+    winnerUserIdRaw: unknown,
+  ): DartsPlayer {
+    if (winnerSlotRaw !== undefined && winnerSlotRaw !== null) {
+      const player = this.playerBySlot(winnerSlotRaw);
+      if (winnerUserIdRaw !== undefined && winnerUserIdRaw !== null) {
+        const userId = parseOptionalId(winnerUserIdRaw, "winnerUserId");
+        if (userId && !player.hasUserId(userId)) {
+          throw new DomainError("winnerUserId does not match winnerSlot");
+        }
+      }
+      return player;
+    }
+
+    const userId = parseOptionalId(winnerUserIdRaw, "winnerUserId");
+    if (!userId) {
+      throw new DomainError("winnerSlot or winnerUserId is required");
+    }
+    const player = this.players.find((candidate) => candidate.hasUserId(userId));
+    if (!player) {
+      throw new DomainError("winnerUserId must match a seated named player");
+    }
+    return player;
+  }
+
+  private resolvePlayer(playerSlotRaw: unknown, userIdRaw: unknown): DartsPlayer {
+    if (playerSlotRaw !== undefined && playerSlotRaw !== null) {
+      const player = this.playerBySlot(playerSlotRaw);
+      const userId = parseOptionalId(userIdRaw, "userId");
+      if (userId && !player.hasUserId(userId)) {
+        throw new DomainError("userId does not match playerSlot");
+      }
+      return player;
+    }
+
+    const userId = parseOptionalId(userIdRaw, "userId");
+    if (!userId) {
+      throw new DomainError("playerSlot or userId is required");
+    }
+    const player = this.players.find((candidate) => candidate.hasUserId(userId));
+    if (!player) {
+      throw new DomainError("userId must match a seated named player");
+    }
+    return player;
+  }
+
+  private playerBySlot(raw: unknown): DartsPlayer {
+    if (typeof raw !== "number" || !Number.isInteger(raw)) {
+      throw new DomainError("playerSlot must be an integer");
+    }
+    const player = this.players.find((candidate) => candidate.slot === raw);
+    if (!player) {
+      throw new DomainError(`playerSlot ${raw} is not seated`);
+    }
+    return player;
+  }
+
+  private winnerUserId(): string | null {
+    if (this.winnerSlotValue === null) {
+      return null;
+    }
+    return (
+      this.players.find((player) => player.slot === this.winnerSlotValue)
+        ?.userId ?? null
+    );
+  }
+
+  private nextSuggestedSlot(): number | null {
+    if (this.isLocked) {
+      return null;
+    }
+    const slots = this.playerSlots();
+    return slots[this.turnsValue.length % slots.length] ?? null;
+  }
+}
+
+function normalizeLockedByUserId(
+  userId: string | null | undefined,
+): string | null {
+  if (typeof userId !== "string") {
+    return null;
+  }
+  const value = userId.trim();
+  return value.length === 0 ? null : value;
+}
+
+function parseOptionalId(raw: unknown, field: string): string | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+  if (typeof raw !== "string") {
+    throw new DomainError(`${field} must be a string`);
+  }
+  const value = raw.trim();
+  return value.length === 0 ? null : value;
+}
+
+function parseRemainingBySlot(
+  raw: unknown,
+  slots: number[],
+): Map<number, number> {
+  if (raw === undefined || raw === null || typeof raw !== "object") {
+    throw new DomainError("remaining is required for each seated player");
+  }
+
+  const record = raw as Record<string, unknown>;
+  const remaining = new Map<number, number>();
+
+  for (const slot of slots) {
+    const value = record[String(slot)] ?? record[slot as unknown as string];
+    if (value === undefined) {
+      continue;
+    }
+    if (typeof value !== "number" || !Number.isInteger(value)) {
+      throw new DomainError(`remaining.${slot} must be an integer`);
+    }
+    remaining.set(slot, value);
+  }
+
+  return remaining;
+}

--- a/src/modules/darts/entities/darts-player.ts
+++ b/src/modules/darts/entities/darts-player.ts
@@ -1,0 +1,111 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+export const DARTS_MIN_PLAYERS = 2;
+export const DARTS_MAX_PLAYERS = 8;
+
+export type DartsPlayerInput = {
+  slot: unknown;
+  userId?: string | null;
+  displayName: unknown;
+  isGuest: unknown;
+};
+
+export type DartsPlayerSnapshot = {
+  slot: number;
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+  remaining: number;
+};
+
+export class DartsPlayer {
+  private constructor(
+    readonly slot: number,
+    readonly userId: string | null,
+    readonly displayName: string,
+    readonly isGuest: boolean,
+  ) {}
+
+  static from(input: DartsPlayerInput): DartsPlayer {
+    const slot = parseSlot(input.slot);
+    const displayName = requiredTrimmed(
+      input.displayName,
+      `players[${slot}].displayName`,
+    );
+    const isGuest = input.isGuest === true;
+    const userId = optionalUserId(input.userId, slot);
+
+    if (isGuest) {
+      if (userId !== null) {
+        throw new DomainError(
+          `players[${slot}] is a guest and cannot have a userId`,
+        );
+      }
+
+      return new DartsPlayer(slot, null, displayName, true);
+    }
+
+    if (userId === null) {
+      throw new DomainError(
+        `players[${slot}] requires a userId unless isGuest is true`,
+      );
+    }
+
+    return new DartsPlayer(slot, userId, displayName, false);
+  }
+
+  static fromPlayers(inputs: DartsPlayerInput[]): DartsPlayer[] {
+    if (
+      !Array.isArray(inputs) ||
+      inputs.length < DARTS_MIN_PLAYERS ||
+      inputs.length > DARTS_MAX_PLAYERS
+    ) {
+      throw new DomainError(
+        `players must include between ${DARTS_MIN_PLAYERS} and ${DARTS_MAX_PLAYERS} players`,
+      );
+    }
+
+    const players = inputs.map((input) => DartsPlayer.from(input));
+    const slots = new Set(players.map((player) => player.slot));
+    if (slots.size !== players.length) {
+      throw new DomainError("players must have unique slots");
+    }
+
+    return [...players].sort((a, b) => a.slot - b.slot);
+  }
+
+  hasUserId(userId: string): boolean {
+    return this.userId === userId;
+  }
+
+  toSnapshot(remaining: number): DartsPlayerSnapshot {
+    return {
+      slot: this.slot,
+      userId: this.userId,
+      displayName: this.displayName,
+      isGuest: this.isGuest,
+      remaining,
+    };
+  }
+}
+
+function parseSlot(raw: unknown): number {
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < 1 || raw > 8) {
+    throw new DomainError("players.slot must be an integer between 1 and 8");
+  }
+
+  return raw;
+}
+
+function optionalUserId(raw: unknown, slot: number): string | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+
+  if (typeof raw !== "string") {
+    throw new DomainError(`players[${slot}].userId must be a string`);
+  }
+
+  const value = raw.trim();
+  return value.length === 0 ? null : value;
+}

--- a/src/modules/darts/entities/darts-turn.ts
+++ b/src/modules/darts/entities/darts-turn.ts
@@ -1,0 +1,69 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const DARTS_MAX_VISIT_SCORE = 180;
+
+export type DartsTurnInput = {
+  playerSlot?: unknown;
+  userId?: unknown;
+  score: unknown;
+  checkout?: unknown;
+};
+
+export type DartsTurnSnapshot = {
+  turnNumber: number;
+  playerSlot: number;
+  score: number;
+  bust: boolean;
+  checkout: boolean;
+  remainingAfter: number;
+};
+
+export class DartsTurn {
+  private constructor(
+    readonly turnNumber: number,
+    readonly playerSlot: number,
+    readonly score: number,
+    readonly bust: boolean,
+    readonly checkout: boolean,
+    readonly remainingAfter: number,
+  ) {}
+
+  static record(props: {
+    turnNumber: number;
+    playerSlot: number;
+    score: number;
+    bust: boolean;
+    checkout: boolean;
+    remainingAfter: number;
+  }): DartsTurn {
+    return new DartsTurn(
+      props.turnNumber,
+      props.playerSlot,
+      props.score,
+      props.bust,
+      props.checkout,
+      props.remainingAfter,
+    );
+  }
+
+  static parseVisitScore(raw: unknown): number {
+    if (typeof raw !== "number" || !Number.isInteger(raw)) {
+      throw new DomainError("score must be an integer between 0 and 180");
+    }
+    if (raw < 0 || raw > DARTS_MAX_VISIT_SCORE) {
+      throw new DomainError("score must be an integer between 0 and 180");
+    }
+    return raw;
+  }
+
+  toSnapshot(): DartsTurnSnapshot {
+    return {
+      turnNumber: this.turnNumber,
+      playerSlot: this.playerSlot,
+      score: this.score,
+      bust: this.bust,
+      checkout: this.checkout,
+      remainingAfter: this.remainingAfter,
+    };
+  }
+}

--- a/src/modules/darts/entities/starts-at.ts
+++ b/src/modules/darts/entities/starts-at.ts
@@ -1,0 +1,29 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export class StartsAt {
+  private constructor(readonly value: Date) {}
+
+  static from(raw: unknown): StartsAt {
+    if (raw instanceof Date) {
+      if (Number.isNaN(raw.getTime())) {
+        throw new DomainError("startsAt must be a valid date");
+      }
+      return new StartsAt(raw);
+    }
+
+    if (typeof raw !== "string" || raw.trim().length === 0) {
+      throw new DomainError("startsAt is required");
+    }
+
+    const parsed = new Date(raw);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new DomainError("startsAt must be a valid date");
+    }
+
+    return new StartsAt(parsed);
+  }
+
+  toIsoString(): string {
+    return this.value.toISOString();
+  }
+}

--- a/src/modules/darts/index.ts
+++ b/src/modules/darts/index.ts
@@ -1,0 +1,79 @@
+import { Request, Router } from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { VenueRepository } from "../venue/repositories/venue.repository";
+import { createDartsMatchController } from "./controllers/darts-match.controller";
+import { DartsMatchRepository } from "./repositories/darts-match.repository";
+import { PrismaDartsMatchRepository } from "./repositories/prisma-darts-match.repository";
+import { createDartsMatchRoutes } from "./routes/darts-match.routes";
+import { CaptureFinishedDartsMatch } from "./services/capture-finished-darts-match.service";
+import { CreateDartsMatch } from "./services/create-darts-match.service";
+import { GetDartsMatchById } from "./services/get-darts-match-by-id.service";
+import {
+  ListLockedDartsMatchesByPlayer,
+  ListLockedDartsMatchesByVenue,
+} from "./services/list-locked-darts-matches.service";
+import { SubmitDartsTurn } from "./services/submit-darts-turn.service";
+
+export type CreateDartsModuleParams = {
+  prisma: PrismaClient;
+  venueRepository: VenueRepository;
+  dartsMatchRepository?: DartsMatchRepository;
+  tryGetSessionUserId: (req: Request) => string | null;
+};
+
+export type DartsModule = {
+  router: Router;
+  dartsMatchRepository: DartsMatchRepository;
+};
+
+export function createDartsModule({
+  prisma,
+  venueRepository,
+  dartsMatchRepository: dartsMatchRepositoryOverride,
+  tryGetSessionUserId,
+}: CreateDartsModuleParams): DartsModule {
+  const dartsMatchRepository =
+    dartsMatchRepositoryOverride ?? new PrismaDartsMatchRepository(prisma);
+
+  const controller = createDartsMatchController({
+    createDartsMatch: new CreateDartsMatch(
+      dartsMatchRepository,
+      venueRepository,
+    ),
+    captureFinishedDartsMatch: new CaptureFinishedDartsMatch(
+      dartsMatchRepository,
+      venueRepository,
+    ),
+    getDartsMatchById: new GetDartsMatchById(dartsMatchRepository),
+    submitDartsTurn: new SubmitDartsTurn(dartsMatchRepository),
+    listLockedDartsMatchesByPlayer: new ListLockedDartsMatchesByPlayer(
+      dartsMatchRepository,
+      venueRepository,
+    ),
+    listLockedDartsMatchesByVenue: new ListLockedDartsMatchesByVenue(
+      dartsMatchRepository,
+      venueRepository,
+    ),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createDartsMatchRoutes(controller),
+    dartsMatchRepository,
+  };
+}
+
+export { createDartsMatchController } from "./controllers/darts-match.controller";
+export { DartsMatch } from "./entities/darts-match";
+export { InMemoryDartsMatchRepository } from "./repositories/in-memory-darts-match.repository";
+export { PrismaDartsMatchRepository } from "./repositories/prisma-darts-match.repository";
+export type { DartsMatchRepository } from "./repositories/darts-match.repository";
+export { CaptureFinishedDartsMatch } from "./services/capture-finished-darts-match.service";
+export { CreateDartsMatch } from "./services/create-darts-match.service";
+export { GetDartsMatchById } from "./services/get-darts-match-by-id.service";
+export { SubmitDartsTurn } from "./services/submit-darts-turn.service";
+export {
+  ListLockedDartsMatchesByPlayer,
+  ListLockedDartsMatchesByVenue,
+} from "./services/list-locked-darts-matches.service";

--- a/src/modules/darts/repositories/darts-match.repository.ts
+++ b/src/modules/darts/repositories/darts-match.repository.ts
@@ -1,0 +1,10 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { DartsMatch } from "../entities/darts-match";
+
+export interface DartsMatchRepository {
+  findById(id: string): Promise<DartsMatch | null>;
+  create(match: DartsMatch): Promise<DartsMatch>;
+  persist(match: DartsMatch): Promise<DartsMatch>;
+  listLockedByPlayerUserId(userId: string): Promise<DartsMatch[]>;
+  listLockedByVenueCmsId(cmsId: CmsId): Promise<DartsMatch[]>;
+}

--- a/src/modules/darts/repositories/in-memory-darts-match.repository.ts
+++ b/src/modules/darts/repositories/in-memory-darts-match.repository.ts
@@ -1,0 +1,87 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { DartsMatch } from "../entities/darts-match";
+import { DartsMatchLockConflictError } from "../entities/darts-match-lock-conflict-error";
+import { DartsPlayer } from "../entities/darts-player";
+import { DartsTurn } from "../entities/darts-turn";
+import { DartsMatchRepository } from "./darts-match.repository";
+
+export class InMemoryDartsMatchRepository implements DartsMatchRepository {
+  private readonly byId = new Map<string, DartsMatch>();
+
+  async findById(id: string): Promise<DartsMatch | null> {
+    return clone(this.byId.get(id) ?? null);
+  }
+
+  async create(match: DartsMatch): Promise<DartsMatch> {
+    this.byId.set(match.id, clone(match)!);
+    return clone(match)!;
+  }
+
+  async persist(match: DartsMatch): Promise<DartsMatch> {
+    const stored = this.byId.get(match.id);
+    if (!stored) {
+      this.byId.set(match.id, clone(match)!);
+      return clone(match)!;
+    }
+
+    if (stored.isLocked) {
+      if (stored.hasSameLockedResult(match)) {
+        return clone(stored)!;
+      }
+
+      throw new DartsMatchLockConflictError();
+    }
+
+    this.byId.set(match.id, clone(match)!);
+    return clone(match)!;
+  }
+
+  async listLockedByPlayerUserId(userId: string): Promise<DartsMatch[]> {
+    return this.lockedNewestFirst().filter((match) =>
+      match.hasPlayerUserId(userId),
+    );
+  }
+
+  async listLockedByVenueCmsId(cmsId: CmsId): Promise<DartsMatch[]> {
+    return this.lockedNewestFirst().filter(
+      (match) => match.venueCmsId?.equals(cmsId) ?? false,
+    );
+  }
+
+  private lockedNewestFirst(): DartsMatch[] {
+    return [...this.byId.values()]
+      .filter((match) => match.isLocked)
+      .sort((a, b) => b.startsAt.value.getTime() - a.startsAt.value.getTime())
+      .map((match) => clone(match)!);
+  }
+}
+
+function clone(match: DartsMatch | null): DartsMatch | null {
+  if (!match) {
+    return null;
+  }
+
+  const snapshot = match.toSnapshot();
+  return DartsMatch.rehydrate({
+    id: snapshot.id,
+    venueCmsId: match.venueCmsId,
+    startsAt: match.startsAt,
+    startingScore: match.startingScore,
+    status: snapshot.status,
+    players: DartsPlayer.fromPlayers(
+      snapshot.players.map((player) => ({
+        slot: player.slot,
+        userId: player.userId,
+        displayName: player.displayName,
+        isGuest: player.isGuest,
+      })),
+    ),
+    remainingBySlot: new Map(
+      snapshot.players.map((player) => [player.slot, player.remaining]),
+    ),
+    turns: snapshot.turns.map((turn) => DartsTurn.record(turn)),
+    winnerSlot: snapshot.winnerSlot,
+    lockedAt: match.lockedAt,
+    lockedByUserId: match.lockedByUserId,
+  });
+}

--- a/src/modules/darts/repositories/prisma-darts-match.repository.ts
+++ b/src/modules/darts/repositories/prisma-darts-match.repository.ts
@@ -1,0 +1,272 @@
+import { Prisma, PrismaClient } from "../../../generated/prisma/client";
+import { CmsId } from "../../venue/entities/cms-id";
+import { DartsMatch, DartsMatchStatusValue } from "../entities/darts-match";
+import { DartsMatchLockConflictError } from "../entities/darts-match-lock-conflict-error";
+import { DartsMatchPersistenceError } from "../entities/darts-match-persistence-error";
+import { DartsMatchVenueNotFoundError } from "../entities/darts-match-venue-not-found-error";
+import { DartsPlayer } from "../entities/darts-player";
+import { DartsTurn } from "../entities/darts-turn";
+import { StartsAt } from "../entities/starts-at";
+import { DartsMatchRepository } from "./darts-match.repository";
+
+type DartsMatchPlayerRow = {
+  slot: number;
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+  remaining: number;
+};
+
+type DartsTurnRow = {
+  turnNumber: number;
+  playerSlot: number;
+  score: number;
+  bust: boolean;
+  checkout: boolean;
+  remainingAfter: number;
+};
+
+type DartsMatchRow = {
+  id: string;
+  venueCmsId: string | null;
+  startsAt: Date;
+  startingScore: number;
+  status: "live" | "locked";
+  winnerSlot: number | null;
+  lockedAt: Date | null;
+  lockedByUserId: string | null;
+  players: DartsMatchPlayerRow[];
+  turns: DartsTurnRow[];
+};
+
+export class PrismaDartsMatchRepository implements DartsMatchRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(id: string): Promise<DartsMatch | null> {
+    try {
+      const row = await this.prisma.dartsMatch.findUnique({
+        where: { id },
+        include: { players: true, turns: true },
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw wrapPersistenceError(error, "Unable to load darts match");
+    }
+  }
+
+  async create(match: DartsMatch): Promise<DartsMatch> {
+    const snapshot = match.toSnapshot();
+
+    try {
+      const row = await this.prisma.dartsMatch.create({
+        data: {
+          id: snapshot.id,
+          venueCmsId: snapshot.venueCmsId,
+          startsAt: match.startsAt.value,
+          startingScore: snapshot.startingScore,
+          status: snapshot.status,
+          winnerSlot: snapshot.winnerSlot,
+          lockedAt: match.lockedAt,
+          lockedByUserId: match.lockedByUserId,
+          players: {
+            create: snapshot.players.map((player) => ({
+              slot: player.slot,
+              userId: player.userId,
+              displayName: player.displayName,
+              isGuest: player.isGuest,
+              remaining: player.remaining,
+            })),
+          },
+          turns: {
+            create: snapshot.turns.map((turn) => ({
+              turnNumber: turn.turnNumber,
+              playerSlot: turn.playerSlot,
+              score: turn.score,
+              bust: turn.bust,
+              checkout: turn.checkout,
+              remainingAfter: turn.remainingAfter,
+            })),
+          },
+        },
+        include: { players: true, turns: true },
+      });
+
+      return toDomain(row);
+    } catch (error) {
+      if (isForeignKeyViolation(error)) {
+        throw new DartsMatchVenueNotFoundError();
+      }
+
+      throw wrapPersistenceError(error, "Unable to save darts match");
+    }
+  }
+
+  async persist(match: DartsMatch): Promise<DartsMatch> {
+    const snapshot = match.toSnapshot();
+
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        const current = await tx.dartsMatch.findUnique({
+          where: { id: match.id },
+          include: { turns: true },
+        });
+        if (!current) {
+          throw new DartsMatchPersistenceError("Unable to load darts match");
+        }
+
+        if (current.status === "locked") {
+          const stored = await this.findById(match.id);
+          if (stored && stored.hasSameLockedResult(match)) {
+            return;
+          }
+          throw new DartsMatchLockConflictError();
+        }
+
+        const existingTurnNumbers = new Set(
+          current.turns.map((turn) => turn.turnNumber),
+        );
+        const newTurns = snapshot.turns.filter(
+          (turn) => !existingTurnNumbers.has(turn.turnNumber),
+        );
+
+        for (const player of snapshot.players) {
+          await tx.dartsMatchPlayer.update({
+            where: {
+              matchId_slot: { matchId: match.id, slot: player.slot },
+            },
+            data: { remaining: player.remaining },
+          });
+        }
+
+        if (newTurns.length > 0) {
+          await tx.dartsTurn.createMany({
+            data: newTurns.map((turn) => ({
+              matchId: match.id,
+              turnNumber: turn.turnNumber,
+              playerSlot: turn.playerSlot,
+              score: turn.score,
+              bust: turn.bust,
+              checkout: turn.checkout,
+              remainingAfter: turn.remainingAfter,
+            })),
+          });
+        }
+
+        if (match.isLocked) {
+          const updated = await tx.dartsMatch.updateMany({
+            where: { id: match.id, status: "live" },
+            data: {
+              status: "locked",
+              winnerSlot: snapshot.winnerSlot,
+              lockedAt: match.lockedAt,
+              lockedByUserId: match.lockedByUserId,
+            },
+          });
+          if (updated.count !== 1) {
+            throw new DartsMatchLockConflictError();
+          }
+        }
+      });
+
+      const persisted = await this.findById(match.id);
+      if (!persisted) {
+        throw new DartsMatchPersistenceError("Unable to load darts match");
+      }
+      return persisted;
+    } catch (error) {
+      if (
+        error instanceof DartsMatchLockConflictError ||
+        error instanceof DartsMatchPersistenceError
+      ) {
+        throw error;
+      }
+
+      throw wrapPersistenceError(error, "Unable to save darts match");
+    }
+  }
+
+  async listLockedByPlayerUserId(userId: string): Promise<DartsMatch[]> {
+    try {
+      const rows = await this.prisma.dartsMatch.findMany({
+        where: {
+          status: "locked",
+          players: { some: { userId } },
+        },
+        include: { players: true, turns: true },
+        orderBy: { startsAt: "desc" },
+      });
+
+      return rows.map(toDomain);
+    } catch (error) {
+      throw wrapPersistenceError(error, "Unable to load darts match");
+    }
+  }
+
+  async listLockedByVenueCmsId(cmsId: CmsId): Promise<DartsMatch[]> {
+    try {
+      const rows = await this.prisma.dartsMatch.findMany({
+        where: {
+          status: "locked",
+          venueCmsId: cmsId.value,
+        },
+        include: { players: true, turns: true },
+        orderBy: { startsAt: "desc" },
+      });
+
+      return rows.map(toDomain);
+    } catch (error) {
+      throw wrapPersistenceError(error, "Unable to load darts match");
+    }
+  }
+}
+
+function toDomain(row: DartsMatchRow): DartsMatch {
+  const players = DartsPlayer.fromPlayers(
+    row.players.map((player) => ({
+      slot: player.slot,
+      userId: player.userId,
+      displayName: player.displayName,
+      isGuest: player.isGuest,
+    })),
+  );
+
+  return DartsMatch.rehydrate({
+    id: row.id,
+    venueCmsId: row.venueCmsId ? CmsId.from(row.venueCmsId) : null,
+    startsAt: StartsAt.from(row.startsAt),
+    startingScore: row.startingScore,
+    status: row.status as DartsMatchStatusValue,
+    players,
+    remainingBySlot: new Map(
+      row.players.map((player) => [player.slot, player.remaining]),
+    ),
+    turns: row.turns.map((turn) =>
+      DartsTurn.record({
+        turnNumber: turn.turnNumber,
+        playerSlot: turn.playerSlot,
+        score: turn.score,
+        bust: turn.bust,
+        checkout: turn.checkout,
+        remainingAfter: turn.remainingAfter,
+      }),
+    ),
+    winnerSlot: row.winnerSlot,
+    lockedAt: row.lockedAt,
+    lockedByUserId: row.lockedByUserId,
+  });
+}
+
+function isForeignKeyViolation(error: unknown): boolean {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === "P2003"
+  );
+}
+
+function wrapPersistenceError(error: unknown, message: string): Error {
+  if (error instanceof DartsMatchPersistenceError) {
+    return error;
+  }
+
+  return new DartsMatchPersistenceError(message, { cause: error });
+}

--- a/src/modules/darts/routes/darts-match.routes.ts
+++ b/src/modules/darts/routes/darts-match.routes.ts
@@ -1,0 +1,35 @@
+import { Router } from "express";
+
+import { createDartsMatchController } from "../controllers/darts-match.controller";
+
+export function createDartsMatchRoutes(
+  controller: ReturnType<typeof createDartsMatchController>,
+): Router {
+  const router = Router();
+
+  router.post("/api/darts", (req, res) => {
+    void controller.create(req, res);
+  });
+
+  router.post("/api/darts/capture", (req, res) => {
+    void controller.capture(req, res);
+  });
+
+  router.get("/api/darts", (req, res) => {
+    void controller.listByPlayer(req, res);
+  });
+
+  router.get("/api/darts/:id", (req, res) => {
+    void controller.getById(req, res);
+  });
+
+  router.post("/api/darts/:id/turns", (req, res) => {
+    void controller.submitTurn(req, res);
+  });
+
+  router.get("/api/venues/:cmsId/darts", (req, res) => {
+    void controller.listByVenue(req, res);
+  });
+
+  return router;
+}

--- a/src/modules/darts/services/capture-finished-darts-match.service.ts
+++ b/src/modules/darts/services/capture-finished-darts-match.service.ts
@@ -1,0 +1,49 @@
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { DartsMatch } from "../entities/darts-match";
+import { DartsMatchVenueNotFoundError } from "../entities/darts-match-venue-not-found-error";
+import { DartsPlayerInput } from "../entities/darts-player";
+import { DartsTurnInput } from "../entities/darts-turn";
+import { StartsAt } from "../entities/starts-at";
+import { DartsMatchRepository } from "../repositories/darts-match.repository";
+import { optionalVenueCmsId } from "../utils/optional-venue";
+
+export type CaptureFinishedDartsMatchInput = {
+  venueCmsId?: string | null;
+  startsAt: unknown;
+  players: DartsPlayerInput[];
+  turns?: DartsTurnInput[];
+  remaining?: unknown;
+  winnerSlot?: unknown;
+  winnerUserId?: unknown;
+  lockedByUserId: string;
+};
+
+export class CaptureFinishedDartsMatch {
+  constructor(
+    private readonly matches: DartsMatchRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async execute(input: CaptureFinishedDartsMatchInput): Promise<DartsMatch> {
+    const venueCmsId = optionalVenueCmsId(input.venueCmsId);
+    if (venueCmsId) {
+      const venue = await this.venues.findByCmsId(venueCmsId);
+      if (!venue) {
+        throw new DartsMatchVenueNotFoundError();
+      }
+    }
+
+    const match = DartsMatch.captureFinished({
+      venueCmsId,
+      startsAt: StartsAt.from(input.startsAt),
+      players: input.players,
+      turns: input.turns,
+      remaining: input.remaining,
+      winnerSlot: input.winnerSlot,
+      winnerUserId: input.winnerUserId,
+      lockedByUserId: input.lockedByUserId,
+    });
+
+    return this.matches.create(match);
+  }
+}

--- a/src/modules/darts/services/create-darts-match.service.test.ts
+++ b/src/modules/darts/services/create-darts-match.service.test.ts
@@ -1,0 +1,186 @@
+import { DomainError } from "../../../lib/domain-error";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { DartsMatchVenueNotFoundError } from "../entities/darts-match-venue-not-found-error";
+import { InMemoryDartsMatchRepository } from "../repositories/in-memory-darts-match.repository";
+import { CaptureFinishedDartsMatch } from "./capture-finished-darts-match.service";
+import { CreateDartsMatch } from "./create-darts-match.service";
+import {
+  ListLockedDartsMatchesByPlayer,
+  ListLockedDartsMatchesByVenue,
+} from "./list-locked-darts-matches.service";
+import { SubmitDartsTurn } from "./submit-darts-turn.service";
+
+const players = [
+  { slot: 1, displayName: "Alex", isGuest: false, userId: "user-alex" },
+  { slot: 2, displayName: "Sam", isGuest: true, userId: null },
+];
+
+async function seedVenue(venues: InMemoryVenueRepository) {
+  await venues.ensureFromCms(
+    Venue.registerFromCms(
+      CmsId.from("sanity-pub-1"),
+      VenueName.from("The Dartboard"),
+      Slug.from("the-dartboard"),
+    ),
+    { refreshDetails: false },
+  );
+}
+
+describe("darts application", () => {
+  test("create persists a live match with or without a venue", async () => {
+    const venues = new InMemoryVenueRepository();
+    const matches = new InMemoryDartsMatchRepository();
+    await seedVenue(venues);
+    const create = new CreateDartsMatch(matches, venues);
+
+    const atPub = await create.execute({
+      venueCmsId: "sanity-pub-1",
+      startsAt: "2026-09-07T18:00:00.000Z",
+      players,
+    });
+    const atHome = await create.execute({
+      venueCmsId: null,
+      startsAt: "2026-09-07T19:00:00.000Z",
+      players,
+    });
+
+    expect(atPub.toSnapshot().venueCmsId).toBe("sanity-pub-1");
+    expect(atHome.toSnapshot().venueCmsId).toBeNull();
+    expect((await matches.findById(atHome.id))?.status).toBe("live");
+  });
+
+  test("create fails when a provided venue cmsId is unknown", async () => {
+    const create = new CreateDartsMatch(
+      new InMemoryDartsMatchRepository(),
+      new InMemoryVenueRepository(),
+    );
+
+    await expect(
+      create.execute({
+        venueCmsId: "missing-pub",
+        startsAt: "2026-09-07T18:00:00.000Z",
+        players,
+      }),
+    ).rejects.toBeInstanceOf(DartsMatchVenueNotFoundError);
+  });
+
+  test("submitTurn persists busts and locks on checkout", async () => {
+    const venues = new InMemoryVenueRepository();
+    const matches = new InMemoryDartsMatchRepository();
+    const created = await new CreateDartsMatch(matches, venues).execute({
+      startsAt: "2026-09-07T18:00:00.000Z",
+      players,
+    });
+    const submit = new SubmitDartsTurn(matches);
+
+    await submit.execute({ matchId: created.id, playerSlot: 1, score: 180 });
+    await submit.execute({ matchId: created.id, playerSlot: 1, score: 180 });
+    const busted = await submit.execute({
+      matchId: created.id,
+      playerSlot: 1,
+      score: 140,
+    });
+    expect(busted?.remainingFor(1)).toBe(141);
+
+    await expect(
+      submit.execute({
+        matchId: created.id,
+        playerSlot: 1,
+        score: 40,
+        checkout: true,
+      }),
+    ).rejects.toBeInstanceOf(DomainError);
+
+    const finished = await submit.execute({
+      matchId: created.id,
+      playerSlot: 2,
+      score: 180,
+    });
+    expect(finished?.status).toBe("live");
+
+    await submit.execute({ matchId: created.id, playerSlot: 2, score: 180 });
+    await submit.execute({ matchId: created.id, playerSlot: 2, score: 101 });
+    const locked = await submit.execute({
+      matchId: created.id,
+      playerSlot: 2,
+      score: 40,
+      checkout: true,
+      lockedByUserId: "user-alex",
+    });
+
+    expect(locked?.status).toBe("locked");
+    expect(locked?.winnerSlot).toBe(2);
+    expect(locked?.lockedByUserId).toBe("user-alex");
+  });
+
+  test("captureFinished with turns lists immediately for the seated player", async () => {
+    const venues = new InMemoryVenueRepository();
+    const matches = new InMemoryDartsMatchRepository();
+    await seedVenue(venues);
+    const capture = new CaptureFinishedDartsMatch(matches, venues);
+
+    const match = await capture.execute({
+      venueCmsId: "sanity-pub-1",
+      startsAt: "2026-09-07T18:00:00.000Z",
+      players,
+      turns: [
+        { playerSlot: 1, score: 180 },
+        { playerSlot: 1, score: 180 },
+        { playerSlot: 1, score: 141, checkout: true },
+      ],
+      lockedByUserId: "user-alex",
+    });
+
+    expect(match.status).toBe("locked");
+    const history = await new ListLockedDartsMatchesByPlayer(
+      matches,
+      venues,
+    ).execute("user-alex");
+    expect(history).toEqual([
+      expect.objectContaining({
+        id: match.id,
+        venueCmsId: "sanity-pub-1",
+        venueName: "The Dartboard",
+        venueSlug: "the-dartboard",
+        winnerSlot: 1,
+      }),
+    ]);
+
+    const venueHistory = await new ListLockedDartsMatchesByVenue(
+      matches,
+      venues,
+    ).execute("sanity-pub-1");
+    expect(venueHistory.map((item) => item.id)).toEqual([match.id]);
+  });
+
+  test("player history includes home games with a null venue", async () => {
+    const venues = new InMemoryVenueRepository();
+    const matches = new InMemoryDartsMatchRepository();
+    const match = await new CaptureFinishedDartsMatch(matches, venues).execute({
+      venueCmsId: null,
+      startsAt: "2026-09-07T18:00:00.000Z",
+      players,
+      remaining: { "1": 0, "2": 220 },
+      winnerSlot: 1,
+      lockedByUserId: "user-alex",
+    });
+
+    const history = await new ListLockedDartsMatchesByPlayer(
+      matches,
+      venues,
+    ).execute("user-alex");
+    expect(history).toEqual([
+      expect.objectContaining({
+        id: match.id,
+        venueCmsId: null,
+        venueName: null,
+        venueSlug: null,
+        winnerSlot: 1,
+      }),
+    ]);
+  });
+});

--- a/src/modules/darts/services/create-darts-match.service.ts
+++ b/src/modules/darts/services/create-darts-match.service.ts
@@ -1,0 +1,38 @@
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { DartsMatch } from "../entities/darts-match";
+import { DartsMatchVenueNotFoundError } from "../entities/darts-match-venue-not-found-error";
+import { DartsPlayerInput } from "../entities/darts-player";
+import { StartsAt } from "../entities/starts-at";
+import { DartsMatchRepository } from "../repositories/darts-match.repository";
+import { optionalVenueCmsId } from "../utils/optional-venue";
+
+export type CreateDartsMatchInput = {
+  venueCmsId?: string | null;
+  startsAt: unknown;
+  players: DartsPlayerInput[];
+};
+
+export class CreateDartsMatch {
+  constructor(
+    private readonly matches: DartsMatchRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async execute(input: CreateDartsMatchInput): Promise<DartsMatch> {
+    const venueCmsId = optionalVenueCmsId(input.venueCmsId);
+    if (venueCmsId) {
+      const venue = await this.venues.findByCmsId(venueCmsId);
+      if (!venue) {
+        throw new DartsMatchVenueNotFoundError();
+      }
+    }
+
+    const match = DartsMatch.create({
+      venueCmsId,
+      startsAt: StartsAt.from(input.startsAt),
+      players: input.players,
+    });
+
+    return this.matches.create(match);
+  }
+}

--- a/src/modules/darts/services/darts-match-history-item.ts
+++ b/src/modules/darts/services/darts-match-history-item.ts
@@ -1,0 +1,36 @@
+import { DartsMatchSnapshot } from "../entities/darts-match";
+import { DartsPlayerSnapshot } from "../entities/darts-player";
+import { DartsTurnSnapshot } from "../entities/darts-turn";
+
+export type DartsMatchHistoryItem = {
+  id: string;
+  startsAt: string;
+  venueCmsId: string | null;
+  venueName: string | null;
+  venueSlug: string | null;
+  startingScore: number;
+  checkoutRule: DartsMatchSnapshot["checkoutRule"];
+  players: DartsPlayerSnapshot[];
+  turns: DartsTurnSnapshot[];
+  winnerSlot: number | null;
+  winnerUserId: string | null;
+};
+
+export function toHistoryItem(
+  snapshot: DartsMatchSnapshot,
+  venue: { name: string; slug: string } | null,
+): DartsMatchHistoryItem {
+  return {
+    id: snapshot.id,
+    startsAt: snapshot.startsAt,
+    venueCmsId: snapshot.venueCmsId,
+    venueName: venue?.name ?? null,
+    venueSlug: venue?.slug ?? null,
+    startingScore: snapshot.startingScore,
+    checkoutRule: snapshot.checkoutRule,
+    players: snapshot.players,
+    turns: snapshot.turns,
+    winnerSlot: snapshot.winnerSlot,
+    winnerUserId: snapshot.winnerUserId,
+  };
+}

--- a/src/modules/darts/services/get-darts-match-by-id.service.ts
+++ b/src/modules/darts/services/get-darts-match-by-id.service.ts
@@ -1,0 +1,9 @@
+import { DartsMatchRepository } from "../repositories/darts-match.repository";
+
+export class GetDartsMatchById {
+  constructor(private readonly matches: DartsMatchRepository) {}
+
+  async execute(id: string) {
+    return this.matches.findById(id);
+  }
+}

--- a/src/modules/darts/services/list-locked-darts-matches.service.ts
+++ b/src/modules/darts/services/list-locked-darts-matches.service.ts
@@ -1,0 +1,67 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { Venue } from "../../venue/entities/venue";
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { requiredTrimmed } from "../../../lib/domain-error";
+import { DartsMatchRepository } from "../repositories/darts-match.repository";
+import {
+  DartsMatchHistoryItem,
+  toHistoryItem,
+} from "./darts-match-history-item";
+
+export class ListLockedDartsMatchesByPlayer {
+  constructor(
+    private readonly matches: DartsMatchRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async execute(playerUserId: unknown): Promise<DartsMatchHistoryItem[]> {
+    const userId = requiredTrimmed(playerUserId, "playerUserId");
+    const matches = await this.matches.listLockedByPlayerUserId(userId);
+    const venuesByCmsId = await loadVenuesByCmsId(
+      this.venues,
+      matches
+        .map((match) => match.venueCmsId)
+        .filter((cmsId): cmsId is CmsId => cmsId !== null),
+    );
+
+    return matches.map((match) => {
+      const venue = match.venueCmsId
+        ? venuesByCmsId.get(match.venueCmsId.value)
+        : undefined;
+      return toHistoryItem(
+        match.toSnapshot(),
+        venue ? { name: venue.name.value, slug: venue.slug.value } : null,
+      );
+    });
+  }
+}
+
+export class ListLockedDartsMatchesByVenue {
+  constructor(
+    private readonly matches: DartsMatchRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async execute(venueCmsId: unknown): Promise<DartsMatchHistoryItem[]> {
+    const cmsId = CmsId.from(venueCmsId);
+    const venue = await this.venues.findByCmsId(cmsId);
+    const matches = await this.matches.listLockedByVenueCmsId(cmsId);
+    const venueDetails = venue
+      ? { name: venue.name.value, slug: venue.slug.value }
+      : null;
+
+    return matches.map((match) => toHistoryItem(match.toSnapshot(), venueDetails));
+  }
+}
+
+async function loadVenuesByCmsId(
+  venues: VenueRepository,
+  cmsIds: CmsId[],
+): Promise<Map<string, Venue>> {
+  const unique = [
+    ...new Map(cmsIds.map((cmsId) => [cmsId.value, cmsId])).values(),
+  ];
+  const found = unique.length === 0 ? [] : await venues.findByCmsIds(unique);
+
+  return new Map(found.map((venue) => [venue.cmsId.value, venue]));
+}

--- a/src/modules/darts/services/submit-darts-turn.service.ts
+++ b/src/modules/darts/services/submit-darts-turn.service.ts
@@ -1,0 +1,33 @@
+import { DartsMatch } from "../entities/darts-match";
+import { DartsMatchRepository } from "../repositories/darts-match.repository";
+
+export type SubmitDartsTurnServiceInput = {
+  matchId: string;
+  playerSlot?: unknown;
+  userId?: unknown;
+  score: unknown;
+  checkout?: unknown;
+  lockedByUserId?: string | null;
+};
+
+export class SubmitDartsTurn {
+  constructor(private readonly matches: DartsMatchRepository) {}
+
+  async execute(
+    input: SubmitDartsTurnServiceInput,
+  ): Promise<DartsMatch | null> {
+    const match = await this.matches.findById(input.matchId);
+    if (!match) {
+      return null;
+    }
+
+    match.submitTurn({
+      playerSlot: input.playerSlot,
+      userId: input.userId,
+      score: input.score,
+      checkout: input.checkout,
+      lockedByUserId: input.lockedByUserId,
+    });
+    return this.matches.persist(match);
+  }
+}

--- a/src/modules/darts/utils/bind-session-user.test.ts
+++ b/src/modules/darts/utils/bind-session-user.test.ts
@@ -1,0 +1,83 @@
+import {
+  bindSessionUserIdToPlayers,
+  sanitizePlayersForCreate,
+} from "./bind-session-user";
+
+const guest = (slot: number, displayName: string) => ({
+  slot,
+  displayName,
+  isGuest: true as const,
+  userId: null as string | null,
+});
+
+const named = (
+  slot: number,
+  displayName: string,
+  userId: string | null,
+  isGuest = false,
+) => ({
+  slot,
+  displayName,
+  isGuest,
+  userId,
+});
+
+describe("bindSessionUserIdToPlayers", () => {
+  test("assigns session userId to the first non-guest with a missing userId", () => {
+    const bound = bindSessionUserIdToPlayers(
+      [guest(1, "Alex"), named(2, "Riley", null)],
+      "user-riley",
+    );
+
+    expect(bound[1]).toEqual({
+      slot: 2,
+      displayName: "Riley",
+      isGuest: false,
+      userId: "user-riley",
+    });
+    expect(bound[0].userId).toBeNull();
+  });
+
+  test("does not overwrite a different account or force a guest slot", () => {
+    const players = [
+      named(1, "Alex", "user-alex"),
+      guest(2, "Sam"),
+    ];
+
+    expect(bindSessionUserIdToPlayers(players, "user-riley")).toEqual(players);
+  });
+});
+
+describe("sanitizePlayersForCreate", () => {
+  test("strips all userIds when there is no session", () => {
+    const sanitized = sanitizePlayersForCreate(
+      [named(1, "Alex", "user-alex"), named(2, "Riley", "user-riley")],
+      null,
+    );
+
+    expect(sanitized).toEqual([
+      { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+      { slot: 2, displayName: "Riley", isGuest: true, userId: null },
+    ]);
+  });
+
+  test("keeps only the session userId and binds an empty non-guest seat", () => {
+    const sanitized = sanitizePlayersForCreate(
+      [named(1, "Alex", "user-alex"), named(2, "Riley", null)],
+      "user-riley",
+    );
+
+    expect(sanitized[0]).toEqual({
+      slot: 1,
+      displayName: "Alex",
+      isGuest: true,
+      userId: null,
+    });
+    expect(sanitized[1]).toEqual({
+      slot: 2,
+      displayName: "Riley",
+      isGuest: false,
+      userId: "user-riley",
+    });
+  });
+});

--- a/src/modules/darts/utils/bind-session-user.ts
+++ b/src/modules/darts/utils/bind-session-user.ts
@@ -1,0 +1,82 @@
+import { DartsPlayerInput } from "../entities/darts-player";
+
+function normalizedUserId(userId: unknown): string | null {
+  if (typeof userId !== "string") {
+    return null;
+  }
+
+  const value = userId.trim();
+  return value.length === 0 ? null : value;
+}
+
+function withSessionUser(
+  player: DartsPlayerInput,
+  sessionUserId: string,
+): DartsPlayerInput {
+  return { ...player, userId: sessionUserId, isGuest: false };
+}
+
+function stripNonSessionUserIds(
+  players: DartsPlayerInput[],
+  sessionUserId: string | null,
+): DartsPlayerInput[] {
+  return players.map((player) => {
+    const id = normalizedUserId(player.userId);
+    if (sessionUserId && id === sessionUserId) {
+      return withSessionUser(player, sessionUserId);
+    }
+    if (id !== null) {
+      return {
+        ...player,
+        displayName: player.displayName,
+        isGuest: true,
+        userId: null,
+      };
+    }
+    return { ...player, userId: null };
+  });
+}
+
+export function bindSessionUserIdToPlayers(
+  players: DartsPlayerInput[],
+  sessionUserId: string,
+): DartsPlayerInput[] {
+  const bound = players.map((player) => ({ ...player }));
+
+  let alreadyBound = false;
+  for (let index = 0; index < bound.length; index++) {
+    const player = bound[index];
+    if (normalizedUserId(player.userId) === sessionUserId) {
+      bound[index] = withSessionUser(player, sessionUserId);
+      alreadyBound = true;
+    }
+  }
+
+  if (!alreadyBound) {
+    for (let index = 0; index < bound.length; index++) {
+      const player = bound[index];
+      if (player.isGuest === true) {
+        continue;
+      }
+      if (normalizedUserId(player.userId) !== null) {
+        continue;
+      }
+      bound[index] = withSessionUser(player, sessionUserId);
+      break;
+    }
+  }
+
+  return bound;
+}
+
+/** Sanitize create payload: only the session user may be stamped as a userId. */
+export function sanitizePlayersForCreate(
+  players: DartsPlayerInput[],
+  sessionUserId: string | null,
+): DartsPlayerInput[] {
+  const stripped = stripNonSessionUserIds(players, sessionUserId);
+  if (!sessionUserId) {
+    return stripped;
+  }
+  return bindSessionUserIdToPlayers(stripped, sessionUserId);
+}

--- a/src/modules/darts/utils/optional-venue.ts
+++ b/src/modules/darts/utils/optional-venue.ts
@@ -1,0 +1,11 @@
+import { CmsId } from "../../venue/entities/cms-id";
+
+export function optionalVenueCmsId(raw: unknown): CmsId | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+  if (typeof raw === "string" && raw.trim().length === 0) {
+    return null;
+  }
+  return CmsId.from(raw);
+}

--- a/src/modules/darts/utils/played-at.ts
+++ b/src/modules/darts/utils/played-at.ts
@@ -1,0 +1,12 @@
+export function resolvePlayedAt(body: {
+  startsAt?: string;
+  playedAt?: string;
+}): string | undefined {
+  const startsAt = typeof body.startsAt === "string" ? body.startsAt.trim() : "";
+  if (startsAt.length > 0) {
+    return startsAt;
+  }
+
+  const playedAt = typeof body.playedAt === "string" ? body.playedAt.trim() : "";
+  return playedAt.length > 0 ? playedAt : undefined;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #40. Draft — **do not merge** until reviewed. Frontend can integrate against this contract.

**Tests:** `yarn test` — 289 passed (including darts domain, services, and HTTP). `yarn tsc --noEmit` clean.

## Why `/api/darts`

Padel kept the original `/api/matches` collection. Golf is sport-prefixed (`/api/golf-rounds`). Darts follows that sport-prefixed pattern as `/api/darts` (not `/api/darts-matches`) so the live scorecard and capture URLs stay short.

## Migration

`20260907180000_darts_501_match`

Venue is **nullable** (`DartsMatch.venueCmsId` optional FK to `Venue.cmsId`). Pub/home games omit `venueCmsId`. If a cmsId is sent, that Venue row must already exist (404 otherwise).

## Product rules (v1)

- Game is always **501** / **double-out**. `startingScore` and `checkoutRule: "double_out"` are returned for the FE; they are not client-selectable.
- Single leg only. No 301, cricket, best-of, per-dart, organise-game, or GPS.
- Entry is a **visit total** (`score` integer 0–180), not per-dart.
- 2–8 seated players, slots `1`–`8`.
- Session cookie is the same `token` cookie as the rest of the API.
- Capture requires a signed-in **named seated** player (same sanitize/bind pattern as padel/golf).
- Live create may be anonymous. Foreign `userId`s are stripped to guests; only the session user may be stamped.
- There is **no** `POST /lock`. A legal checkout (`remaining − score === 0` and `checkout: true`) locks the match and sets the winner. Capture creates the match already locked.

### Bust / checkout

| Visit | Result |
| --- | --- |
| `score` not an integer in `0…180` | `400` |
| `score > remaining` | **bust** — turn stored, remaining unchanged |
| `remaining − score === 1` | **bust** — remaining `1` is never persisted |
| `remaining − score === 0` and `checkout !== true` | `400` `"checkout must be true to finish on 0"` |
| `remaining − score === 0` and `checkout: true` | checkout — remaining `0`, match **locked**, `winnerSlot` set |
| `checkout: true` on a bust or a non-finishing visit | `400` |
| Turn on a locked match | `409` |

The API does **not** validate that a finishing visit is a legal double-out combination (that needs per-darts). The FE asserts double-out and must send `checkout: true`. Turn order is **not** enforced; `nextSuggestedSlot` is a hint only (`slots[turnCount % playerCount]`).

Identify the thrower with `playerSlot` and/or `userId` (must match a seated named player).

## Routes

All JSON. Cookie: `token=<jwt>` when auth is required or when binding the session user on create/capture.

| Method | Path | Auth | Status | Purpose |
| --- | --- | --- | --- | --- |
| `POST` | `/api/darts` | optional | `201` | Create live match, remaining `501` |
| `POST` | `/api/darts/:id/turns` | optional | `200` | Submit a visit; checkout auto-locks |
| `GET` | `/api/darts/:id` | none | `200` / `404` | Live or locked snapshot |
| `POST` | `/api/darts/capture` | required seated named player | `201` | One-shot locked match + turn log |
| `GET` | `/api/darts?playerUserId=` | none | `200` | Locked history for that user |
| `GET` | `/api/venues/:cmsId/darts` | none | `200` | Locked history at that venue |

Errors: `400` invalid payload / domain rule, `401` capture without session, `403` capture when session user is not seated, `404` missing match or unknown venue cmsId, `409` locked conflict, `503` persistence.

### `POST /api/darts`

```json
{
  "venueCmsId": "sanity-pub-1",
  "startsAt": "2026-09-07T18:00:00.000Z",
  "players": [
    { "slot": 1, "displayName": "Alex", "isGuest": true, "userId": null },
    { "slot": 2, "displayName": "Riley", "isGuest": false, "userId": null }
  ]
}
```

`venueCmsId` may be omitted or `null` for a home/pub game. `startsAt` is required (ISO-8601).

### `POST /api/darts/:id/turns`

```json
{ "playerSlot": 1, "score": 60 }
```

```json
{ "userId": "user-riley", "score": 40, "checkout": true }
```

If a session cookie is present on a finishing checkout, `lockedByUserId` is attributed to that user.

### Snapshot (`201`/`200` create, get, turn, capture)

```json
{
  "id": "uuid",
  "venueCmsId": "sanity-pub-1",
  "startsAt": "2026-09-07T18:00:00.000Z",
  "startingScore": 501,
  "checkoutRule": "double_out",
  "status": "live",
  "players": [
    { "slot": 1, "userId": null, "displayName": "Alex", "isGuest": true, "remaining": 441 },
    { "slot": 2, "userId": "user-riley", "displayName": "Riley", "isGuest": false, "remaining": 501 }
  ],
  "turns": [
    { "turnNumber": 1, "playerSlot": 1, "score": 60, "bust": false, "checkout": false, "remainingAfter": 441 }
  ],
  "winnerSlot": null,
  "winnerUserId": null,
  "lockedAt": null,
  "nextSuggestedSlot": 2
}
```

Locked snapshot: `status: "locked"`, `winnerSlot` / `winnerUserId` set, `lockedAt` ISO, `nextSuggestedSlot: null`.

### `POST /api/darts/capture`

Requires session. Session user must remain a named seated player after sanitize.

**Preferred — replay a turn log:**

```json
{
  "venueCmsId": null,
  "playedAt": "2026-09-07T18:00:00.000Z",
  "players": [
    { "slot": 1, "displayName": "Alex", "isGuest": true, "userId": null },
    { "slot": 2, "displayName": "Riley", "isGuest": false, "userId": null }
  ],
  "turns": [
    { "playerSlot": 2, "score": 180 },
    { "playerSlot": 2, "score": 180 },
    { "playerSlot": 2, "score": 141, "checkout": true }
  ]
}
```

Turns are replayed with the same bust/checkout rules. The log must include a finishing checkout. Optional `winnerSlot` / `winnerUserId` / `remaining` must match the replay.

**Fallback — remaining + winner, empty turn log:**

```json
{
  "venueCmsId": "sanity-pub-1",
  "startsAt": "2026-09-07T18:00:00.000Z",
  "players": [
    { "slot": 1, "displayName": "Alex", "isGuest": true, "userId": null },
    { "slot": 2, "displayName": "Riley", "isGuest": false, "userId": null }
  ],
  "remaining": { "1": 220, "2": 0 },
  "winnerSlot": 2
}
```

Winner remaining must be `0`. No other player may be on `0`. Remaining `1` is rejected. `startsAt` or `playedAt` is required.

### History item (`GET /api/darts?playerUserId=` and `GET /api/venues/:cmsId/darts`)

```json
{
  "id": "uuid",
  "startsAt": "2026-09-07T18:00:00.000Z",
  "venueCmsId": "sanity-pub-1",
  "venueName": "The Dartboard",
  "venueSlug": "the-dartboard",
  "startingScore": 501,
  "checkoutRule": "double_out",
  "players": [],
  "turns": [],
  "winnerSlot": 2,
  "winnerUserId": "user-riley"
}
```

Home games: `venueCmsId`, `venueName`, and `venueSlug` are `null`. Live matches are omitted. Newest `startsAt` first.

## Domain

`src/modules/darts` mirrors padel `Match` / golf `GolfRound`: aggregate + VOs, in-memory + Prisma repos, create / capture / get / list / persist-turn services.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a0eba72-a4cf-4c2e-8681-4b54eef415b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a0eba72-a4cf-4c2e-8681-4b54eef415b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

