### PR TITLE
feat: Teams API v1 (CRUD, roster, invites)

### DIFF
--- a/prisma/migrations/20260907200000_team/migration.sql
+++ b/prisma/migrations/20260907200000_team/migration.sql
@@ -1,0 +1,75 @@
+-- CreateEnum
+CREATE TYPE "TeamSport" AS ENUM ('padel', 'golf', 'darts');
+
+-- CreateEnum
+CREATE TYPE "TeamMemberRole" AS ENUM ('owner', 'captain', 'member');
+
+-- CreateEnum
+CREATE TYPE "TeamMemberStatus" AS ENUM ('active', 'invited');
+
+-- CreateTable
+CREATE TABLE "Team" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "sport" "TeamSport" NOT NULL,
+    "homeVenueCmsId" TEXT,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Team_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TeamMembership" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "TeamMemberRole" NOT NULL DEFAULT 'member',
+    "status" "TeamMemberStatus" NOT NULL DEFAULT 'active',
+    "joinedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TeamMembership_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TeamInviteLink" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "token" VARCHAR(32) NOT NULL,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "TeamInviteLink_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Team_createdBy_idx" ON "Team"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "Team_createdAt_idx" ON "Team"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "TeamMembership_userId_idx" ON "TeamMembership"("userId");
+
+-- CreateIndex
+CREATE INDEX "TeamMembership_teamId_idx" ON "TeamMembership"("teamId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TeamMembership_teamId_userId_key" ON "TeamMembership"("teamId", "userId");
+
+-- Exactly one owner per team (role is owner regardless of status).
+CREATE UNIQUE INDEX "TeamMembership_one_owner_per_team" ON "TeamMembership"("teamId") WHERE "role" = 'owner';
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TeamInviteLink_token_key" ON "TeamInviteLink"("token");
+
+-- CreateIndex
+CREATE INDEX "TeamInviteLink_teamId_idx" ON "TeamInviteLink"("teamId");
+
+-- AddForeignKey
+ALTER TABLE "TeamMembership" ADD CONSTRAINT "TeamMembership_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamInviteLink" ADD CONSTRAINT "TeamInviteLink_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -367,6 +367,70 @@ model OrganisedGameInvite {
   @@index([gameId])
 }
 
+enum TeamSport {
+  padel
+  golf
+  darts
+}
+
+enum TeamMemberRole {
+  owner
+  captain
+  member
+}
+
+enum TeamMemberStatus {
+  active
+  invited
+}
+
+// Competitive squad (primary sport + roster). Not a Community.
+// No User FK — same as Friendship / CommunityMember. homeVenueCmsId is
+// optional and unused in UI v1; no Venue FK so teams can exist without
+// a registered venue.
+model Team {
+  id             String           @id @default(uuid())
+  name           String
+  sport          TeamSport
+  homeVenueCmsId String?
+  createdBy      String
+  createdAt      DateTime         @default(now())
+  updatedAt      DateTime         @updatedAt
+  members        TeamMembership[]
+  inviteLinks    TeamInviteLink[]
+
+  @@index([createdBy])
+  @@index([createdAt])
+}
+
+model TeamMembership {
+  id       String           @id @default(uuid())
+  teamId   String
+  userId   String
+  role     TeamMemberRole   @default(member)
+  status   TeamMemberStatus @default(active)
+  joinedAt DateTime         @default(now())
+
+  team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  @@unique([teamId, userId])
+  @@index([userId])
+  @@index([teamId])
+}
+
+model TeamInviteLink {
+  id        String    @id @default(uuid())
+  teamId    String
+  token     String    @unique @db.VarChar(32)
+  createdBy String
+  createdAt DateTime  @default(now())
+  revokedAt DateTime?
+
+  team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
+
+  @@index([teamId])
+}
+
 enum NotificationType {
   organised_game_invite
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -58,6 +58,10 @@ import {
   createNotificationsModule,
   NotificationRepository,
 } from "./modules/notifications";
+import {
+  createTeamsModule,
+  TeamRepository,
+} from "./modules/teams";
 
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
@@ -75,6 +79,7 @@ export type CreateAppDependencies = {
   poolRepository?: PoolRepository;
   organisedGameRepository?: OrganisedGameRepository;
   notificationRepository?: NotificationRepository;
+  teamRepository?: TeamRepository;
 };
 
 export async function createApp(
@@ -196,6 +201,14 @@ export async function createApp(
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
+  const teams = createTeamsModule({
+    prisma,
+    teamRepository: dependencies.teamRepository,
+    friendshipRepository: friends.friendshipRepository,
+    friendProfileLookup: friends.friendProfileLookup,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
@@ -211,6 +224,7 @@ export async function createApp(
   app.use(pools.router);
   app.use(notifications.router);
   app.use(organisedGames.router);
+  app.use(teams.router);
 
   app.use(
     (

--- a/src/modules/teams/controllers/teams.controller.ts
+++ b/src/modules/teams/controllers/teams.controller.ts
@@ -1,0 +1,356 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { TeamForbiddenError } from "../entities/team-forbidden-error";
+import { TeamInviteLinkNotFoundError } from "../entities/team-invite-link-not-found-error";
+import { TeamMembershipNotFoundError } from "../entities/team-membership-not-found-error";
+import { TeamNotFoundError } from "../entities/team-not-found-error";
+import { TeamNotFriendError } from "../entities/team-not-friend-error";
+import { TeamOwnerLeaveError } from "../entities/team-owner-leave-error";
+import { TeamPersistenceError } from "../entities/team-persistence-error";
+import {
+  CreateInviteLink,
+  CreateTeam,
+  DeleteTeam,
+  GetTeam,
+  InviteFriends,
+  JoinByToken,
+  LeaveTeam,
+  ListMyTeams,
+  RemoveMember,
+  TransferOwnership,
+  UpdateMemberRole,
+  UpdateTeam,
+} from "../services/teams.service";
+
+const createBodySchema = z.object({
+  name: z.string(),
+  sport: z.string(),
+  homeVenueCmsId: z.string().nullable().optional(),
+});
+
+const updateBodySchema = z
+  .object({
+    name: z.string().optional(),
+    sport: z.string().optional(),
+    homeVenueCmsId: z.string().nullable().optional(),
+  })
+  .refine(
+    (body) =>
+      body.name !== undefined ||
+      body.sport !== undefined ||
+      Object.prototype.hasOwnProperty.call(body, "homeVenueCmsId"),
+    { message: "At least one field is required" },
+  );
+
+const teamIdParamSchema = z.object({
+  id: z.string(),
+});
+
+const memberParamSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+});
+
+const inviteBodySchema = z.object({
+  userIds: z.array(z.string()),
+});
+
+const joinBodySchema = z.object({
+  token: z.string(),
+});
+
+const roleBodySchema = z.object({
+  role: z.string(),
+});
+
+const transferBodySchema = z.object({
+  userId: z.string(),
+});
+
+export function createTeamsController(deps: {
+  createTeam: CreateTeam;
+  getTeam: GetTeam;
+  listMyTeams: ListMyTeams;
+  updateTeam: UpdateTeam;
+  deleteTeam: DeleteTeam;
+  inviteFriends: InviteFriends;
+  createInviteLink: CreateInviteLink;
+  joinByToken: JoinByToken;
+  updateMemberRole: UpdateMemberRole;
+  removeMember: RemoveMember;
+  leaveTeam: LeaveTeam;
+  transferOwnership: TransferOwnership;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async create(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const body = z.parse(createBodySchema, req.body ?? {});
+        const result = await deps.createTeam.execute({
+          userId,
+          name: body.name,
+          sport: body.sport,
+          homeVenueCmsId: body.homeVenueCmsId,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+
+    async list(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const result = await deps.listMyTeams.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+
+    async get(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(teamIdParamSchema, req.params);
+        const result = await deps.getTeam.execute({ userId, teamId: id });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+
+    async update(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(teamIdParamSchema, req.params);
+        const body = z.parse(updateBodySchema, req.body ?? {});
+        const result = await deps.updateTeam.execute({
+          userId,
+          teamId: id,
+          name: body.name,
+          sport: body.sport,
+          homeVenueCmsId: body.homeVenueCmsId,
+          hasHomeVenueCmsId: Object.prototype.hasOwnProperty.call(
+            req.body ?? {},
+            "homeVenueCmsId",
+          ),
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+
+    async remove(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(teamIdParamSchema, req.params);
+        const result = await deps.deleteTeam.execute({ userId, teamId: id });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+
+    async invite(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(teamIdParamSchema, req.params);
+        const body = z.parse(inviteBodySchema, req.body ?? {});
+        const result = await deps.inviteFriends.execute({
+          userId,
+          teamId: id,
+          userIds: body.userIds,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+
+    async inviteLink(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(teamIdParamSchema, req.params);
+        const result = await deps.createInviteLink.execute({
+          userId,
+          teamId: id,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+
+    async join(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const body = z.parse(joinBodySchema, req.body ?? {});
+        const result = await deps.joinByToken.execute({
+          userId,
+          token: body.token,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+
+    async updateMember(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id, userId: memberUserId } = z.parse(
+          memberParamSchema,
+          req.params,
+        );
+        const body = z.parse(roleBodySchema, req.body ?? {});
+        const result = await deps.updateMemberRole.execute({
+          userId,
+          teamId: id,
+          memberUserId,
+          role: body.role,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+
+    async removeMember(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id, userId: memberUserId } = z.parse(
+          memberParamSchema,
+          req.params,
+        );
+        const result = await deps.removeMember.execute({
+          userId,
+          teamId: id,
+          memberUserId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+
+    async leave(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(teamIdParamSchema, req.params);
+        const result = await deps.leaveTeam.execute({ userId, teamId: id });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+
+    async transfer(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { id } = z.parse(teamIdParamSchema, req.params);
+        const body = z.parse(transferBodySchema, req.body ?? {});
+        const result = await deps.transferOwnership.execute({
+          userId,
+          teamId: id,
+          newOwnerUserId: body.userId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+  };
+}
+
+function sendTeamsError(res: Response, error: unknown) {
+  if (error instanceof TeamNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof TeamInviteLinkNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof TeamMembershipNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof TeamForbiddenError) {
+    return res.status(403).json({ error: error.message });
+  }
+
+  if (error instanceof TeamNotFriendError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof TeamOwnerLeaveError) {
+    return res.status(409).json({ error: error.message });
+  }
+
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid teams payload" });
+  }
+
+  if (error instanceof TeamPersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/teams/controllers/teams.http.test.ts
+++ b/src/modules/teams/controllers/teams.http.test.ts
@@ -1,0 +1,452 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { signAuthenticationToken } from "../../identity/utils/jwt";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { Team } from "../entities/team";
+import { TeamName } from "../entities/team-name";
+import { TeamSport } from "../entities/team-sport";
+import { InMemoryTeamRepository } from "../repositories/in-memory-team.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function becomeFriends(
+  friendships: InMemoryFriendshipRepository,
+  a: string,
+  b: string,
+) {
+  const pending = await friendships.createPending(a, b);
+  await friendships.accept(pending.id);
+}
+
+type PublicTeam = {
+  id: string;
+  name: string;
+  sport: string;
+  homeVenueCmsId: string | null;
+  memberCount: number;
+  myRole: string;
+  myStatus: string;
+  members: Array<{
+    id: string;
+    handle: string;
+    role: string;
+    status: string;
+  }>;
+  inviteLink: { token: string; createdAt: string } | null;
+};
+
+describe("teams HTTP", () => {
+  const config = makeConfig();
+  let teams: InMemoryTeamRepository;
+  let friendships: InMemoryFriendshipRepository;
+  let profiles: InMemoryFriendProfileLookup;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  function cookie(userId: string) {
+    return `token=${signAuthenticationToken(config, { userId })}`;
+  }
+
+  async function json(
+    path: string,
+    init: RequestInit & { userId?: string } = {},
+  ) {
+    const headers = new Headers(init.headers);
+    if (init.body && !headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+    if (init.userId) {
+      headers.set("Cookie", cookie(init.userId));
+    }
+    return fetch(`${server.url}${path}`, { ...init, headers });
+  }
+
+  beforeEach(async () => {
+    teams = new InMemoryTeamRepository();
+    friendships = new InMemoryFriendshipRepository();
+    profiles = new InMemoryFriendProfileLookup();
+
+    profiles.seed({
+      userId: "user-a",
+      displayName: "Alex",
+      handle: "alex",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-b",
+      displayName: "Blake",
+      handle: "blake",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-c",
+      displayName: "Casey",
+      handle: "casey",
+      avatarUrl: null,
+    });
+
+    await becomeFriends(friendships, "user-a", "user-b");
+
+    app = await createApp(config, {
+      venueRepository: new InMemoryVenueRepository(),
+      friendshipRepository: friendships,
+      friendProfileLookup: profiles,
+      teamRepository: teams,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("create requires auth and makes the caller the owner", async () => {
+    const unauth = await json("/api/teams", {
+      method: "POST",
+      body: JSON.stringify({ name: "Sunday Smash", sport: "padel" }),
+    });
+    expect(unauth.status).toBe(401);
+
+    const created = await json("/api/teams", {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({
+        name: "Sunday Smash",
+        sport: "padel",
+        homeVenueCmsId: "sanity-court-1",
+      }),
+    });
+    expect(created.status).toBe(201);
+    const body = (await created.json()) as { team: PublicTeam };
+    expect(body.team).toMatchObject({
+      name: "Sunday Smash",
+      sport: "padel",
+      homeVenueCmsId: "sanity-court-1",
+      memberCount: 1,
+      myRole: "owner",
+      myStatus: "active",
+    });
+    expect(body.team.members).toEqual([
+      expect.objectContaining({ handle: "alex", role: "owner", status: "active" }),
+    ]);
+  });
+
+  test("list mine + pending invites and get roster", async () => {
+    const created = await json("/api/teams", {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ name: "Active Side", sport: "golf" }),
+    });
+    const { team } = (await created.json()) as { team: PublicTeam };
+
+    const pending = Team.create({
+      name: TeamName.from("Pending Side"),
+      sport: TeamSport.from("darts"),
+      createdBy: "user-c",
+    });
+    const snapshot = pending.toSnapshot();
+    snapshot.members.push({
+      id: "invite-mem",
+      userId: "user-a",
+      role: "member",
+      status: "invited",
+      joinedAt: new Date().toISOString(),
+    });
+    await teams.create(Team.fromSnapshot(snapshot));
+
+    const listed = await json("/api/teams", { userId: "user-a" });
+    expect(listed.status).toBe(200);
+    expect(await listed.json()).toMatchObject({
+      teams: [expect.objectContaining({ id: team.id, myRole: "owner" })],
+      pendingInvites: [
+        expect.objectContaining({ name: "Pending Side", myStatus: "invited" }),
+      ],
+    });
+
+    const detail = await json(`/api/teams/${team.id}`, { userId: "user-a" });
+    expect(detail.status).toBe(200);
+    expect(await detail.json()).toMatchObject({
+      team: {
+        id: team.id,
+        members: [{ handle: "alex", role: "owner" }],
+      },
+    });
+
+    const stranger = await json(`/api/teams/${team.id}`, { userId: "user-c" });
+    expect(stranger.status).toBe(403);
+  });
+
+  test("friend invite direct-adds; strangers are rejected", async () => {
+    const created = await json("/api/teams", {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ name: "Squad", sport: "padel" }),
+    });
+    const { team } = (await created.json()) as { team: PublicTeam };
+
+    const stranger = await json(`/api/teams/${team.id}/invite`, {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ userIds: ["user-c"] }),
+    });
+    expect(stranger.status).toBe(400);
+    expect(await stranger.json()).toMatchObject({
+      error: "Can only invite an accepted friend",
+    });
+
+    const invited = await json(`/api/teams/${team.id}/invite`, {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ userIds: ["user-b"] }),
+    });
+    expect(invited.status).toBe(200);
+    const invitedBody = (await invited.json()) as { team: PublicTeam };
+    expect(invitedBody.team.memberCount).toBe(2);
+    expect(invitedBody.team.members).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          handle: "blake",
+          role: "member",
+          status: "active",
+        }),
+      ]),
+    );
+  });
+
+  test("invite link join adds an active member", async () => {
+    const created = await json("/api/teams", {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ name: "Open Squad", sport: "darts" }),
+    });
+    const { team } = (await created.json()) as { team: PublicTeam };
+
+    const linkRes = await json(`/api/teams/${team.id}/invite-link`, {
+      method: "POST",
+      userId: "user-a",
+    });
+    expect(linkRes.status).toBe(201);
+    const { inviteLink } = (await linkRes.json()) as {
+      inviteLink: { token: string };
+    };
+    expect(inviteLink.token).toHaveLength(32);
+
+    const joined = await json("/api/teams/join", {
+      method: "POST",
+      userId: "user-c",
+      body: JSON.stringify({ token: inviteLink.token }),
+    });
+    expect(joined.status).toBe(200);
+    expect(await joined.json()).toMatchObject({
+      team: {
+        id: team.id,
+        myRole: "member",
+        myStatus: "active",
+        memberCount: 2,
+      },
+    });
+
+    const stale = await json(`/api/teams/${team.id}/invite-link`, {
+      method: "POST",
+      userId: "user-a",
+    });
+    const next = (await stale.json()) as { inviteLink: { token: string } };
+    const rejected = await json("/api/teams/join", {
+      method: "POST",
+      userId: "user-b",
+      body: JSON.stringify({ token: inviteLink.token }),
+    });
+    expect(rejected.status).toBe(404);
+    const joinedNext = await json("/api/teams/join", {
+      method: "POST",
+      userId: "user-b",
+      body: JSON.stringify({ token: next.inviteLink.token }),
+    });
+    expect(joinedNext.status).toBe(200);
+  });
+
+  test("role updates, remove, leave, transfer, delete, and permission denials", async () => {
+    await becomeFriends(friendships, "user-a", "user-c");
+    const created = await json("/api/teams", {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ name: "Club", sport: "padel" }),
+    });
+    const { team } = (await created.json()) as { team: PublicTeam };
+
+    const memberPatch = await json(`/api/teams/${team.id}`, {
+      method: "PATCH",
+      userId: "user-b",
+      body: JSON.stringify({ name: "Hijack" }),
+    });
+    expect(memberPatch.status).toBe(403);
+
+    const patched = await json(`/api/teams/${team.id}`, {
+      method: "PATCH",
+      userId: "user-a",
+      body: JSON.stringify({ name: "Night Club", sport: "golf" }),
+    });
+    expect(patched.status).toBe(200);
+    expect(await patched.json()).toMatchObject({
+      team: { name: "Night Club", sport: "golf" },
+    });
+
+    await json(`/api/teams/${team.id}/invite`, {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ userIds: ["user-b", "user-c"] }),
+    });
+
+    const memberPromote = await json(`/api/teams/${team.id}/members/user-c`, {
+      method: "PATCH",
+      userId: "user-b",
+      body: JSON.stringify({ role: "captain" }),
+    });
+    expect(memberPromote.status).toBe(403);
+
+    const promote = await json(`/api/teams/${team.id}/members/user-b`, {
+      method: "PATCH",
+      userId: "user-a",
+      body: JSON.stringify({ role: "captain" }),
+    });
+    expect(promote.status).toBe(200);
+    expect(await promote.json()).toMatchObject({
+      team: {
+        members: expect.arrayContaining([
+          expect.objectContaining({ id: "user-b", role: "captain" }),
+        ]),
+      },
+    });
+
+    const demoteOwner = await json(`/api/teams/${team.id}/members/user-a`, {
+      method: "PATCH",
+      userId: "user-a",
+      body: JSON.stringify({ role: "member" }),
+    });
+    expect(demoteOwner.status).toBe(409);
+
+    const removeOwner = await json(`/api/teams/${team.id}/members/user-a`, {
+      method: "DELETE",
+      userId: "user-b",
+    });
+    expect(removeOwner.status).toBe(403);
+
+    const removed = await json(`/api/teams/${team.id}/members/user-c`, {
+      method: "DELETE",
+      userId: "user-b",
+    });
+    expect(removed.status).toBe(200);
+    const removedBody = (await removed.json()) as { team: PublicTeam };
+    expect(removedBody.team.members.map((member) => member.id)).not.toContain(
+      "user-c",
+    );
+
+    await json(`/api/teams/${team.id}/invite`, {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ userIds: ["user-c"] }),
+    });
+    const ownerLeave = await json(`/api/teams/${team.id}/leave`, {
+      method: "POST",
+      userId: "user-a",
+    });
+    expect(ownerLeave.status).toBe(409);
+
+    const left = await json(`/api/teams/${team.id}/leave`, {
+      method: "POST",
+      userId: "user-c",
+    });
+    expect(left.status).toBe(200);
+    expect(await left.json()).toEqual({ ok: true });
+
+    const memberDelete = await json(`/api/teams/${team.id}`, {
+      method: "DELETE",
+      userId: "user-b",
+    });
+    expect(memberDelete.status).toBe(403);
+
+    const transferred = await json(`/api/teams/${team.id}/transfer-ownership`, {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ userId: "user-b" }),
+    });
+    expect(transferred.status).toBe(200);
+    expect(await transferred.json()).toMatchObject({
+      team: {
+        myRole: "captain",
+        members: expect.arrayContaining([
+          expect.objectContaining({ id: "user-b", role: "owner" }),
+          expect.objectContaining({ id: "user-a", role: "captain" }),
+        ]),
+      },
+    });
+
+    const deleted = await json(`/api/teams/${team.id}`, {
+      method: "DELETE",
+      userId: "user-b",
+    });
+    expect(deleted.status).toBe(200);
+    expect(await deleted.json()).toEqual({ ok: true });
+
+    const missing = await json(`/api/teams/${team.id}`, { userId: "user-b" });
+    expect(missing.status).toBe(404);
+  });
+
+  test("unknown sport and empty invite payload are 400", async () => {
+    const badSport = await json("/api/teams", {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ name: "X", sport: "tennis" }),
+    });
+    expect(badSport.status).toBe(400);
+
+    const created = await json("/api/teams", {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ name: "X", sport: "padel" }),
+    });
+    const { team } = (await created.json()) as { team: PublicTeam };
+    const emptyInvite = await json(`/api/teams/${team.id}/invite`, {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ userIds: [] }),
+    });
+    expect(emptyInvite.status).toBe(400);
+  });
+});

--- a/src/modules/teams/entities/home-venue-cms-id.ts
+++ b/src/modules/teams/entities/home-venue-cms-id.ts
@@ -1,0 +1,27 @@
+import { DomainError } from "../../../lib/domain-error";
+
+const MAX_LENGTH = 120;
+
+export class HomeVenueCmsId {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): HomeVenueCmsId | null {
+    if (raw == null) return null;
+    if (typeof raw !== "string") {
+      throw new DomainError("homeVenueCmsId must be a string");
+    }
+
+    const value = raw.trim();
+    if (value.length === 0) return null;
+    if (value.length > MAX_LENGTH) {
+      throw new DomainError(
+        `homeVenueCmsId must be at most ${MAX_LENGTH} characters`,
+      );
+    }
+    return new HomeVenueCmsId(value);
+  }
+
+  equals(other: HomeVenueCmsId): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/teams/entities/team-forbidden-error.ts
+++ b/src/modules/teams/entities/team-forbidden-error.ts
@@ -1,0 +1,6 @@
+export class TeamForbiddenError extends Error {
+  constructor(message = "Not allowed for this team") {
+    super(message);
+    this.name = "TeamForbiddenError";
+  }
+}

--- a/src/modules/teams/entities/team-invite-link-not-found-error.ts
+++ b/src/modules/teams/entities/team-invite-link-not-found-error.ts
@@ -1,0 +1,6 @@
+export class TeamInviteLinkNotFoundError extends Error {
+  constructor(message = "Invite link not found") {
+    super(message);
+    this.name = "TeamInviteLinkNotFoundError";
+  }
+}

--- a/src/modules/teams/entities/team-invite-link.ts
+++ b/src/modules/teams/entities/team-invite-link.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from "node:crypto";
+
+import { requiredTrimmed } from "../../../lib/domain-error";
+import { TeamInviteToken } from "./team-invite-token";
+
+export type TeamInviteLinkSnapshot = {
+  id: string;
+  token: string;
+  createdBy: string;
+  createdAt: string;
+  revokedAt: string | null;
+};
+
+export class TeamInviteLink {
+  private constructor(
+    readonly id: string,
+    readonly token: TeamInviteToken,
+    readonly createdBy: string,
+    readonly createdAt: Date,
+    private revokedAtValue: Date | null,
+  ) {}
+
+  static create(createdBy: string, now = new Date()): TeamInviteLink {
+    return new TeamInviteLink(
+      randomUUID(),
+      TeamInviteToken.generate(),
+      requiredTrimmed(createdBy, "userId"),
+      now,
+      null,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    token: TeamInviteToken;
+    createdBy: string;
+    createdAt: Date;
+    revokedAt: Date | null;
+  }): TeamInviteLink {
+    return new TeamInviteLink(
+      props.id,
+      props.token,
+      props.createdBy,
+      props.createdAt,
+      props.revokedAt,
+    );
+  }
+
+  get revokedAt(): Date | null {
+    return this.revokedAtValue;
+  }
+
+  get isActive(): boolean {
+    return this.revokedAtValue == null;
+  }
+
+  revoke(now = new Date()): void {
+    if (this.revokedAtValue) return;
+    this.revokedAtValue = now;
+  }
+
+  toSnapshot(): TeamInviteLinkSnapshot {
+    return {
+      id: this.id,
+      token: this.token.value,
+      createdBy: this.createdBy,
+      createdAt: this.createdAt.toISOString(),
+      revokedAt: this.revokedAtValue?.toISOString() ?? null,
+    };
+  }
+}

--- a/src/modules/teams/entities/team-invite-token.ts
+++ b/src/modules/teams/entities/team-invite-token.ts
@@ -1,0 +1,31 @@
+import { randomBytes } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+export const TEAM_INVITE_TOKEN_LENGTH = 32;
+const TEAM_INVITE_TOKEN_PATTERN = /^[a-f0-9]+$/;
+
+export class TeamInviteToken {
+  private constructor(readonly value: string) {}
+
+  static generate(): TeamInviteToken {
+    return new TeamInviteToken(randomBytes(16).toString("hex"));
+  }
+
+  static from(raw: unknown): TeamInviteToken {
+    const value = requiredTrimmed(raw, "token").toLowerCase();
+    if (value.length !== TEAM_INVITE_TOKEN_LENGTH) {
+      throw new DomainError(
+        `token must be ${TEAM_INVITE_TOKEN_LENGTH} characters`,
+      );
+    }
+    if (!TEAM_INVITE_TOKEN_PATTERN.test(value)) {
+      throw new DomainError("token is invalid");
+    }
+    return new TeamInviteToken(value);
+  }
+
+  equals(other: TeamInviteToken): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/teams/entities/team-member-role.ts
+++ b/src/modules/teams/entities/team-member-role.ts
@@ -1,0 +1,46 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export type TeamMemberRoleValue = "owner" | "captain" | "member";
+
+export class TeamMemberRole {
+  static readonly OWNER = new TeamMemberRole("owner");
+  static readonly CAPTAIN = new TeamMemberRole("captain");
+  static readonly MEMBER = new TeamMemberRole("member");
+
+  private constructor(readonly value: TeamMemberRoleValue) {}
+
+  static from(raw: unknown): TeamMemberRole {
+    if (raw === "owner") return TeamMemberRole.OWNER;
+    if (raw === "captain") return TeamMemberRole.CAPTAIN;
+    if (raw === "member") return TeamMemberRole.MEMBER;
+    throw new DomainError("role must be owner, captain, or member");
+  }
+
+  get isOwner(): boolean {
+    return this.value === "owner";
+  }
+
+  get isCaptain(): boolean {
+    return this.value === "captain";
+  }
+
+  get isMember(): boolean {
+    return this.value === "member";
+  }
+
+  get canInvite(): boolean {
+    return this.isOwner || this.isCaptain;
+  }
+
+  get canRemoveMembers(): boolean {
+    return this.isOwner || this.isCaptain;
+  }
+
+  get canManageTeam(): boolean {
+    return this.isOwner;
+  }
+
+  equals(other: TeamMemberRole): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/teams/entities/team-member-status.ts
+++ b/src/modules/teams/entities/team-member-status.ts
@@ -1,0 +1,28 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export type TeamMemberStatusValue = "active" | "invited";
+
+export class TeamMemberStatus {
+  static readonly ACTIVE = new TeamMemberStatus("active");
+  static readonly INVITED = new TeamMemberStatus("invited");
+
+  private constructor(readonly value: TeamMemberStatusValue) {}
+
+  static from(raw: unknown): TeamMemberStatus {
+    if (raw === "active") return TeamMemberStatus.ACTIVE;
+    if (raw === "invited") return TeamMemberStatus.INVITED;
+    throw new DomainError("status must be active or invited");
+  }
+
+  get isActive(): boolean {
+    return this.value === "active";
+  }
+
+  get isInvited(): boolean {
+    return this.value === "invited";
+  }
+
+  equals(other: TeamMemberStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/teams/entities/team-membership-not-found-error.ts
+++ b/src/modules/teams/entities/team-membership-not-found-error.ts
@@ -1,0 +1,6 @@
+export class TeamMembershipNotFoundError extends Error {
+  constructor(message = "Team membership not found") {
+    super(message);
+    this.name = "TeamMembershipNotFoundError";
+  }
+}

--- a/src/modules/teams/entities/team-membership.ts
+++ b/src/modules/teams/entities/team-membership.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from "node:crypto";
+
+import { requiredTrimmed } from "../../../lib/domain-error";
+import { TeamMemberRole } from "./team-member-role";
+import { TeamMemberStatus } from "./team-member-status";
+
+export type TeamMembershipSnapshot = {
+  id: string;
+  userId: string;
+  role: "owner" | "captain" | "member";
+  status: "active" | "invited";
+  joinedAt: string;
+};
+
+export class TeamMembership {
+  private constructor(
+    readonly id: string,
+    readonly userId: string,
+    private roleValue: TeamMemberRole,
+    private statusValue: TeamMemberStatus,
+    readonly joinedAt: Date,
+  ) {}
+
+  static owner(userId: string, joinedAt = new Date()): TeamMembership {
+    return new TeamMembership(
+      randomUUID(),
+      requiredTrimmed(userId, "userId"),
+      TeamMemberRole.OWNER,
+      TeamMemberStatus.ACTIVE,
+      joinedAt,
+    );
+  }
+
+  static captain(userId: string, joinedAt = new Date()): TeamMembership {
+    return new TeamMembership(
+      randomUUID(),
+      requiredTrimmed(userId, "userId"),
+      TeamMemberRole.CAPTAIN,
+      TeamMemberStatus.ACTIVE,
+      joinedAt,
+    );
+  }
+
+  static member(
+    userId: string,
+    status: TeamMemberStatus = TeamMemberStatus.ACTIVE,
+    joinedAt = new Date(),
+  ): TeamMembership {
+    return new TeamMembership(
+      randomUUID(),
+      requiredTrimmed(userId, "userId"),
+      TeamMemberRole.MEMBER,
+      status,
+      joinedAt,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    userId: string;
+    role: TeamMemberRole;
+    status: TeamMemberStatus;
+    joinedAt: Date;
+  }): TeamMembership {
+    return new TeamMembership(
+      props.id,
+      props.userId,
+      props.role,
+      props.status,
+      props.joinedAt,
+    );
+  }
+
+  get role(): TeamMemberRole {
+    return this.roleValue;
+  }
+
+  get status(): TeamMemberStatus {
+    return this.statusValue;
+  }
+
+  assignRole(role: TeamMemberRole): void {
+    this.roleValue = role;
+  }
+
+  activate(): void {
+    this.statusValue = TeamMemberStatus.ACTIVE;
+  }
+
+  toSnapshot(): TeamMembershipSnapshot {
+    return {
+      id: this.id,
+      userId: this.userId,
+      role: this.roleValue.value,
+      status: this.statusValue.value,
+      joinedAt: this.joinedAt.toISOString(),
+    };
+  }
+}

--- a/src/modules/teams/entities/team-name.ts
+++ b/src/modules/teams/entities/team-name.ts
@@ -1,0 +1,19 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const MAX_LENGTH = 80;
+
+export class TeamName {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): TeamName {
+    const name = requiredTrimmed(raw, "name");
+    if (name.length > MAX_LENGTH) {
+      throw new DomainError(`name must be at most ${MAX_LENGTH} characters`);
+    }
+    return new TeamName(name);
+  }
+
+  equals(other: TeamName): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/teams/entities/team-not-found-error.ts
+++ b/src/modules/teams/entities/team-not-found-error.ts
@@ -1,0 +1,6 @@
+export class TeamNotFoundError extends Error {
+  constructor(message = "Team not found") {
+    super(message);
+    this.name = "TeamNotFoundError";
+  }
+}

--- a/src/modules/teams/entities/team-not-friend-error.ts
+++ b/src/modules/teams/entities/team-not-friend-error.ts
@@ -1,0 +1,6 @@
+export class TeamNotFriendError extends Error {
+  constructor(message = "Can only invite an accepted friend") {
+    super(message);
+    this.name = "TeamNotFriendError";
+  }
+}

--- a/src/modules/teams/entities/team-owner-leave-error.ts
+++ b/src/modules/teams/entities/team-owner-leave-error.ts
@@ -1,0 +1,10 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export class TeamOwnerLeaveError extends DomainError {
+  constructor(
+    message = "Owner must transfer ownership before leaving or changing role",
+  ) {
+    super(message);
+    this.name = "TeamOwnerLeaveError";
+  }
+}

--- a/src/modules/teams/entities/team-persistence-error.ts
+++ b/src/modules/teams/entities/team-persistence-error.ts
@@ -1,0 +1,6 @@
+export class TeamPersistenceError extends Error {
+  constructor(message = "Unable to save team", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "TeamPersistenceError";
+  }
+}

--- a/src/modules/teams/entities/team-sport.ts
+++ b/src/modules/teams/entities/team-sport.ts
@@ -1,0 +1,29 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const TEAM_SPORTS = ["padel", "golf", "darts"] as const;
+export type TeamSportValue = (typeof TEAM_SPORTS)[number];
+
+export class TeamSport {
+  static readonly PADEL = new TeamSport("padel");
+  static readonly GOLF = new TeamSport("golf");
+  static readonly DARTS = new TeamSport("darts");
+
+  private constructor(readonly value: TeamSportValue) {}
+
+  static from(raw: unknown): TeamSport {
+    if (typeof raw !== "string") {
+      throw new DomainError("sport must be padel, golf, or darts");
+    }
+
+    const sport = raw.trim().toLowerCase();
+    if (sport === "padel") return TeamSport.PADEL;
+    if (sport === "golf") return TeamSport.GOLF;
+    if (sport === "darts") return TeamSport.DARTS;
+
+    throw new DomainError("sport must be padel, golf, or darts");
+  }
+
+  equals(other: TeamSport): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/teams/entities/team.test.ts
+++ b/src/modules/teams/entities/team.test.ts
@@ -1,0 +1,247 @@
+import { DomainError } from "../../../lib/domain-error";
+import { HomeVenueCmsId } from "./home-venue-cms-id";
+import { Team } from "./team";
+import { TeamForbiddenError } from "./team-forbidden-error";
+import { TeamInviteLinkNotFoundError } from "./team-invite-link-not-found-error";
+import { TeamInviteToken } from "./team-invite-token";
+import { TeamMemberRole } from "./team-member-role";
+import { TeamMemberStatus } from "./team-member-status";
+import { TeamMembershipNotFoundError } from "./team-membership-not-found-error";
+import { TeamName } from "./team-name";
+import { TeamOwnerLeaveError } from "./team-owner-leave-error";
+import { TeamSport } from "./team-sport";
+
+function createSmash() {
+  return Team.create({
+    name: TeamName.from("  Sunday Smash  "),
+    sport: TeamSport.from("Padel"),
+    createdBy: "user-a",
+    homeVenueCmsId: HomeVenueCmsId.from("sanity-court-1"),
+  });
+}
+
+describe("team value objects", () => {
+  test("trims name and caps length", () => {
+    expect(TeamName.from("  Sunday Smash  ").value).toBe("Sunday Smash");
+    expect(() => TeamName.from("")).toThrow(DomainError);
+    expect(() => TeamName.from("x".repeat(81))).toThrow(DomainError);
+  });
+
+  test("sport is padel, golf, or darts", () => {
+    expect(TeamSport.from("Padel").value).toBe("padel");
+    expect(TeamSport.from("golf").value).toBe("golf");
+    expect(TeamSport.from("DARTS").value).toBe("darts");
+    expect(() => TeamSport.from("tennis")).toThrow(DomainError);
+  });
+
+  test("role and status are closed enums", () => {
+    expect(TeamMemberRole.from("owner").isOwner).toBe(true);
+    expect(TeamMemberRole.from("captain").canInvite).toBe(true);
+    expect(TeamMemberRole.from("member").canInvite).toBe(false);
+    expect(() => TeamMemberRole.from("admin")).toThrow(DomainError);
+    expect(TeamMemberStatus.from("active").isActive).toBe(true);
+    expect(TeamMemberStatus.from("invited").isInvited).toBe(true);
+    expect(() => TeamMemberStatus.from("pending")).toThrow(DomainError);
+  });
+
+  test("home venue cms id is optional", () => {
+    expect(HomeVenueCmsId.from(null)).toBeNull();
+    expect(HomeVenueCmsId.from("  ")).toBeNull();
+    expect(HomeVenueCmsId.from("venue-1")?.value).toBe("venue-1");
+  });
+});
+
+describe(Team, () => {
+  test("create mints exactly one owner membership", () => {
+    const team = createSmash();
+    const snapshot = team.toSnapshot();
+
+    expect(snapshot).toMatchObject({
+      name: "Sunday Smash",
+      sport: "padel",
+      homeVenueCmsId: "sanity-court-1",
+      createdBy: "user-a",
+    });
+    expect(snapshot.members).toHaveLength(1);
+    expect(snapshot.members[0]).toMatchObject({
+      userId: "user-a",
+      role: "owner",
+      status: "active",
+    });
+    expect(team.memberCount).toBe(1);
+    expect(team.owner().userId).toBe("user-a");
+  });
+
+  test("owner can edit name, sport, and home venue", () => {
+    const team = createSmash();
+    team.updateDetails("user-a", {
+      name: TeamName.from("Night Smash"),
+      sport: TeamSport.from("golf"),
+      homeVenueCmsId: null,
+    });
+
+    expect(team.toSnapshot()).toMatchObject({
+      name: "Night Smash",
+      sport: "golf",
+      homeVenueCmsId: null,
+    });
+  });
+
+  test("member cannot edit team details", () => {
+    const team = createSmash();
+    team.inviteFriend("user-a", "user-b");
+    expect(() =>
+      team.updateDetails("user-b", { name: TeamName.from("Nope") }),
+    ).toThrow(TeamForbiddenError);
+  });
+
+  test("friend invite direct-adds an active member and is idempotent", () => {
+    const team = createSmash();
+    team.inviteFriend("user-a", "user-b");
+    team.inviteFriend("user-a", "  user-b  ");
+
+    expect(team.memberCount).toBe(2);
+    expect(team.membershipOf("user-b")).toMatchObject({
+      role: TeamMemberRole.MEMBER,
+      status: TeamMemberStatus.ACTIVE,
+    });
+    expect(team.members.filter((member) => member.role.isOwner)).toHaveLength(1);
+  });
+
+  test("member cannot invite; cannot invite yourself", () => {
+    const team = createSmash();
+    team.inviteFriend("user-a", "user-b");
+
+    expect(() => team.inviteFriend("user-b", "user-c")).toThrow(
+      TeamForbiddenError,
+    );
+    expect(() => team.inviteFriend("user-a", "user-a")).toThrow(DomainError);
+  });
+
+  test("owner appoints and removes captains; cannot demote owner via role", () => {
+    const team = createSmash();
+    team.inviteFriend("user-a", "user-b");
+    team.updateMemberRole("user-a", "user-b", TeamMemberRole.CAPTAIN);
+    expect(team.membershipOf("user-b")?.role.isCaptain).toBe(true);
+
+    team.updateMemberRole("user-a", "user-b", TeamMemberRole.MEMBER);
+    expect(team.membershipOf("user-b")?.role.isMember).toBe(true);
+
+    expect(() =>
+      team.updateMemberRole("user-a", "user-a", TeamMemberRole.MEMBER),
+    ).toThrow(TeamOwnerLeaveError);
+    expect(() =>
+      team.updateMemberRole("user-a", "user-b", TeamMemberRole.OWNER),
+    ).toThrow(DomainError);
+  });
+
+  test("captain can invite and remove members but not the owner", () => {
+    const team = createSmash();
+    team.inviteFriend("user-a", "user-b");
+    team.updateMemberRole("user-a", "user-b", TeamMemberRole.CAPTAIN);
+    team.inviteFriend("user-b", "user-c");
+
+    expect(team.membershipOf("user-c")?.role.isMember).toBe(true);
+    team.removeMember("user-b", "user-c");
+    expect(team.membershipOf("user-c")).toBeNull();
+    expect(team.removedUserIds).toEqual(["user-c"]);
+
+    expect(() => team.removeMember("user-b", "user-a")).toThrow(
+      TeamForbiddenError,
+    );
+  });
+
+  test("captain cannot remove another captain", () => {
+    const team = createSmash();
+    team.inviteFriend("user-a", "user-b");
+    team.inviteFriend("user-a", "user-c");
+    team.updateMemberRole("user-a", "user-b", TeamMemberRole.CAPTAIN);
+    team.updateMemberRole("user-a", "user-c", TeamMemberRole.CAPTAIN);
+
+    expect(() => team.removeMember("user-b", "user-c")).toThrow(
+      TeamForbiddenError,
+    );
+  });
+
+  test("owner can remove a captain; cannot remove the owner", () => {
+    const team = createSmash();
+    team.inviteFriend("user-a", "user-b");
+    team.updateMemberRole("user-a", "user-b", TeamMemberRole.CAPTAIN);
+    team.removeMember("user-a", "user-b");
+    expect(team.membershipOf("user-b")).toBeNull();
+
+    team.inviteFriend("user-a", "user-c");
+    expect(() => team.removeMember("user-a", "user-a")).toThrow(DomainError);
+  });
+
+  test("member and captain can leave; owner must transfer first", () => {
+    const team = createSmash();
+    team.inviteFriend("user-a", "user-b");
+    team.inviteFriend("user-a", "user-c");
+    team.updateMemberRole("user-a", "user-b", TeamMemberRole.CAPTAIN);
+
+    team.leave("user-c");
+    expect(team.membershipOf("user-c")).toBeNull();
+    team.leave("user-b");
+    expect(team.membershipOf("user-b")).toBeNull();
+    expect(() => team.leave("user-a")).toThrow(TeamOwnerLeaveError);
+    expect(() => team.leave("user-z")).toThrow(TeamMembershipNotFoundError);
+  });
+
+  test("transfer ownership makes former owner a captain", () => {
+    const team = createSmash();
+    team.inviteFriend("user-a", "user-b");
+    team.transferOwnership("user-a", "user-b");
+
+    expect(team.membershipOf("user-b")?.role.isOwner).toBe(true);
+    expect(team.membershipOf("user-a")?.role.isCaptain).toBe(true);
+    expect(team.members.filter((member) => member.role.isOwner)).toHaveLength(1);
+
+    expect(() => team.transferOwnership("user-a", "user-b")).toThrow(
+      TeamForbiddenError,
+    );
+  });
+
+  test("invite link regenerate revokes the previous token", () => {
+    const team = createSmash();
+    const first = team.regenerateInviteLink("user-a");
+    const second = team.regenerateInviteLink("user-a");
+
+    expect(first.isActive).toBe(false);
+    expect(second.isActive).toBe(true);
+    expect(team.activeInviteLink()?.token.value).toBe(second.token.value);
+
+    expect(() =>
+      team.joinWithToken("user-b", TeamInviteToken.from(first.token.value)),
+    ).toThrow(TeamInviteLinkNotFoundError);
+
+    team.joinWithToken("user-b", TeamInviteToken.from(second.token.value));
+    expect(team.membershipOf("user-b")?.status.isActive).toBe(true);
+    team.joinWithToken("user-b", TeamInviteToken.from(second.token.value));
+    expect(team.memberCount).toBe(2);
+  });
+
+  test("member cannot create an invite link", () => {
+    const team = createSmash();
+    team.inviteFriend("user-a", "user-b");
+    expect(() => team.regenerateInviteLink("user-b")).toThrow(
+      TeamForbiddenError,
+    );
+  });
+
+  test("non-member cannot view the team", () => {
+    const team = createSmash();
+    expect(() => team.assertCanView("user-z")).toThrow(TeamForbiddenError);
+    team.assertCanView("user-a");
+  });
+
+  test("rehydrate + snapshot round-trips memberships and links", () => {
+    const created = createSmash();
+    created.inviteFriend("user-a", "user-b");
+    created.regenerateInviteLink("user-a");
+    const restored = Team.fromSnapshot(created.toSnapshot());
+
+    expect(restored.toSnapshot()).toEqual(created.toSnapshot());
+    expect(restored.removedUserIds).toEqual([]);
+  });
+});

--- a/src/modules/teams/entities/team.ts
+++ b/src/modules/teams/entities/team.ts
@@ -1,0 +1,432 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { HomeVenueCmsId } from "./home-venue-cms-id";
+import { TeamForbiddenError } from "./team-forbidden-error";
+import { TeamInviteLink } from "./team-invite-link";
+import { TeamInviteLinkNotFoundError } from "./team-invite-link-not-found-error";
+import { TeamInviteToken } from "./team-invite-token";
+import { TeamMemberRole } from "./team-member-role";
+import { TeamMemberStatus } from "./team-member-status";
+import { TeamMembership } from "./team-membership";
+import { TeamMembershipNotFoundError } from "./team-membership-not-found-error";
+import { TeamName } from "./team-name";
+import { TeamOwnerLeaveError } from "./team-owner-leave-error";
+import { TeamSport } from "./team-sport";
+
+export type TeamSnapshot = {
+  id: string;
+  name: string;
+  sport: "padel" | "golf" | "darts";
+  homeVenueCmsId: string | null;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+  members: ReturnType<TeamMembership["toSnapshot"]>[];
+  inviteLinks: ReturnType<TeamInviteLink["toSnapshot"]>[];
+};
+
+export type CreateTeamProps = {
+  name: TeamName;
+  sport: TeamSport;
+  createdBy: string;
+  homeVenueCmsId?: HomeVenueCmsId | null;
+};
+
+export type UpdateTeamDetailsProps = {
+  name?: TeamName;
+  sport?: TeamSport;
+  homeVenueCmsId?: HomeVenueCmsId | null;
+};
+
+const ROLE_RANK: Record<TeamMemberRole["value"], number> = {
+  owner: 0,
+  captain: 1,
+  member: 2,
+};
+
+export class Team {
+  private constructor(
+    readonly id: string,
+    private nameValue: TeamName,
+    private sportValue: TeamSport,
+    private homeVenueCmsIdValue: HomeVenueCmsId | null,
+    readonly createdBy: string,
+    readonly createdAt: Date,
+    private updatedAtValue: Date,
+    private membersValue: TeamMembership[],
+    private inviteLinksValue: TeamInviteLink[],
+    private removedUserIdsValue: string[],
+  ) {}
+
+  static create(props: CreateTeamProps): Team {
+    const createdBy = requiredTrimmed(props.createdBy, "userId");
+    const now = new Date();
+    return new Team(
+      randomUUID(),
+      props.name,
+      props.sport,
+      props.homeVenueCmsId ?? null,
+      createdBy,
+      now,
+      now,
+      [TeamMembership.owner(createdBy, now)],
+      [],
+      [],
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    name: TeamName;
+    sport: TeamSport;
+    homeVenueCmsId: HomeVenueCmsId | null;
+    createdBy: string;
+    createdAt: Date;
+    updatedAt: Date;
+    members: TeamMembership[];
+    inviteLinks: TeamInviteLink[];
+  }): Team {
+    const team = new Team(
+      props.id,
+      props.name,
+      props.sport,
+      props.homeVenueCmsId,
+      props.createdBy,
+      props.createdAt,
+      props.updatedAt,
+      [...props.members],
+      [...props.inviteLinks],
+      [],
+    );
+    team.assertExactlyOneOwner();
+    return team;
+  }
+
+  static fromSnapshot(snapshot: TeamSnapshot): Team {
+    return Team.rehydrate({
+      id: snapshot.id,
+      name: TeamName.from(snapshot.name),
+      sport: TeamSport.from(snapshot.sport),
+      homeVenueCmsId: HomeVenueCmsId.from(snapshot.homeVenueCmsId),
+      createdBy: snapshot.createdBy,
+      createdAt: new Date(snapshot.createdAt),
+      updatedAt: new Date(snapshot.updatedAt),
+      members: snapshot.members.map((member) =>
+        TeamMembership.rehydrate({
+          id: member.id,
+          userId: member.userId,
+          role: TeamMemberRole.from(member.role),
+          status: TeamMemberStatus.from(member.status),
+          joinedAt: new Date(member.joinedAt),
+        }),
+      ),
+      inviteLinks: snapshot.inviteLinks.map((link) =>
+        TeamInviteLink.rehydrate({
+          id: link.id,
+          token: TeamInviteToken.from(link.token),
+          createdBy: link.createdBy,
+          createdAt: new Date(link.createdAt),
+          revokedAt: link.revokedAt ? new Date(link.revokedAt) : null,
+        }),
+      ),
+    });
+  }
+
+  get name(): TeamName {
+    return this.nameValue;
+  }
+
+  get sport(): TeamSport {
+    return this.sportValue;
+  }
+
+  get homeVenueCmsId(): HomeVenueCmsId | null {
+    return this.homeVenueCmsIdValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  get members(): readonly TeamMembership[] {
+    return this.membersValue;
+  }
+
+  get inviteLinks(): readonly TeamInviteLink[] {
+    return this.inviteLinksValue;
+  }
+
+  get memberCount(): number {
+    return this.membersValue.filter((member) => member.status.isActive).length;
+  }
+
+  /** User ids removed since this instance was created or rehydrated. */
+  get removedUserIds(): readonly string[] {
+    return this.removedUserIdsValue;
+  }
+
+  membershipOf(userId: string): TeamMembership | null {
+    const id = userId.trim();
+    return this.membersValue.find((member) => member.userId === id) ?? null;
+  }
+
+  isMember(userId: string): boolean {
+    return this.membershipOf(userId) != null;
+  }
+
+  isActiveMember(userId: string): boolean {
+    return this.membershipOf(userId)?.status.isActive === true;
+  }
+
+  owner(): TeamMembership {
+    const owner = this.membersValue.find((member) => member.role.isOwner);
+    if (!owner) {
+      throw new DomainError("Team is missing an owner");
+    }
+    return owner;
+  }
+
+  activeInviteLink(): TeamInviteLink | null {
+    return (
+      [...this.inviteLinksValue]
+        .filter((link) => link.isActive)
+        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0] ??
+      null
+    );
+  }
+
+  assertCanView(userId: string): void {
+    if (!this.isMember(userId)) {
+      throw new TeamForbiddenError("Only a team member can view this team");
+    }
+  }
+
+  assertOwner(userId: string): TeamMembership {
+    const membership = this.membershipOf(userId);
+    if (!membership?.role.isOwner || !membership.status.isActive) {
+      throw new TeamForbiddenError("Only the team owner can do that");
+    }
+    return membership;
+  }
+
+  updateDetails(actorId: string, details: UpdateTeamDetailsProps): void {
+    this.assertOwner(actorId);
+    if (
+      details.name == null &&
+      details.sport == null &&
+      !("homeVenueCmsId" in details)
+    ) {
+      throw new DomainError("At least one field is required");
+    }
+
+    if (details.name) this.nameValue = details.name;
+    if (details.sport) this.sportValue = details.sport;
+    if ("homeVenueCmsId" in details) {
+      this.homeVenueCmsIdValue = details.homeVenueCmsId ?? null;
+    }
+    this.touch();
+  }
+
+  /**
+   * Direct-add an accepted friend as an active member.
+   * Friendship is verified by the application service before this call.
+   */
+  inviteFriend(actorId: string, userId: string, now = new Date()): void {
+    const actor = this.requireActiveStaff(actorId);
+    const id = requiredTrimmed(userId, "userId");
+    if (id === actor.userId) {
+      throw new DomainError("Cannot invite yourself");
+    }
+
+    const existing = this.membershipOf(id);
+    if (existing) {
+      if (existing.status.isInvited) existing.activate();
+      this.touch(now);
+      return;
+    }
+
+    this.removedUserIdsValue = this.removedUserIdsValue.filter(
+      (removed) => removed !== id,
+    );
+    this.membersValue = [
+      ...this.membersValue,
+      TeamMembership.member(id, TeamMemberStatus.ACTIVE, now),
+    ];
+    this.assertExactlyOneOwner();
+    this.touch(now);
+  }
+
+  joinAsMember(userId: string, now = new Date()): void {
+    const id = requiredTrimmed(userId, "userId");
+    const existing = this.membershipOf(id);
+    if (existing) {
+      if (existing.status.isInvited) existing.activate();
+      this.touch(now);
+      return;
+    }
+
+    this.removedUserIdsValue = this.removedUserIdsValue.filter(
+      (removed) => removed !== id,
+    );
+    this.membersValue = [
+      ...this.membersValue,
+      TeamMembership.member(id, TeamMemberStatus.ACTIVE, now),
+    ];
+    this.assertExactlyOneOwner();
+    this.touch(now);
+  }
+
+  joinWithToken(userId: string, token: TeamInviteToken, now = new Date()): void {
+    const link = this.inviteLinksValue.find(
+      (item) => item.token.equals(token) && item.isActive,
+    );
+    if (!link) {
+      throw new TeamInviteLinkNotFoundError();
+    }
+    this.joinAsMember(userId, now);
+  }
+
+  regenerateInviteLink(actorId: string, now = new Date()): TeamInviteLink {
+    this.requireActiveStaff(actorId);
+    for (const link of this.inviteLinksValue) {
+      link.revoke(now);
+    }
+    const created = TeamInviteLink.create(actorId, now);
+    this.inviteLinksValue = [...this.inviteLinksValue, created];
+    this.touch(now);
+    return created;
+  }
+
+  updateMemberRole(
+    actorId: string,
+    userId: string,
+    role: TeamMemberRole,
+  ): void {
+    this.assertOwner(actorId);
+    if (role.isOwner) {
+      throw new DomainError("Use transfer ownership to appoint a new owner");
+    }
+
+    const target = this.requireMembership(userId);
+    if (!target.status.isActive) {
+      throw new TeamForbiddenError("Only an active member can change role");
+    }
+    if (target.role.isOwner) {
+      throw new TeamOwnerLeaveError();
+    }
+
+    target.assignRole(role);
+    this.assertExactlyOneOwner();
+    this.touch();
+  }
+
+  removeMember(actorId: string, userId: string): void {
+    const actor = this.requireActiveStaff(actorId);
+    const id = requiredTrimmed(userId, "userId");
+    if (id === actor.userId) {
+      throw new DomainError("Use leave to remove yourself");
+    }
+
+    const target = this.requireMembership(id);
+    if (target.role.isOwner) {
+      throw new TeamForbiddenError("Cannot remove the team owner");
+    }
+    if (actor.role.isCaptain && !target.role.isMember) {
+      throw new TeamForbiddenError("Captain can only remove members");
+    }
+
+    this.dropMembership(id);
+    this.assertExactlyOneOwner();
+    this.touch();
+  }
+
+  leave(actorId: string): void {
+    const membership = this.requireMembership(actorId);
+    if (membership.role.isOwner) {
+      throw new TeamOwnerLeaveError();
+    }
+    this.dropMembership(membership.userId);
+    this.assertExactlyOneOwner();
+    this.touch();
+  }
+
+  transferOwnership(actorId: string, newOwnerUserId: string): void {
+    const actor = this.assertOwner(actorId);
+    const targetId = requiredTrimmed(newOwnerUserId, "userId");
+    if (targetId === actor.userId) {
+      throw new DomainError("Already the team owner");
+    }
+
+    const target = this.requireMembership(targetId);
+    if (!target.status.isActive) {
+      throw new TeamForbiddenError("Can only transfer ownership to an active member");
+    }
+
+    actor.assignRole(TeamMemberRole.CAPTAIN);
+    target.assignRole(TeamMemberRole.OWNER);
+    target.activate();
+    this.assertExactlyOneOwner();
+    this.touch();
+  }
+
+  assertCanDelete(actorId: string): void {
+    this.assertOwner(actorId);
+  }
+
+  toSnapshot(): TeamSnapshot {
+    const members = [...this.membersValue].sort((a, b) => {
+      const rank = ROLE_RANK[a.role.value] - ROLE_RANK[b.role.value];
+      if (rank !== 0) return rank;
+      return a.joinedAt.getTime() - b.joinedAt.getTime();
+    });
+
+    return {
+      id: this.id,
+      name: this.nameValue.value,
+      sport: this.sportValue.value,
+      homeVenueCmsId: this.homeVenueCmsIdValue?.value ?? null,
+      createdBy: this.createdBy,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+      members: members.map((member) => member.toSnapshot()),
+      inviteLinks: this.inviteLinksValue.map((link) => link.toSnapshot()),
+    };
+  }
+
+  private requireMembership(userId: string): TeamMembership {
+    const membership = this.membershipOf(userId);
+    if (!membership) {
+      throw new TeamMembershipNotFoundError();
+    }
+    return membership;
+  }
+
+  private requireActiveStaff(userId: string): TeamMembership {
+    const membership = this.membershipOf(userId);
+    if (!membership?.status.isActive || !membership.role.canInvite) {
+      throw new TeamForbiddenError("Only an owner or captain can do that");
+    }
+    return membership;
+  }
+
+  private dropMembership(userId: string): void {
+    this.membersValue = this.membersValue.filter(
+      (member) => member.userId !== userId,
+    );
+    if (!this.removedUserIdsValue.includes(userId)) {
+      this.removedUserIdsValue = [...this.removedUserIdsValue, userId];
+    }
+  }
+
+  private assertExactlyOneOwner(): void {
+    const owners = this.membersValue.filter((member) => member.role.isOwner);
+    if (owners.length !== 1) {
+      throw new DomainError("Team must have exactly one owner");
+    }
+  }
+
+  private touch(now = new Date()): void {
+    this.updatedAtValue = now;
+  }
+}

--- a/src/modules/teams/index.ts
+++ b/src/modules/teams/index.ts
@@ -1,0 +1,125 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import {
+  FriendProfileLookup,
+  FriendshipRepository,
+} from "../friends/repositories/friendship.repository";
+import { createTeamsController } from "./controllers/teams.controller";
+import { PrismaTeamRepository } from "./repositories/prisma-team.repository";
+import { TeamRepository } from "./repositories/team.repository";
+import { createTeamsRoutes } from "./routes/teams.routes";
+import {
+  CreateInviteLink,
+  CreateTeam,
+  DeleteTeam,
+  GetTeam,
+  InviteFriends,
+  JoinByToken,
+  LeaveTeam,
+  ListMyTeams,
+  RemoveMember,
+  TransferOwnership,
+  UpdateMemberRole,
+  UpdateTeam,
+} from "./services/teams.service";
+
+export type CreateTeamsModuleParams = {
+  prisma: PrismaClient;
+  teamRepository?: TeamRepository;
+  friendshipRepository: FriendshipRepository;
+  friendProfileLookup: FriendProfileLookup;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type TeamsModule = {
+  router: Router;
+  teamRepository: TeamRepository;
+};
+
+export function createTeamsModule({
+  prisma,
+  teamRepository: teamRepositoryOverride,
+  friendshipRepository,
+  friendProfileLookup,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreateTeamsModuleParams): TeamsModule {
+  const teamRepository =
+    teamRepositoryOverride ?? new PrismaTeamRepository(prisma);
+
+  const controller = createTeamsController({
+    createTeam: new CreateTeam(teamRepository, friendProfileLookup),
+    getTeam: new GetTeam(teamRepository, friendProfileLookup),
+    listMyTeams: new ListMyTeams(teamRepository),
+    updateTeam: new UpdateTeam(teamRepository, friendProfileLookup),
+    deleteTeam: new DeleteTeam(teamRepository),
+    inviteFriends: new InviteFriends(
+      teamRepository,
+      friendshipRepository,
+      friendProfileLookup,
+    ),
+    createInviteLink: new CreateInviteLink(teamRepository),
+    joinByToken: new JoinByToken(teamRepository, friendProfileLookup),
+    updateMemberRole: new UpdateMemberRole(teamRepository, friendProfileLookup),
+    removeMember: new RemoveMember(teamRepository, friendProfileLookup),
+    leaveTeam: new LeaveTeam(teamRepository),
+    transferOwnership: new TransferOwnership(
+      teamRepository,
+      friendProfileLookup,
+    ),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createTeamsRoutes(controller, { requireAuth }),
+    teamRepository,
+  };
+}
+
+export { createTeamsController } from "./controllers/teams.controller";
+export { InMemoryTeamRepository } from "./repositories/in-memory-team.repository";
+export { PrismaTeamRepository } from "./repositories/prisma-team.repository";
+export type { TeamRepository } from "./repositories/team.repository";
+export { Team } from "./entities/team";
+export { TeamName } from "./entities/team-name";
+export { TeamSport, TEAM_SPORTS } from "./entities/team-sport";
+export { TeamMemberRole } from "./entities/team-member-role";
+export { TeamMemberStatus } from "./entities/team-member-status";
+export { TeamMembership } from "./entities/team-membership";
+export { TeamInviteLink } from "./entities/team-invite-link";
+export { TeamInviteToken } from "./entities/team-invite-token";
+export { HomeVenueCmsId } from "./entities/home-venue-cms-id";
+export { TeamPersistenceError } from "./entities/team-persistence-error";
+export { TeamMembershipNotFoundError } from "./entities/team-membership-not-found-error";
+export { TeamNotFoundError } from "./entities/team-not-found-error";
+export { TeamForbiddenError } from "./entities/team-forbidden-error";
+export { TeamNotFriendError } from "./entities/team-not-friend-error";
+export { TeamOwnerLeaveError } from "./entities/team-owner-leave-error";
+export { TeamInviteLinkNotFoundError } from "./entities/team-invite-link-not-found-error";
+export {
+  CreateInviteLink,
+  CreateTeam,
+  DeleteTeam,
+  GetTeam,
+  InviteFriends,
+  JoinByToken,
+  LeaveTeam,
+  ListMyTeams,
+  RemoveMember,
+  TransferOwnership,
+  UpdateMemberRole,
+  UpdateTeam,
+} from "./services/teams.service";
+export type {
+  PublicInviteLink,
+  PublicTeam,
+  PublicTeamMember,
+  PublicTeamSummary,
+} from "./services/teams.service";

--- a/src/modules/teams/repositories/in-memory-team.repository.ts
+++ b/src/modules/teams/repositories/in-memory-team.repository.ts
@@ -1,0 +1,57 @@
+import { Team } from "../entities/team";
+import { TeamPersistenceError } from "../entities/team-persistence-error";
+import { TeamRepository } from "./team.repository";
+
+export class InMemoryTeamRepository implements TeamRepository {
+  private readonly byId = new Map<string, Team>();
+
+  async findById(id: string): Promise<Team | null> {
+    return clone(this.byId.get(id) ?? null);
+  }
+
+  async findByInviteToken(token: string): Promise<Team | null> {
+    const value = token.trim().toLowerCase();
+    for (const team of this.byId.values()) {
+      const link = team.activeInviteLink();
+      if (link?.token.value === value) {
+        return clone(team)!;
+      }
+    }
+    return null;
+  }
+
+  async create(team: Team): Promise<Team> {
+    const stored = clone(team)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async persist(team: Team): Promise<Team> {
+    if (!this.byId.has(team.id)) {
+      throw new TeamPersistenceError("Unable to save team");
+    }
+    const stored = clone(team)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async delete(id: string): Promise<void> {
+    this.byId.delete(id);
+  }
+
+  async listForUser(userId: string): Promise<Team[]> {
+    return [...this.byId.values()]
+      .filter((team) => team.membershipOf(userId))
+      .sort((a, b) => {
+        const aJoined = a.membershipOf(userId)?.joinedAt.getTime() ?? 0;
+        const bJoined = b.membershipOf(userId)?.joinedAt.getTime() ?? 0;
+        return bJoined - aJoined;
+      })
+      .map((team) => clone(team)!);
+  }
+}
+
+function clone(team: Team | null): Team | null {
+  if (!team) return null;
+  return Team.fromSnapshot(team.toSnapshot());
+}

--- a/src/modules/teams/repositories/prisma-team.repository.ts
+++ b/src/modules/teams/repositories/prisma-team.repository.ts
@@ -1,0 +1,264 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { HomeVenueCmsId } from "../entities/home-venue-cms-id";
+import { Team } from "../entities/team";
+import { TeamInviteLink } from "../entities/team-invite-link";
+import { TeamInviteToken } from "../entities/team-invite-token";
+import { TeamMemberRole } from "../entities/team-member-role";
+import { TeamMemberStatus } from "../entities/team-member-status";
+import { TeamMembership } from "../entities/team-membership";
+import { TeamName } from "../entities/team-name";
+import { TeamPersistenceError } from "../entities/team-persistence-error";
+import { TeamSport } from "../entities/team-sport";
+import { TeamRepository } from "./team.repository";
+
+type MemberRow = {
+  id: string;
+  userId: string;
+  role: "owner" | "captain" | "member";
+  status: "active" | "invited";
+  joinedAt: Date;
+};
+
+type InviteLinkRow = {
+  id: string;
+  token: string;
+  createdBy: string;
+  createdAt: Date;
+  revokedAt: Date | null;
+};
+
+type TeamRow = {
+  id: string;
+  name: string;
+  sport: "padel" | "golf" | "darts";
+  homeVenueCmsId: string | null;
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+  members: MemberRow[];
+  inviteLinks: InviteLinkRow[];
+};
+
+function prismaErrorCode(error: unknown): string {
+  if (error && typeof error === "object" && "code" in error) {
+    return String((error as { code?: unknown }).code);
+  }
+  return "";
+}
+
+function toDomain(row: TeamRow): Team {
+  return Team.rehydrate({
+    id: row.id,
+    name: TeamName.from(row.name),
+    sport: TeamSport.from(row.sport),
+    homeVenueCmsId: HomeVenueCmsId.from(row.homeVenueCmsId),
+    createdBy: row.createdBy,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    members: row.members.map((member) =>
+      TeamMembership.rehydrate({
+        id: member.id,
+        userId: member.userId,
+        role: TeamMemberRole.from(member.role),
+        status: TeamMemberStatus.from(member.status),
+        joinedAt: member.joinedAt,
+      }),
+    ),
+    inviteLinks: row.inviteLinks.map((link) =>
+      TeamInviteLink.rehydrate({
+        id: link.id,
+        token: TeamInviteToken.from(link.token),
+        createdBy: link.createdBy,
+        createdAt: link.createdAt,
+        revokedAt: link.revokedAt,
+      }),
+    ),
+  });
+}
+
+const includeRelations = {
+  members: { orderBy: { joinedAt: "asc" as const } },
+  inviteLinks: { orderBy: { createdAt: "asc" as const } },
+};
+
+export class PrismaTeamRepository implements TeamRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(id: string): Promise<Team | null> {
+    try {
+      const row = await this.prisma.team.findUnique({
+        where: { id },
+        include: includeRelations,
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new TeamPersistenceError("Failed to load team", { cause: error });
+    }
+  }
+
+  async findByInviteToken(token: string): Promise<Team | null> {
+    try {
+      const row = await this.prisma.team.findFirst({
+        where: {
+          inviteLinks: {
+            some: {
+              token: token.trim().toLowerCase(),
+              revokedAt: null,
+            },
+          },
+        },
+        include: includeRelations,
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new TeamPersistenceError("Failed to load team", { cause: error });
+    }
+  }
+
+  async create(team: Team): Promise<Team> {
+    const snapshot = team.toSnapshot();
+    try {
+      const row = await this.prisma.team.create({
+        data: {
+          id: snapshot.id,
+          name: snapshot.name,
+          sport: snapshot.sport,
+          homeVenueCmsId: snapshot.homeVenueCmsId,
+          createdBy: snapshot.createdBy,
+          createdAt: team.createdAt,
+          updatedAt: team.updatedAt,
+          members: {
+            create: snapshot.members.map((member) => ({
+              id: member.id,
+              userId: member.userId,
+              role: member.role,
+              status: member.status,
+              joinedAt: new Date(member.joinedAt),
+            })),
+          },
+          inviteLinks: {
+            create: snapshot.inviteLinks.map((link) => ({
+              id: link.id,
+              token: link.token,
+              createdBy: link.createdBy,
+              createdAt: new Date(link.createdAt),
+              revokedAt: link.revokedAt ? new Date(link.revokedAt) : null,
+            })),
+          },
+        },
+        include: includeRelations,
+      });
+      return toDomain(row);
+    } catch (error) {
+      throw new TeamPersistenceError("Failed to create team", { cause: error });
+    }
+  }
+
+  async persist(team: Team): Promise<Team> {
+    const snapshot = team.toSnapshot();
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.team.update({
+          where: { id: snapshot.id },
+          data: {
+            name: snapshot.name,
+            sport: snapshot.sport,
+            homeVenueCmsId: snapshot.homeVenueCmsId,
+            updatedAt: team.updatedAt,
+          },
+        });
+
+        for (const member of snapshot.members) {
+          try {
+            await tx.teamMembership.upsert({
+              where: {
+                teamId_userId: {
+                  teamId: snapshot.id,
+                  userId: member.userId,
+                },
+              },
+              create: {
+                id: member.id,
+                teamId: snapshot.id,
+                userId: member.userId,
+                role: member.role,
+                status: member.status,
+                joinedAt: new Date(member.joinedAt),
+              },
+              update: {
+                role: member.role,
+                status: member.status,
+              },
+            });
+          } catch (error) {
+            if (prismaErrorCode(error) !== "P2002") throw error;
+          }
+        }
+
+        if (team.removedUserIds.length > 0) {
+          await tx.teamMembership.deleteMany({
+            where: {
+              teamId: snapshot.id,
+              userId: { in: [...team.removedUserIds] },
+            },
+          });
+        }
+
+        for (const link of snapshot.inviteLinks) {
+          await tx.teamInviteLink.upsert({
+            where: { id: link.id },
+            create: {
+              id: link.id,
+              teamId: snapshot.id,
+              token: link.token,
+              createdBy: link.createdBy,
+              createdAt: new Date(link.createdAt),
+              revokedAt: link.revokedAt ? new Date(link.revokedAt) : null,
+            },
+            update: {
+              revokedAt: link.revokedAt ? new Date(link.revokedAt) : null,
+            },
+          });
+        }
+      });
+
+      const reloaded = await this.findById(snapshot.id);
+      if (!reloaded) {
+        throw new TeamPersistenceError("Failed to load team");
+      }
+      return reloaded;
+    } catch (error) {
+      if (error instanceof TeamPersistenceError) throw error;
+      throw new TeamPersistenceError("Failed to save team", { cause: error });
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      await this.prisma.team.delete({ where: { id } });
+    } catch (error) {
+      if (prismaErrorCode(error) === "P2025") return;
+      throw new TeamPersistenceError("Failed to delete team", { cause: error });
+    }
+  }
+
+  async listForUser(userId: string): Promise<Team[]> {
+    try {
+      const rows = await this.prisma.team.findMany({
+        where: { members: { some: { userId } } },
+        include: includeRelations,
+      });
+      return rows
+        .map(toDomain)
+        .sort((a, b) => {
+          const aJoined = a.membershipOf(userId)?.joinedAt.getTime() ?? 0;
+          const bJoined = b.membershipOf(userId)?.joinedAt.getTime() ?? 0;
+          return bJoined - aJoined;
+        });
+    } catch (error) {
+      throw new TeamPersistenceError("Failed to list user teams", {
+        cause: error,
+      });
+    }
+  }
+}

--- a/src/modules/teams/repositories/team.repository.ts
+++ b/src/modules/teams/repositories/team.repository.ts
@@ -1,0 +1,10 @@
+import { Team } from "../entities/team";
+
+export interface TeamRepository {
+  findById(id: string): Promise<Team | null>;
+  findByInviteToken(token: string): Promise<Team | null>;
+  create(team: Team): Promise<Team>;
+  persist(team: Team): Promise<Team>;
+  delete(id: string): Promise<void>;
+  listForUser(userId: string): Promise<Team[]>;
+}

--- a/src/modules/teams/routes/teams.routes.ts
+++ b/src/modules/teams/routes/teams.routes.ts
@@ -1,0 +1,78 @@
+import { Router } from "express";
+
+import { createTeamsController } from "../controllers/teams.controller";
+
+export function createTeamsRoutes(
+  controller: ReturnType<typeof createTeamsController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.post("/api/teams", options.requireAuth, (req, res) => {
+    void controller.create(req, res);
+  });
+
+  router.get("/api/teams", options.requireAuth, (req, res) => {
+    void controller.list(req, res);
+  });
+
+  router.post("/api/teams/join", options.requireAuth, (req, res) => {
+    void controller.join(req, res);
+  });
+
+  router.get("/api/teams/:id", options.requireAuth, (req, res) => {
+    void controller.get(req, res);
+  });
+
+  router.patch("/api/teams/:id", options.requireAuth, (req, res) => {
+    void controller.update(req, res);
+  });
+
+  router.delete("/api/teams/:id", options.requireAuth, (req, res) => {
+    void controller.remove(req, res);
+  });
+
+  router.post("/api/teams/:id/invite", options.requireAuth, (req, res) => {
+    void controller.invite(req, res);
+  });
+
+  router.post("/api/teams/:id/invite-link", options.requireAuth, (req, res) => {
+    void controller.inviteLink(req, res);
+  });
+
+  router.patch(
+    "/api/teams/:id/members/:userId",
+    options.requireAuth,
+    (req, res) => {
+      void controller.updateMember(req, res);
+    },
+  );
+
+  router.delete(
+    "/api/teams/:id/members/:userId",
+    options.requireAuth,
+    (req, res) => {
+      void controller.removeMember(req, res);
+    },
+  );
+
+  router.post("/api/teams/:id/leave", options.requireAuth, (req, res) => {
+    void controller.leave(req, res);
+  });
+
+  router.post(
+    "/api/teams/:id/transfer-ownership",
+    options.requireAuth,
+    (req, res) => {
+      void controller.transfer(req, res);
+    },
+  );
+
+  return router;
+}

--- a/src/modules/teams/services/teams.service.test.ts
+++ b/src/modules/teams/services/teams.service.test.ts
@@ -1,0 +1,298 @@
+import { DomainError } from "../../../lib/domain-error";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { Team } from "../entities/team";
+import { TeamName } from "../entities/team-name";
+import { TeamNotFriendError } from "../entities/team-not-friend-error";
+import { TeamSport } from "../entities/team-sport";
+import { InMemoryTeamRepository } from "../repositories/in-memory-team.repository";
+import {
+  CreateInviteLink,
+  CreateTeam,
+  DeleteTeam,
+  GetTeam,
+  InviteFriends,
+  JoinByToken,
+  LeaveTeam,
+  ListMyTeams,
+  RemoveMember,
+  TransferOwnership,
+  UpdateMemberRole,
+  UpdateTeam,
+} from "./teams.service";
+
+async function becomeFriends(
+  friendships: InMemoryFriendshipRepository,
+  a: string,
+  b: string,
+) {
+  const pending = await friendships.createPending(a, b);
+  await friendships.accept(pending.id);
+}
+
+function setup() {
+  const teams = new InMemoryTeamRepository();
+  const friendships = new InMemoryFriendshipRepository();
+  const profiles = new InMemoryFriendProfileLookup();
+  profiles.seed({
+    userId: "user-a",
+    displayName: "Alex",
+    handle: "alex",
+    avatarUrl: null,
+  });
+  profiles.seed({
+    userId: "user-b",
+    displayName: "Blake",
+    handle: "blake",
+    avatarUrl: null,
+  });
+  profiles.seed({
+    userId: "user-c",
+    displayName: "Casey",
+    handle: "casey",
+    avatarUrl: null,
+  });
+  return {
+    teams,
+    friendships,
+    profiles,
+    create: new CreateTeam(teams, profiles),
+    get: new GetTeam(teams, profiles),
+    list: new ListMyTeams(teams),
+    update: new UpdateTeam(teams, profiles),
+    remove: new DeleteTeam(teams),
+    invite: new InviteFriends(teams, friendships, profiles),
+    inviteLink: new CreateInviteLink(teams),
+    join: new JoinByToken(teams, profiles),
+    updateRole: new UpdateMemberRole(teams, profiles),
+    removeMember: new RemoveMember(teams, profiles),
+    leave: new LeaveTeam(teams),
+    transfer: new TransferOwnership(teams, profiles),
+  };
+}
+
+describe("teams services", () => {
+  test("create makes the session user the sole owner", async () => {
+    const { create } = setup();
+    const result = await create.execute({
+      userId: "user-a",
+      name: "  Sunday Smash  ",
+      sport: "Padel",
+    });
+
+    expect(result.team).toMatchObject({
+      name: "Sunday Smash",
+      sport: "padel",
+      memberCount: 1,
+      myRole: "owner",
+      myStatus: "active",
+      createdBy: "user-a",
+    });
+    expect(result.team.members).toEqual([
+      expect.objectContaining({
+        id: "user-a",
+        handle: "alex",
+        role: "owner",
+        status: "active",
+      }),
+    ]);
+  });
+
+  test("list splits active memberships from pending invites", async () => {
+    const ctx = setup();
+    const created = await ctx.create.execute({
+      userId: "user-a",
+      name: "Active Side",
+      sport: "golf",
+    });
+    await becomeFriends(ctx.friendships, "user-a", "user-b");
+    await ctx.invite.execute({
+      userId: "user-a",
+      teamId: created.team.id,
+      userIds: ["user-b"],
+    });
+
+    const inviteTeam = Team.create({
+      name: TeamName.from("Pending Side"),
+      sport: TeamSport.from("darts"),
+      createdBy: "user-c",
+    });
+    const snapshot = inviteTeam.toSnapshot();
+    snapshot.members.push({
+      id: "invite-mem",
+      userId: "user-a",
+      role: "member",
+      status: "invited",
+      joinedAt: new Date().toISOString(),
+    });
+    await ctx.teams.create(Team.fromSnapshot(snapshot));
+
+    const listed = await ctx.list.execute({ userId: "user-a" });
+    expect(listed.teams.map((team) => team.name)).toContain("Active Side");
+    expect(listed.pendingInvites.map((team) => team.name)).toEqual([
+      "Pending Side",
+    ]);
+    expect(listed.pendingInvites[0]?.myStatus).toBe("invited");
+  });
+
+  test("invite requires an accepted friendship and direct-adds", async () => {
+    const ctx = setup();
+    const created = await ctx.create.execute({
+      userId: "user-a",
+      name: "Squad",
+      sport: "padel",
+    });
+
+    await expect(
+      ctx.invite.execute({
+        userId: "user-a",
+        teamId: created.team.id,
+        userIds: ["user-b"],
+      }),
+    ).rejects.toBeInstanceOf(TeamNotFriendError);
+
+    const pending = await ctx.friendships.createPending("user-a", "user-b");
+    await expect(
+      ctx.invite.execute({
+        userId: "user-a",
+        teamId: created.team.id,
+        userIds: ["user-b"],
+      }),
+    ).rejects.toBeInstanceOf(TeamNotFriendError);
+
+    await ctx.friendships.accept(pending.id);
+    const invited = await ctx.invite.execute({
+      userId: "user-a",
+      teamId: created.team.id,
+      userIds: ["user-b"],
+    });
+    expect(invited.team.members).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "user-b",
+          role: "member",
+          status: "active",
+        }),
+      ]),
+    );
+  });
+
+  test("join via invite token adds an active member", async () => {
+    const ctx = setup();
+    const created = await ctx.create.execute({
+      userId: "user-a",
+      name: "Open Squad",
+      sport: "darts",
+    });
+    const link = await ctx.inviteLink.execute({
+      userId: "user-a",
+      teamId: created.team.id,
+    });
+    const joined = await ctx.join.execute({
+      userId: "user-c",
+      token: link.inviteLink.token,
+    });
+    expect(joined.team.myRole).toBe("member");
+    expect(joined.team.memberCount).toBe(2);
+  });
+
+  test("update, roles, remove, leave, transfer, and delete", async () => {
+    const ctx = setup();
+    await becomeFriends(ctx.friendships, "user-a", "user-b");
+    await becomeFriends(ctx.friendships, "user-a", "user-c");
+    const created = await ctx.create.execute({
+      userId: "user-a",
+      name: "Club",
+      sport: "padel",
+    });
+    const teamId = created.team.id;
+
+    const updated = await ctx.update.execute({
+      userId: "user-a",
+      teamId,
+      name: "Night Club",
+      sport: "golf",
+      hasHomeVenueCmsId: true,
+      homeVenueCmsId: "venue-9",
+    });
+    expect(updated.team).toMatchObject({
+      name: "Night Club",
+      sport: "golf",
+      homeVenueCmsId: "venue-9",
+    });
+
+    await ctx.invite.execute({
+      userId: "user-a",
+      teamId,
+      userIds: ["user-b", "user-c"],
+    });
+    const captained = await ctx.updateRole.execute({
+      userId: "user-a",
+      teamId,
+      memberUserId: "user-b",
+      role: "captain",
+    });
+    expect(
+      captained.team.members.find((member) => member.id === "user-b")?.role,
+    ).toBe("captain");
+
+    const removed = await ctx.removeMember.execute({
+      userId: "user-b",
+      teamId,
+      memberUserId: "user-c",
+    });
+    expect(removed.team.members.map((member) => member.id)).not.toContain(
+      "user-c",
+    );
+
+    await ctx.invite.execute({
+      userId: "user-a",
+      teamId,
+      userIds: ["user-c"],
+    });
+    await ctx.leave.execute({ userId: "user-c", teamId });
+
+    const transferred = await ctx.transfer.execute({
+      userId: "user-a",
+      teamId,
+      newOwnerUserId: "user-b",
+    });
+    expect(transferred.team.myRole).toBe("captain");
+    expect(
+      transferred.team.members.find((member) => member.id === "user-b")?.role,
+    ).toBe("owner");
+
+    await expect(
+      ctx.remove.execute({ userId: "user-a", teamId }),
+    ).rejects.toBeInstanceOf(Error);
+
+    await ctx.remove.execute({ userId: "user-b", teamId });
+    await expect(ctx.get.execute({ userId: "user-b", teamId })).rejects.toThrow(
+      "Team not found",
+    );
+  });
+
+  test("rejects empty invite list and unknown sport", async () => {
+    const ctx = setup();
+    await expect(
+      ctx.create.execute({
+        userId: "user-a",
+        name: "X",
+        sport: "tennis",
+      }),
+    ).rejects.toBeInstanceOf(DomainError);
+
+    const created = await ctx.create.execute({
+      userId: "user-a",
+      name: "X",
+      sport: "padel",
+    });
+    await expect(
+      ctx.invite.execute({
+        userId: "user-a",
+        teamId: created.team.id,
+        userIds: [],
+      }),
+    ).rejects.toBeInstanceOf(DomainError);
+  });
+});

--- a/src/modules/teams/services/teams.service.ts
+++ b/src/modules/teams/services/teams.service.ts
@@ -1,0 +1,419 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import {
+  FriendProfile,
+  FriendProfileLookup,
+  FriendshipRepository,
+} from "../../friends/repositories/friendship.repository";
+import { HomeVenueCmsId } from "../entities/home-venue-cms-id";
+import { Team } from "../entities/team";
+import { TeamInviteLinkNotFoundError } from "../entities/team-invite-link-not-found-error";
+import { TeamInviteToken } from "../entities/team-invite-token";
+import { TeamMemberRole } from "../entities/team-member-role";
+import { TeamName } from "../entities/team-name";
+import { TeamNotFoundError } from "../entities/team-not-found-error";
+import { TeamNotFriendError } from "../entities/team-not-friend-error";
+import { TeamSport } from "../entities/team-sport";
+import { TeamRepository } from "../repositories/team.repository";
+
+export type PublicTeamMember = {
+  id: string;
+  displayName: string;
+  handle: string;
+  avatarUrl: string | null;
+  role: "owner" | "captain" | "member";
+  status: "active" | "invited";
+  joinedAt: string;
+};
+
+export type PublicInviteLink = {
+  token: string;
+  createdAt: string;
+};
+
+export type PublicTeamSummary = {
+  id: string;
+  name: string;
+  sport: "padel" | "golf" | "darts";
+  homeVenueCmsId: string | null;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+  memberCount: number;
+  myRole: "owner" | "captain" | "member";
+  myStatus: "active" | "invited";
+};
+
+export type PublicTeam = PublicTeamSummary & {
+  members: PublicTeamMember[];
+  inviteLink: PublicInviteLink | null;
+};
+
+async function requireAcceptedFriend(
+  friendships: FriendshipRepository,
+  actorId: string,
+  otherUserId: string,
+): Promise<void> {
+  const existing = await friendships.findBetween(actorId, otherUserId);
+  if (!existing || existing.status !== "accepted") {
+    throw new TeamNotFriendError();
+  }
+}
+
+function parseUserIds(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    throw new DomainError("userIds is required");
+  }
+  const ids: string[] = [];
+  for (const item of raw) {
+    const id = requiredTrimmed(item, "userId");
+    if (!ids.includes(id)) ids.push(id);
+  }
+  return ids;
+}
+
+async function resolveProfile(
+  lookup: FriendProfileLookup,
+  userId: string,
+): Promise<FriendProfile> {
+  const profile = await lookup.findByUserId(userId);
+  if (profile) return profile;
+  return {
+    userId,
+    displayName: "Player",
+    handle: userId.slice(0, 8),
+    avatarUrl: null,
+  };
+}
+
+function toPublicSummary(team: Team, userId: string): PublicTeamSummary {
+  const snapshot = team.toSnapshot();
+  const membership = team.membershipOf(userId);
+  return {
+    id: snapshot.id,
+    name: snapshot.name,
+    sport: snapshot.sport,
+    homeVenueCmsId: snapshot.homeVenueCmsId,
+    createdBy: snapshot.createdBy,
+    createdAt: snapshot.createdAt,
+    updatedAt: snapshot.updatedAt,
+    memberCount: team.memberCount,
+    myRole: membership?.role.value ?? "member",
+    myStatus: membership?.status.value ?? "active",
+  };
+}
+
+async function toPublicMembers(
+  lookup: FriendProfileLookup,
+  team: Team,
+): Promise<PublicTeamMember[]> {
+  const out: PublicTeamMember[] = [];
+  for (const member of team.toSnapshot().members) {
+    const profile = await resolveProfile(lookup, member.userId);
+    out.push({
+      id: profile.userId,
+      displayName: profile.displayName,
+      handle: profile.handle,
+      avatarUrl: profile.avatarUrl,
+      role: member.role,
+      status: member.status,
+      joinedAt: member.joinedAt,
+    });
+  }
+  return out;
+}
+
+function publicInviteLink(team: Team, userId: string): PublicInviteLink | null {
+  const membership = team.membershipOf(userId);
+  if (!membership?.role.canInvite || !membership.status.isActive) {
+    return null;
+  }
+  const link = team.activeInviteLink();
+  if (!link) return null;
+  return { token: link.token.value, createdAt: link.createdAt.toISOString() };
+}
+
+async function toPublicTeam(
+  lookup: FriendProfileLookup,
+  team: Team,
+  userId: string,
+): Promise<PublicTeam> {
+  return {
+    ...toPublicSummary(team, userId),
+    members: await toPublicMembers(lookup, team),
+    inviteLink: publicInviteLink(team, userId),
+  };
+}
+
+async function loadTeam(teams: TeamRepository, teamId: string): Promise<Team> {
+  const id = requiredTrimmed(teamId, "team id");
+  const team = await teams.findById(id);
+  if (!team) throw new TeamNotFoundError();
+  return team;
+}
+
+export class CreateTeam {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    name: unknown;
+    sport: unknown;
+    homeVenueCmsId?: unknown;
+  }): Promise<{ team: PublicTeam }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const team = Team.create({
+      name: TeamName.from(input.name),
+      sport: TeamSport.from(input.sport),
+      createdBy: userId,
+      homeVenueCmsId: HomeVenueCmsId.from(input.homeVenueCmsId),
+    });
+    const saved = await this.teams.create(team);
+    return { team: await toPublicTeam(this.profiles, saved, userId) };
+  }
+}
+
+export class GetTeam {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    teamId: string;
+  }): Promise<{ team: PublicTeam }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const team = await loadTeam(this.teams, input.teamId);
+    team.assertCanView(userId);
+    return { team: await toPublicTeam(this.profiles, team, userId) };
+  }
+}
+
+export class ListMyTeams {
+  constructor(private readonly teams: TeamRepository) {}
+
+  async execute(input: { userId: string }): Promise<{
+    teams: PublicTeamSummary[];
+    pendingInvites: PublicTeamSummary[];
+  }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const rows = await this.teams.listForUser(userId);
+    const teams: PublicTeamSummary[] = [];
+    const pendingInvites: PublicTeamSummary[] = [];
+
+    for (const team of rows) {
+      const membership = team.membershipOf(userId);
+      if (!membership) continue;
+      const summary = toPublicSummary(team, userId);
+      if (membership.status.isInvited) {
+        pendingInvites.push(summary);
+      } else if (membership.status.isActive) {
+        teams.push(summary);
+      }
+    }
+
+    return { teams, pendingInvites };
+  }
+}
+
+export class UpdateTeam {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    teamId: string;
+    name?: unknown;
+    sport?: unknown;
+    homeVenueCmsId?: unknown;
+    hasHomeVenueCmsId: boolean;
+  }): Promise<{ team: PublicTeam }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const team = await loadTeam(this.teams, input.teamId);
+    team.updateDetails(userId, {
+      name: input.name === undefined ? undefined : TeamName.from(input.name),
+      sport: input.sport === undefined ? undefined : TeamSport.from(input.sport),
+      ...(input.hasHomeVenueCmsId
+        ? { homeVenueCmsId: HomeVenueCmsId.from(input.homeVenueCmsId) }
+        : {}),
+    });
+    const saved = await this.teams.persist(team);
+    return { team: await toPublicTeam(this.profiles, saved, userId) };
+  }
+}
+
+export class DeleteTeam {
+  constructor(private readonly teams: TeamRepository) {}
+
+  async execute(input: {
+    userId: string;
+    teamId: string;
+  }): Promise<{ ok: true }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const team = await loadTeam(this.teams, input.teamId);
+    team.assertCanDelete(userId);
+    await this.teams.delete(team.id);
+    return { ok: true as const };
+  }
+}
+
+export class InviteFriends {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly friendships: FriendshipRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    teamId: string;
+    userIds: unknown;
+  }): Promise<{ team: PublicTeam }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const team = await loadTeam(this.teams, input.teamId);
+    const userIds = parseUserIds(input.userIds);
+    if (userIds.length === 0) {
+      throw new DomainError("userIds is required");
+    }
+
+    for (const inviteeId of userIds) {
+      await requireAcceptedFriend(this.friendships, userId, inviteeId);
+      team.inviteFriend(userId, inviteeId);
+    }
+
+    const saved = await this.teams.persist(team);
+    return { team: await toPublicTeam(this.profiles, saved, userId) };
+  }
+}
+
+export class CreateInviteLink {
+  constructor(private readonly teams: TeamRepository) {}
+
+  async execute(input: {
+    userId: string;
+    teamId: string;
+  }): Promise<{ inviteLink: PublicInviteLink }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const team = await loadTeam(this.teams, input.teamId);
+    const link = team.regenerateInviteLink(userId);
+    await this.teams.persist(team);
+    return {
+      inviteLink: {
+        token: link.token.value,
+        createdAt: link.createdAt.toISOString(),
+      },
+    };
+  }
+}
+
+export class JoinByToken {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    token: unknown;
+  }): Promise<{ team: PublicTeam }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const token = TeamInviteToken.from(input.token);
+    const team = await this.teams.findByInviteToken(token.value);
+    if (!team) {
+      throw new TeamInviteLinkNotFoundError();
+    }
+    team.joinWithToken(userId, token);
+    const saved = await this.teams.persist(team);
+    return { team: await toPublicTeam(this.profiles, saved, userId) };
+  }
+}
+
+export class UpdateMemberRole {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    teamId: string;
+    memberUserId: string;
+    role: unknown;
+  }): Promise<{ team: PublicTeam }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const team = await loadTeam(this.teams, input.teamId);
+    team.updateMemberRole(
+      userId,
+      requiredTrimmed(input.memberUserId, "userId"),
+      TeamMemberRole.from(input.role),
+    );
+    const saved = await this.teams.persist(team);
+    return { team: await toPublicTeam(this.profiles, saved, userId) };
+  }
+}
+
+export class RemoveMember {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    teamId: string;
+    memberUserId: string;
+  }): Promise<{ team: PublicTeam }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const team = await loadTeam(this.teams, input.teamId);
+    team.removeMember(userId, input.memberUserId);
+    const saved = await this.teams.persist(team);
+    return { team: await toPublicTeam(this.profiles, saved, userId) };
+  }
+}
+
+export class LeaveTeam {
+  constructor(private readonly teams: TeamRepository) {}
+
+  async execute(input: {
+    userId: string;
+    teamId: string;
+  }): Promise<{ ok: true }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const team = await loadTeam(this.teams, input.teamId);
+    team.leave(userId);
+    await this.teams.persist(team);
+    return { ok: true as const };
+  }
+}
+
+export class TransferOwnership {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    teamId: string;
+    newOwnerUserId: unknown;
+  }): Promise<{ team: PublicTeam }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const team = await loadTeam(this.teams, input.teamId);
+    team.transferOwnership(userId, String(input.newOwnerUserId ?? ""));
+    const saved = await this.teams.persist(team);
+    return { team: await toPublicTeam(this.profiles, saved, userId) };
+  }
+}
+
+export { TeamForbiddenError } from "../entities/team-forbidden-error";
+export { TeamInviteLinkNotFoundError } from "../entities/team-invite-link-not-found-error";
+export { TeamMembershipNotFoundError } from "../entities/team-membership-not-found-error";
+export { TeamNotFoundError } from "../entities/team-not-found-error";
+export { TeamNotFriendError } from "../entities/team-not-friend-error";
+export { TeamOwnerLeaveError } from "../entities/team-owner-leave-error";
+export { TEAM_SPORTS } from "../entities/team-sport";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #42

Teams v1 for competitive squads (primary sport + roster). Not communities. Out of scope: team matches, tournaments, leagues, standings, public discovery, payments.

## What landed

- `Team` aggregate owns memberships and invite links (Venue / Match / OrganisedGame style — not anemic Friends-style)
- Invariants: exactly one owner, friend-only direct-add invites, owner cannot leave without transfer, captains cannot remove the owner or other captains
- Prisma models + migration `20260907200000_team` (`Team`, `TeamMembership`, `TeamInviteLink`)
- Session-cookie routes under `/api/teams`
- Domain, service, and HTTP tests (full suite green)

**Do not merge.** Brandon merges.

## Frontend contract

Auth: same session cookie as the rest of the API (`token=<jwt>`). All routes use `requireAuth`. Missing/invalid session → `401 { "error": "Unauthorized" }`.

Error envelope is always `{ "error": string }`.

| Status | When |
| --- | --- |
| 400 | Validation / domain (`name` blank, unknown `sport`, empty `userIds`, self-invite, invalid token shape) **or** non-friend invite (`Can only invite an accepted friend`) |
| 403 | Not allowed (non-member view, member editing team, captain removing owner/captain, non-owner delete/role/transfer) |
| 404 | Unknown team, unknown/revoked invite token, unknown membership |
| 409 | Owner leave / demote without transfer (`Owner must transfer ownership before leaving or changing role`) |
| 503 | Persistence failure |

### Shared shapes

```ts
type PublicTeamMember = {
  id: string; // userId
  displayName: string;
  handle: string;
  avatarUrl: string | null;
  role: "owner" | "captain" | "member";
  status: "active" | "invited";
  joinedAt: string; // ISO
};

type PublicInviteLink = {
  token: string; // 32-char hex
  createdAt: string; // ISO
};

type PublicTeamSummary = {
  id: string;
  name: string;
  sport: "padel" | "golf" | "darts";
  homeVenueCmsId: string | null;
  createdBy: string;
  createdAt: string;
  updatedAt: string;
  memberCount: number; // active members only
  myRole: "owner" | "captain" | "member";
  myStatus: "active" | "invited";
};

type PublicTeam = PublicTeamSummary & {
  members: PublicTeamMember[];
  inviteLink: PublicInviteLink | null; // active link, owner/captain only; otherwise null
};
```

### Routes

**`POST /api/teams`** — create; creator becomes owner (active). `201 { team }`

```json
{ "name": "Sunday Smash", "sport": "padel", "homeVenueCmsId": "optional-or-null" }
```

**`GET /api/teams`** — my active teams + pending invites for me. `200`

```json
{ "teams": [PublicTeamSummary], "pendingInvites": [PublicTeamSummary] }
```

Friend invites are **direct-add** (`status: "active"`), so `pendingInvites` is empty unless a membership was stored as `invited`.

**`GET /api/teams/:id`** — team + roster. Members only (active or invited). `200 { team }`

**`PATCH /api/teams/:id`** — owner only. At least one field. `200 { team }`

```json
{ "name": "Night Smash", "sport": "golf", "homeVenueCmsId": null }
```

**`DELETE /api/teams/:id`** — owner only. `200 { "ok": true }`

**`POST /api/teams/:id/invite`** — owner/captain. Accepted friends only; **adds as active member** (not invite→accept). `200 { team }`

```json
{ "userIds": ["user-uuid"] }
```

**`POST /api/teams/:id/invite-link`** — owner/captain. Creates or regenerates token (previous token is revoked). `201 { "inviteLink": { "token", "createdAt" } }`

**`POST /api/teams/join`** — open join as active member via token. `200 { team }`

```json
{ "token": "32-char-hex" }
```

**`PATCH /api/teams/:id/members/:userId`** — owner only. Appoint/remove captain. Cannot set `owner` (use transfer). Cannot demote last owner. `200 { team }`

```json
{ "role": "captain" }
```

**`DELETE /api/teams/:id/members/:userId`** — owner can remove captain/member; captain can remove `member` only. Cannot remove owner. `200 { team }`

**`POST /api/teams/:id/leave`** — captain/member. Owner must transfer first (`409`). `200 { "ok": true }`

**`POST /api/teams/:id/transfer-ownership`** — owner → an active member. Former owner becomes **captain**. `200 { team }`

```json
{ "userId": "new-owner-user-id" }
```

### Permissions recap

| Action | Owner | Captain | Member |
| --- | --- | --- | --- |
| Edit name/sport/homeVenue | yes | no | no |
| Appoint/remove captains | yes | no | no |
| Invite friends / invite link | yes | yes | no |
| Remove members | yes (not owner) | yes (members only) | no |
| Leave | no (transfer first) | yes | yes |
| Transfer ownership | yes | no | no |
| Delete team | yes | no | no |

Sport change is allowed in v1 (no team matches yet). `homeVenueCmsId` is stored and unused in UI v1.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26566627-0fea-40fd-8e69-bb133ffaccc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26566627-0fea-40fd-8e69-bb133ffaccc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

