### PR TITLE
feat: Team matches API (challenge, lineups, start, complete)

### DIFF
--- a/prisma/migrations/20260907210000_team_match/migration.sql
+++ b/prisma/migrations/20260907210000_team_match/migration.sql
@@ -1,0 +1,71 @@
+-- CreateEnum
+CREATE TYPE "TeamMatchStatus" AS ENUM ('pending', 'scheduled', 'live', 'completed', 'declined', 'cancelled');
+
+-- CreateTable
+CREATE TABLE "TeamMatch" (
+    "id" TEXT NOT NULL,
+    "homeTeamId" TEXT NOT NULL,
+    "awayTeamId" TEXT,
+    "sport" "TeamSport" NOT NULL,
+    "status" "TeamMatchStatus" NOT NULL DEFAULT 'pending',
+    "venueCmsId" TEXT,
+    "startsAt" TIMESTAMP(3),
+    "challengeToken" VARCHAR(32),
+    "createdBy" TEXT NOT NULL,
+    "winnerTeamId" TEXT,
+    "scorecardSport" TEXT,
+    "scorecardId" TEXT,
+    "scorecardPath" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TeamMatch_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TeamMatchLineup" (
+    "id" TEXT NOT NULL,
+    "teamMatchId" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "slot" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TeamMatchLineup_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TeamMatch_challengeToken_key" ON "TeamMatch"("challengeToken");
+
+-- CreateIndex
+CREATE INDEX "TeamMatch_homeTeamId_idx" ON "TeamMatch"("homeTeamId");
+
+-- CreateIndex
+CREATE INDEX "TeamMatch_awayTeamId_idx" ON "TeamMatch"("awayTeamId");
+
+-- CreateIndex
+CREATE INDEX "TeamMatch_status_startsAt_idx" ON "TeamMatch"("status", "startsAt");
+
+-- CreateIndex
+CREATE INDEX "TeamMatch_createdBy_idx" ON "TeamMatch"("createdBy");
+
+-- CreateIndex
+CREATE INDEX "TeamMatch_scorecardId_idx" ON "TeamMatch"("scorecardId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TeamMatchLineup_teamMatchId_teamId_userId_key" ON "TeamMatchLineup"("teamMatchId", "teamId", "userId");
+
+-- CreateIndex
+CREATE INDEX "TeamMatchLineup_teamMatchId_idx" ON "TeamMatchLineup"("teamMatchId");
+
+-- CreateIndex
+CREATE INDEX "TeamMatchLineup_teamId_idx" ON "TeamMatchLineup"("teamId");
+
+-- AddForeignKey
+ALTER TABLE "TeamMatch" ADD CONSTRAINT "TeamMatch_homeTeamId_fkey" FOREIGN KEY ("homeTeamId") REFERENCES "Team"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamMatch" ADD CONSTRAINT "TeamMatch_awayTeamId_fkey" FOREIGN KEY ("awayTeamId") REFERENCES "Team"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TeamMatchLineup" ADD CONSTRAINT "TeamMatchLineup_teamMatchId_fkey" FOREIGN KEY ("teamMatchId") REFERENCES "TeamMatch"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -398,6 +398,8 @@ model Team {
   updatedAt      DateTime         @updatedAt
   members        TeamMembership[]
   inviteLinks    TeamInviteLink[]
+  homeMatches    TeamMatch[]      @relation("TeamMatchHome")
+  awayMatches    TeamMatch[]      @relation("TeamMatchAway")
 
   @@index([createdBy])
   @@index([createdAt])
@@ -428,6 +430,62 @@ model TeamInviteLink {
 
   team Team @relation(fields: [teamId], references: [id], onDelete: Cascade)
 
+  @@index([teamId])
+}
+
+enum TeamMatchStatus {
+  pending
+  scheduled
+  live
+  completed
+  declined
+  cancelled
+}
+
+// Competitive fixture between two same-sport teams. Not an OrganisedGame.
+// No User FK — same as Team / Friendship. venueCmsId is optional and has
+// no Venue FK so a challenge can exist before a court/course is booked.
+// Lineups are stored as ordered user ids per side.
+model TeamMatch {
+  id             String          @id @default(uuid())
+  homeTeamId     String
+  awayTeamId     String?
+  sport          TeamSport
+  status         TeamMatchStatus @default(pending)
+  venueCmsId     String?
+  startsAt       DateTime?
+  challengeToken String?         @unique @db.VarChar(32)
+  createdBy      String
+  winnerTeamId   String?
+  scorecardSport String?
+  scorecardId    String?
+  scorecardPath  String?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  lineups        TeamMatchLineup[]
+
+  homeTeam Team  @relation("TeamMatchHome", fields: [homeTeamId], references: [id])
+  awayTeam Team? @relation("TeamMatchAway", fields: [awayTeamId], references: [id])
+
+  @@index([homeTeamId])
+  @@index([awayTeamId])
+  @@index([status, startsAt])
+  @@index([createdBy])
+  @@index([scorecardId])
+}
+
+model TeamMatchLineup {
+  id          String    @id @default(uuid())
+  teamMatchId String
+  teamId      String
+  userId      String
+  slot        Int
+  createdAt   DateTime  @default(now())
+
+  match TeamMatch @relation(fields: [teamMatchId], references: [id], onDelete: Cascade)
+
+  @@unique([teamMatchId, teamId, userId])
+  @@index([teamMatchId])
   @@index([teamId])
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -62,6 +62,13 @@ import {
   createTeamsModule,
   TeamRepository,
 } from "./modules/teams";
+import {
+  createTeamMatchesModule,
+  TeamMatchRepository,
+} from "./modules/team-matches";
+import { PrismaTeamMatchRepository } from "./modules/team-matches/repositories/prisma-team-match.repository";
+import { CompleteTeamMatchOnScorecardLock } from "./modules/team-matches/services/complete-on-scorecard-lock";
+import { ScorecardLockedEvent } from "./modules/scorecards/on-scorecard-locked";
 
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
@@ -80,6 +87,7 @@ export type CreateAppDependencies = {
   organisedGameRepository?: OrganisedGameRepository;
   notificationRepository?: NotificationRepository;
   teamRepository?: TeamRepository;
+  teamMatchRepository?: TeamMatchRepository;
 };
 
 export async function createApp(
@@ -114,23 +122,35 @@ export async function createApp(
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
+  const teamMatchRepository =
+    dependencies.teamMatchRepository ??
+    new PrismaTeamMatchRepository(prisma);
+  const completeOnLock = new CompleteTeamMatchOnScorecardLock(
+    teamMatchRepository,
+  );
+  const onScorecardLocked = (event: ScorecardLockedEvent) =>
+    completeOnLock.execute(event);
+
   const match = createMatchModule({
     prisma,
     venueRepository: venue.venueRepository,
     matchRepository: dependencies.matchRepository,
     tryGetSessionUserId: identity.tryGetSessionUserId,
+    onScorecardLocked,
   });
   const golfRound = createGolfRoundModule({
     prisma,
     venueRepository: venue.venueRepository,
     golfRoundRepository: dependencies.golfRoundRepository,
     tryGetSessionUserId: identity.tryGetSessionUserId,
+    onScorecardLocked,
   });
   const darts = createDartsModule({
     prisma,
     venueRepository: venue.venueRepository,
     dartsMatchRepository: dependencies.dartsMatchRepository,
     tryGetSessionUserId: identity.tryGetSessionUserId,
+    onScorecardLocked,
   });
   const friends = createFriendsModule({
     prisma,
@@ -209,6 +229,18 @@ export async function createApp(
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
+  const teamMatches = createTeamMatchesModule({
+    prisma,
+    teamRepository: teams.teamRepository,
+    venueRepository: venue.venueRepository,
+    matchRepository: match.matchRepository,
+    golfRoundRepository: golfRound.golfRoundRepository,
+    dartsMatchRepository: darts.dartsMatchRepository,
+    friendProfileLookup: friends.friendProfileLookup,
+    teamMatchRepository,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
@@ -225,6 +257,7 @@ export async function createApp(
   app.use(notifications.router);
   app.use(organisedGames.router);
   app.use(teams.router);
+  app.use(teamMatches.router);
 
   app.use(
     (

--- a/src/modules/darts/index.ts
+++ b/src/modules/darts/index.ts
@@ -1,6 +1,7 @@
 import { Request, Router } from "express";
 
 import { PrismaClient } from "../../generated/prisma/client";
+import { OnScorecardLocked } from "../scorecards/on-scorecard-locked";
 import { VenueRepository } from "../venue/repositories/venue.repository";
 import { createDartsMatchController } from "./controllers/darts-match.controller";
 import { DartsMatchRepository } from "./repositories/darts-match.repository";
@@ -20,6 +21,7 @@ export type CreateDartsModuleParams = {
   venueRepository: VenueRepository;
   dartsMatchRepository?: DartsMatchRepository;
   tryGetSessionUserId: (req: Request) => string | null;
+  onScorecardLocked?: OnScorecardLocked;
 };
 
 export type DartsModule = {
@@ -32,6 +34,7 @@ export function createDartsModule({
   venueRepository,
   dartsMatchRepository: dartsMatchRepositoryOverride,
   tryGetSessionUserId,
+  onScorecardLocked,
 }: CreateDartsModuleParams): DartsModule {
   const dartsMatchRepository =
     dartsMatchRepositoryOverride ?? new PrismaDartsMatchRepository(prisma);
@@ -46,7 +49,10 @@ export function createDartsModule({
       venueRepository,
     ),
     getDartsMatchById: new GetDartsMatchById(dartsMatchRepository),
-    submitDartsTurn: new SubmitDartsTurn(dartsMatchRepository),
+    submitDartsTurn: new SubmitDartsTurn(
+      dartsMatchRepository,
+      onScorecardLocked,
+    ),
     listLockedDartsMatchesByPlayer: new ListLockedDartsMatchesByPlayer(
       dartsMatchRepository,
       venueRepository,

--- a/src/modules/darts/services/submit-darts-turn.service.ts
+++ b/src/modules/darts/services/submit-darts-turn.service.ts
@@ -1,3 +1,4 @@
+import { OnScorecardLocked } from "../../scorecards/on-scorecard-locked";
 import { DartsMatch } from "../entities/darts-match";
 import { DartsMatchRepository } from "../repositories/darts-match.repository";
 
@@ -11,7 +12,10 @@ export type SubmitDartsTurnServiceInput = {
 };
 
 export class SubmitDartsTurn {
-  constructor(private readonly matches: DartsMatchRepository) {}
+  constructor(
+    private readonly matches: DartsMatchRepository,
+    private readonly onScorecardLocked?: OnScorecardLocked,
+  ) {}
 
   async execute(
     input: SubmitDartsTurnServiceInput,
@@ -28,6 +32,14 @@ export class SubmitDartsTurn {
       checkout: input.checkout,
       lockedByUserId: input.lockedByUserId,
     });
-    return this.matches.persist(match);
+    const persisted = await this.matches.persist(match);
+    if (persisted?.isLocked && this.onScorecardLocked) {
+      await this.onScorecardLocked({
+        sport: "darts",
+        scorecardId: persisted.id,
+        dartsWinnerUserId: persisted.toSnapshot().winnerUserId,
+      });
+    }
+    return persisted;
   }
 }

--- a/src/modules/golf-round/index.ts
+++ b/src/modules/golf-round/index.ts
@@ -1,6 +1,7 @@
 import { Request, Router } from "express";
 
 import { PrismaClient } from "../../generated/prisma/client";
+import { OnScorecardLocked } from "../scorecards/on-scorecard-locked";
 import { VenueRepository } from "../venue/repositories/venue.repository";
 import { createGolfRoundController } from "./controllers/golf-round.controller";
 import { GolfRoundRepository } from "./repositories/golf-round.repository";
@@ -20,6 +21,7 @@ export type CreateGolfRoundModuleParams = {
   venueRepository: VenueRepository;
   golfRoundRepository?: GolfRoundRepository;
   tryGetSessionUserId: (req: Request) => string | null;
+  onScorecardLocked?: OnScorecardLocked;
 };
 
 export type GolfRoundModule = {
@@ -32,6 +34,7 @@ export function createGolfRoundModule({
   venueRepository,
   golfRoundRepository: golfRoundRepositoryOverride,
   tryGetSessionUserId,
+  onScorecardLocked,
 }: CreateGolfRoundModuleParams): GolfRoundModule {
   const golfRoundRepository =
     golfRoundRepositoryOverride ?? new PrismaGolfRoundRepository(prisma);
@@ -43,7 +46,7 @@ export function createGolfRoundModule({
       venueRepository,
     ),
     getGolfRoundById: new GetGolfRoundById(golfRoundRepository),
-    lockGolfRound: new LockGolfRound(golfRoundRepository),
+    lockGolfRound: new LockGolfRound(golfRoundRepository, onScorecardLocked),
     listLockedGolfRoundsByPlayer: new ListLockedGolfRoundsByPlayer(
       golfRoundRepository,
       venueRepository,

--- a/src/modules/golf-round/services/lock-golf-round.service.ts
+++ b/src/modules/golf-round/services/lock-golf-round.service.ts
@@ -1,3 +1,4 @@
+import { OnScorecardLocked } from "../../scorecards/on-scorecard-locked";
 import { GolfRound } from "../entities/golf-round";
 import { GolfScore } from "../entities/golf-score";
 import { GolfRoundRepository } from "../repositories/golf-round.repository";
@@ -9,7 +10,10 @@ export type LockGolfRoundInput = {
 };
 
 export class LockGolfRound {
-  constructor(private readonly rounds: GolfRoundRepository) {}
+  constructor(
+    private readonly rounds: GolfRoundRepository,
+    private readonly onScorecardLocked?: OnScorecardLocked,
+  ) {}
 
   async execute(input: LockGolfRoundInput): Promise<GolfRound | null> {
     const round = await this.rounds.findById(input.roundId);
@@ -22,6 +26,20 @@ export class LockGolfRound {
       playerSlots: round.playerSlots(),
     });
     round.lock(score, new Date(), input.lockedByUserId);
-    return this.rounds.persistLock(round);
+    const persisted = await this.rounds.persistLock(round);
+    if (persisted?.isLocked && persisted.score && this.onScorecardLocked) {
+      await this.onScorecardLocked({
+        sport: "golf",
+        scorecardId: persisted.id,
+        golf: {
+          players: persisted.players.map((player) => ({
+            slot: player.slot,
+            userId: player.userId,
+          })),
+          holes: persisted.score.toSnapshot().holes,
+        },
+      });
+    }
+    return persisted;
   }
 }

--- a/src/modules/match/index.ts
+++ b/src/modules/match/index.ts
@@ -1,6 +1,7 @@
 import { Request, Router } from "express";
 
 import { PrismaClient } from "../../generated/prisma/client";
+import { OnScorecardLocked } from "../scorecards/on-scorecard-locked";
 import { VenueRepository } from "../venue/repositories/venue.repository";
 import { createMatchController } from "./controllers/match.controller";
 import { PrismaMatchRepository } from "./repositories/prisma-match.repository";
@@ -20,6 +21,7 @@ export type CreateMatchModuleParams = {
   venueRepository: VenueRepository;
   matchRepository?: MatchRepository;
   tryGetSessionUserId: (req: Request) => string | null;
+  onScorecardLocked?: OnScorecardLocked;
 };
 
 export type MatchModule = {
@@ -32,6 +34,7 @@ export function createMatchModule({
   venueRepository,
   matchRepository: matchRepositoryOverride,
   tryGetSessionUserId,
+  onScorecardLocked,
 }: CreateMatchModuleParams): MatchModule {
   const matchRepository =
     matchRepositoryOverride ?? new PrismaMatchRepository(prisma);
@@ -43,7 +46,7 @@ export function createMatchModule({
       venueRepository,
     ),
     getMatchById: new GetMatchById(matchRepository),
-    lockMatch: new LockMatch(matchRepository),
+    lockMatch: new LockMatch(matchRepository, onScorecardLocked),
     listLockedMatchesByPlayer: new ListLockedMatchesByPlayer(
       matchRepository,
       venueRepository,

--- a/src/modules/match/services/lock-match.service.ts
+++ b/src/modules/match/services/lock-match.service.ts
@@ -1,3 +1,4 @@
+import { OnScorecardLocked } from "../../scorecards/on-scorecard-locked";
 import { Match } from "../entities/match";
 import { MatchRepository } from "../repositories/match.repository";
 import { MatchScore } from "../entities/match-score";
@@ -11,7 +12,10 @@ export type LockMatchInput = {
 };
 
 export class LockMatch {
-  constructor(private readonly matches: MatchRepository) {}
+  constructor(
+    private readonly matches: MatchRepository,
+    private readonly onScorecardLocked?: OnScorecardLocked,
+  ) {}
 
   async execute(input: LockMatchInput): Promise<Match | null> {
     const match = await this.matches.findById(input.matchId);
@@ -25,6 +29,14 @@ export class LockMatch {
       new Date(),
       input.lockedByUserId,
     );
-    return this.matches.persistLock(match);
+    const persisted = await this.matches.persistLock(match);
+    if (persisted?.isLocked && this.onScorecardLocked) {
+      await this.onScorecardLocked({
+        sport: "padel",
+        scorecardId: persisted.id,
+        padelWinner: persisted.winner?.value,
+      });
+    }
+    return persisted;
   }
 }

--- a/src/modules/scorecards/on-scorecard-locked.ts
+++ b/src/modules/scorecards/on-scorecard-locked.ts
@@ -1,0 +1,12 @@
+export type ScorecardLockedEvent = {
+  sport: "padel" | "golf" | "darts";
+  scorecardId: string;
+  padelWinner?: "A" | "B";
+  dartsWinnerUserId?: string | null;
+  golf?: {
+    players: Array<{ slot: number; userId: string | null }>;
+    holes: Array<{ strokes: Record<string, number> }>;
+  };
+};
+
+export type OnScorecardLocked = (event: ScorecardLockedEvent) => Promise<void>;

--- a/src/modules/team-matches/controllers/team-matches.controller.ts
+++ b/src/modules/team-matches/controllers/team-matches.controller.ts
@@ -1,0 +1,369 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { TeamForbiddenError } from "../../teams/entities/team-forbidden-error";
+import { TeamNotFoundError } from "../../teams/entities/team-not-found-error";
+import { TeamPersistenceError } from "../../teams/entities/team-persistence-error";
+import { TeamMatchAlreadyAcceptedError } from "../entities/team-match-already-accepted-error";
+import { TeamMatchForbiddenError } from "../entities/team-match-forbidden-error";
+import { TeamMatchNotFoundError } from "../entities/team-match-not-found-error";
+import { TeamMatchNotReadyError } from "../entities/team-match-not-ready-error";
+import { TeamMatchPersistenceError } from "../entities/team-match-persistence-error";
+import { TeamMatchSportMismatchError } from "../entities/team-match-sport-mismatch-error";
+import {
+  AcceptTeamMatch,
+  CancelTeamMatch,
+  CompleteTeamMatch,
+  CreateTeamMatch,
+  DeclineTeamMatch,
+  GetTeamMatch,
+  JoinTeamMatch,
+  ListMyTeamMatches,
+  ListTeamMatches,
+  ScheduleTeamMatch,
+  SetTeamMatchLineup,
+  StartTeamMatch,
+} from "../services/team-matches.service";
+
+const createBodySchema = z
+  .object({
+    homeTeamId: z.string(),
+    awayTeamId: z.string().optional(),
+    generateChallengeLink: z.boolean().optional(),
+    venueCmsId: z.string().nullable().optional(),
+    startsAt: z.string().nullable().optional(),
+  })
+  .refine(
+    (body) =>
+      Boolean(body.awayTeamId) || body.generateChallengeLink === true,
+    { message: "awayTeamId or generateChallengeLink is required" },
+  );
+
+const joinBodySchema = z.object({
+  token: z.string(),
+  teamId: z.string(),
+});
+
+const matchIdParamSchema = z.object({
+  id: z.string(),
+});
+
+const teamIdParamSchema = z.object({
+  id: z.string(),
+});
+
+const listQuerySchema = z.object({
+  teamId: z.string().optional(),
+});
+
+const scheduleBodySchema = z
+  .object({
+    startsAt: z.string().nullable().optional(),
+    venueCmsId: z.string().nullable().optional(),
+  })
+  .refine(
+    (body) =>
+      body.startsAt !== undefined ||
+      Object.prototype.hasOwnProperty.call(body, "venueCmsId") ||
+      Object.prototype.hasOwnProperty.call(body, "startsAt"),
+    { message: "At least one field is required" },
+  );
+
+const lineupBodySchema = z.object({
+  userIds: z.array(z.string()),
+  teamId: z.string().optional(),
+});
+
+const startBodySchema = z.object({
+  ruleset: z.enum(["golden_point", "advantage"]).optional(),
+  servingTeam: z.enum(["A", "B"]).optional(),
+  holesPlayed: z.union([z.literal(9), z.literal(18)]).optional(),
+  startingHole: z.number().optional(),
+  teeName: z.string().optional(),
+  course: z
+    .object({
+      name: z.string().nullable().optional(),
+      holes: z.array(
+        z.object({
+          number: z.number(),
+          par: z.number(),
+          strokeIndex: z.number(),
+        }),
+      ),
+    })
+    .optional(),
+});
+
+const completeBodySchema = z.object({
+  winnerTeamId: z.string().optional(),
+});
+
+export function createTeamMatchesController(deps: {
+  createTeamMatch: CreateTeamMatch;
+  joinTeamMatch: JoinTeamMatch;
+  acceptTeamMatch: AcceptTeamMatch;
+  declineTeamMatch: DeclineTeamMatch;
+  scheduleTeamMatch: ScheduleTeamMatch;
+  setTeamMatchLineup: SetTeamMatchLineup;
+  startTeamMatch: StartTeamMatch;
+  cancelTeamMatch: CancelTeamMatch;
+  completeTeamMatch: CompleteTeamMatch;
+  getTeamMatch: GetTeamMatch;
+  listTeamMatches: ListTeamMatches;
+  listMyTeamMatches: ListMyTeamMatches;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async create(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const body = z.parse(createBodySchema, req.body ?? {});
+        const result = await deps.createTeamMatch.execute({
+          userId,
+          homeTeamId: body.homeTeamId,
+          awayTeamId: body.awayTeamId,
+          generateChallengeLink: body.generateChallengeLink,
+          venueCmsId: body.venueCmsId,
+          startsAt: body.startsAt,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+
+    async join(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const body = z.parse(joinBodySchema, req.body ?? {});
+        const result = await deps.joinTeamMatch.execute({
+          userId,
+          token: body.token,
+          teamId: body.teamId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+
+    async accept(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(matchIdParamSchema, req.params);
+        const result = await deps.acceptTeamMatch.execute({
+          userId,
+          matchId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+
+    async decline(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(matchIdParamSchema, req.params);
+        const result = await deps.declineTeamMatch.execute({
+          userId,
+          matchId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+
+    async schedule(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(matchIdParamSchema, req.params);
+        const body = z.parse(scheduleBodySchema, req.body ?? {});
+        const raw = (req.body ?? {}) as Record<string, unknown>;
+        const result = await deps.scheduleTeamMatch.execute({
+          userId,
+          matchId: id,
+          startsAt: body.startsAt,
+          venueCmsId: body.venueCmsId,
+          hasStartsAt: Object.prototype.hasOwnProperty.call(raw, "startsAt"),
+          hasVenueCmsId: Object.prototype.hasOwnProperty.call(raw, "venueCmsId"),
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+
+    async lineup(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(matchIdParamSchema, req.params);
+        const body = z.parse(lineupBodySchema, req.body ?? {});
+        const result = await deps.setTeamMatchLineup.execute({
+          userId,
+          matchId: id,
+          userIds: body.userIds,
+          teamId: body.teamId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+
+    async start(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(matchIdParamSchema, req.params);
+        const body = z.parse(startBodySchema, req.body ?? {});
+        const result = await deps.startTeamMatch.execute({
+          userId,
+          matchId: id,
+          ...body,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+
+    async cancel(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(matchIdParamSchema, req.params);
+        const result = await deps.cancelTeamMatch.execute({
+          userId,
+          matchId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+
+    async complete(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(matchIdParamSchema, req.params);
+        const body = z.parse(completeBodySchema, req.body ?? {});
+        const result = await deps.completeTeamMatch.execute({
+          userId,
+          matchId: id,
+          winnerTeamId: body.winnerTeamId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+
+    async get(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(matchIdParamSchema, req.params);
+        const result = await deps.getTeamMatch.execute({
+          userId,
+          matchId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+
+    async list(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const query = z.parse(listQuerySchema, req.query);
+        if (query.teamId) {
+          const result = await deps.listTeamMatches.execute({
+            userId,
+            teamId: query.teamId,
+          });
+          return res.status(200).json(result);
+        }
+        const result = await deps.listMyTeamMatches.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+
+    async listMine(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const result = await deps.listMyTeamMatches.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+
+    async listForTeam(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(teamIdParamSchema, req.params);
+        const result = await deps.listTeamMatches.execute({
+          userId,
+          teamId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamMatchError(res, error);
+      }
+    },
+  };
+}
+
+function sendTeamMatchError(res: Response, error: unknown) {
+  if (error instanceof TeamMatchNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+  if (error instanceof TeamNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+  if (
+    error instanceof TeamMatchForbiddenError ||
+    error instanceof TeamForbiddenError
+  ) {
+    return res.status(403).json({ error: error.message });
+  }
+  if (error instanceof TeamMatchAlreadyAcceptedError) {
+    return res.status(409).json({ error: error.message });
+  }
+  if (
+    error instanceof TeamMatchSportMismatchError ||
+    error instanceof TeamMatchNotReadyError
+  ) {
+    return res.status(400).json({ error: error.message });
+  }
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid team match payload" });
+  }
+  if (
+    error instanceof TeamMatchPersistenceError ||
+    error instanceof TeamPersistenceError
+  ) {
+    return res.status(503).json({ error: error.message });
+  }
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/team-matches/controllers/team-matches.http.test.ts
+++ b/src/modules/team-matches/controllers/team-matches.http.test.ts
@@ -1,0 +1,385 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryDartsMatchRepository } from "../../darts/repositories/in-memory-darts-match.repository";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { InMemoryGolfRoundRepository } from "../../golf-round/repositories/in-memory-golf-round.repository";
+import { signAuthenticationToken } from "../../identity/utils/jwt";
+import { InMemoryMatchRepository } from "../../match/repositories/in-memory-match.repository";
+import { Team } from "../../teams/entities/team";
+import { TeamName } from "../../teams/entities/team-name";
+import { TeamSport } from "../../teams/entities/team-sport";
+import { InMemoryTeamRepository } from "../../teams/repositories/in-memory-team.repository";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { InMemoryTeamMatchRepository } from "../repositories/in-memory-team-match.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function becomeFriends(
+  friendships: InMemoryFriendshipRepository,
+  a: string,
+  b: string,
+) {
+  const pending = await friendships.createPending(a, b);
+  await friendships.accept(pending.id);
+}
+
+type PublicTeamMatch = {
+  id: string;
+  sport: string;
+  status: string;
+  homeTeam: { id: string; name: string };
+  awayTeam: { id: string; name: string } | null;
+  venueCmsId: string | null;
+  startsAt: string | null;
+  challengeToken: string | null;
+  lineups: { home: Array<{ id: string }>; away: Array<{ id: string }> };
+  scorecard: { sport: string; id: string; path: string } | null;
+  winnerTeamId: string | null;
+};
+
+describe("team matches HTTP", () => {
+  const config = makeConfig();
+  let teams: InMemoryTeamRepository;
+  let matches: InMemoryTeamMatchRepository;
+  let friendships: InMemoryFriendshipRepository;
+  let profiles: InMemoryFriendProfileLookup;
+  let venues: InMemoryVenueRepository;
+  let padel: InMemoryMatchRepository;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+  let homeId: string;
+  let awayId: string;
+  let golfAwayId: string;
+
+  function cookie(userId: string) {
+    return `token=${signAuthenticationToken(config, { userId })}`;
+  }
+
+  async function json(
+    path: string,
+    init: RequestInit & { userId?: string } = {},
+  ) {
+    const headers = new Headers(init.headers);
+    if (init.body && !headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+    if (init.userId) headers.set("Cookie", cookie(init.userId));
+    return fetch(`${server.url}${path}`, { ...init, headers });
+  }
+
+  async function seedSquad(
+    ownerId: string,
+    name: string,
+    sport: string,
+    extraIds: string[],
+  ) {
+    const team = Team.create({
+      name: TeamName.from(name),
+      sport: TeamSport.from(sport),
+      createdBy: ownerId,
+    });
+    for (const extraId of extraIds) {
+      await becomeFriends(friendships, ownerId, extraId);
+      team.inviteFriend(ownerId, extraId);
+    }
+    return teams.create(team);
+  }
+
+  beforeEach(async () => {
+    teams = new InMemoryTeamRepository();
+    matches = new InMemoryTeamMatchRepository();
+    friendships = new InMemoryFriendshipRepository();
+    profiles = new InMemoryFriendProfileLookup();
+    venues = new InMemoryVenueRepository();
+    padel = new InMemoryMatchRepository();
+
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-court-1"),
+        VenueName.from("Padel Club"),
+        Slug.from("padel-club"),
+      ),
+      { refreshDetails: false },
+    );
+
+    for (const [userId, displayName, handle] of [
+      ["user-a", "Alex", "alex"],
+      ["user-a2", "Avery", "avery"],
+      ["user-b", "Blake", "blake"],
+      ["user-b2", "Blair", "blair"],
+      ["user-c", "Casey", "casey"],
+    ] as const) {
+      profiles.seed({ userId, displayName, handle, avatarUrl: null });
+    }
+
+    const home = await seedSquad("user-a", "Sunday Smash", "padel", ["user-a2"]);
+    const away = await seedSquad("user-b", "Night Walls", "padel", ["user-b2"]);
+    const golfAway = await seedSquad("user-c", "Fairway", "golf", []);
+    homeId = home.id;
+    awayId = away.id;
+    golfAwayId = golfAway.id;
+
+    app = await createApp(config, {
+      venueRepository: venues,
+      friendshipRepository: friendships,
+      friendProfileLookup: profiles,
+      teamRepository: teams,
+      teamMatchRepository: matches,
+      matchRepository: padel,
+      golfRoundRepository: new InMemoryGolfRoundRepository(),
+      dartsMatchRepository: new InMemoryDartsMatchRepository(),
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("create requires auth and rejects a different sport", async () => {
+    const unauth = await json("/api/team-matches", {
+      method: "POST",
+      body: JSON.stringify({ homeTeamId: homeId, awayTeamId: awayId }),
+    });
+    expect(unauth.status).toBe(401);
+
+    const mismatch = await json("/api/team-matches", {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ homeTeamId: homeId, awayTeamId: golfAwayId }),
+    });
+    expect(mismatch.status).toBe(400);
+    expect(await mismatch.json()).toEqual({
+      error: "Both teams must play the same sport",
+    });
+  });
+
+  test("targeted accept/decline, lineup, schedule, start, lock hook, list, search", async () => {
+    const created = await json("/api/team-matches", {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({
+        homeTeamId: homeId,
+        awayTeamId: awayId,
+        venueCmsId: "sanity-court-1",
+      }),
+    });
+    expect(created.status).toBe(201);
+    const { match } = (await created.json()) as { match: PublicTeamMatch };
+    expect(match.status).toBe("pending");
+    expect(match.challengeToken).toBeNull();
+
+    const memberAccept = await json(`/api/team-matches/${match.id}/accept`, {
+      method: "POST",
+      userId: "user-a2",
+    });
+    expect(memberAccept.status).toBe(403);
+
+    const accepted = await json(`/api/team-matches/${match.id}/accept`, {
+      method: "POST",
+      userId: "user-b",
+    });
+    expect(accepted.status).toBe(200);
+    expect(((await accepted.json()) as { match: PublicTeamMatch }).match.status).toBe(
+      "scheduled",
+    );
+
+    const scheduled = await json(`/api/team-matches/${match.id}`, {
+      method: "PATCH",
+      userId: "user-a",
+      body: JSON.stringify({ startsAt: "2026-09-08T18:00:00.000Z" }),
+    });
+    expect(scheduled.status).toBe(200);
+
+    const homeLineup = await json(`/api/team-matches/${match.id}/lineup`, {
+      method: "PUT",
+      userId: "user-a",
+      body: JSON.stringify({ userIds: ["user-a", "user-a2"] }),
+    });
+    expect(homeLineup.status).toBe(200);
+    const awayLineup = await json(`/api/team-matches/${match.id}/lineup`, {
+      method: "PUT",
+      userId: "user-b",
+      body: JSON.stringify({ userIds: ["user-b", "user-b2"] }),
+    });
+    expect(awayLineup.status).toBe(200);
+
+    const started = await json(`/api/team-matches/${match.id}/start`, {
+      method: "POST",
+      userId: "user-a",
+    });
+    expect(started.status).toBe(200);
+    const startedBody = (await started.json()) as {
+      match: PublicTeamMatch;
+      scorecard: { sport: string; id: string; path: string };
+    };
+    expect(startedBody.match.status).toBe("live");
+    expect(startedBody.scorecard.sport).toBe("padel");
+    expect(startedBody.scorecard.path).toBe(`/padel/${startedBody.scorecard.id}`);
+
+    const locked = await json(`/api/matches/${startedBody.scorecard.id}/lock`, {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({
+        score: { sets: [{ gamesA: 6, gamesB: 4, tieBreak: null, winner: "A" }] },
+        winner: "A",
+      }),
+    });
+    expect(locked.status).toBe(200);
+
+    const afterLock = await json(`/api/team-matches/${match.id}`, {
+      userId: "user-a",
+    });
+    expect(afterLock.status).toBe(200);
+    expect(await afterLock.json()).toMatchObject({
+      match: { status: "completed", winnerTeamId: homeId },
+    });
+
+    const listed = await json(`/api/team-matches?teamId=${homeId}`, {
+      userId: "user-a",
+    });
+    expect(listed.status).toBe(200);
+    expect(await listed.json()).toMatchObject({
+      matches: [expect.objectContaining({ id: match.id, status: "completed" })],
+    });
+
+    const byTeam = await json(`/api/teams/${homeId}/matches`, {
+      userId: "user-a",
+    });
+    expect(byTeam.status).toBe(200);
+
+    const mine = await json("/api/team-matches/mine", { userId: "user-a" });
+    expect(mine.status).toBe(200);
+    expect(await mine.json()).toMatchObject({
+      upcoming: [],
+      recent: [expect.objectContaining({ id: match.id })],
+    });
+
+    await becomeFriends(friendships, "user-a", "user-b");
+    const search = await json("/api/teams/search?sport=padel&q=Night", {
+      userId: "user-a",
+    });
+    expect(search.status).toBe(200);
+    expect(await search.json()).toMatchObject({
+      teams: [
+        expect.objectContaining({
+          id: awayId,
+          name: "Night Walls",
+          sport: "padel",
+        }),
+      ],
+    });
+  });
+
+  test("challenge link join and cancel before start", async () => {
+    const created = await json("/api/team-matches", {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({
+        homeTeamId: homeId,
+        generateChallengeLink: true,
+        venueCmsId: "sanity-court-1",
+      }),
+    });
+    const { match } = (await created.json()) as { match: PublicTeamMatch };
+    expect(match.challengeToken).toHaveLength(32);
+
+    const joined = await json("/api/team-matches/join", {
+      method: "POST",
+      userId: "user-b",
+      body: JSON.stringify({ token: match.challengeToken, teamId: awayId }),
+    });
+    expect(joined.status).toBe(200);
+    expect(((await joined.json()) as { match: PublicTeamMatch }).match.status).toBe(
+      "scheduled",
+    );
+
+    const cancelled = await json(`/api/team-matches/${match.id}/cancel`, {
+      method: "POST",
+      userId: "user-a",
+    });
+    expect(cancelled.status).toBe(200);
+    expect(((await cancelled.json()) as { match: PublicTeamMatch }).match.status).toBe(
+      "cancelled",
+    );
+  });
+
+  test("complete endpoint sets winner when lock hook is not used", async () => {
+    const created = await json("/api/team-matches", {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({
+        homeTeamId: homeId,
+        awayTeamId: awayId,
+        venueCmsId: "sanity-court-1",
+      }),
+    });
+    const { match } = (await created.json()) as { match: PublicTeamMatch };
+    await json(`/api/team-matches/${match.id}/accept`, {
+      method: "POST",
+      userId: "user-b",
+    });
+    await json(`/api/team-matches/${match.id}/lineup`, {
+      method: "PUT",
+      userId: "user-a",
+      body: JSON.stringify({ userIds: ["user-a", "user-a2"] }),
+    });
+    await json(`/api/team-matches/${match.id}/lineup`, {
+      method: "PUT",
+      userId: "user-b",
+      body: JSON.stringify({ userIds: ["user-b", "user-b2"] }),
+    });
+    await json(`/api/team-matches/${match.id}/start`, {
+      method: "POST",
+      userId: "user-a",
+    });
+
+    const completed = await json(`/api/team-matches/${match.id}/complete`, {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ winnerTeamId: awayId }),
+    });
+    expect(completed.status).toBe(200);
+    expect(await completed.json()).toMatchObject({
+      match: { status: "completed", winnerTeamId: awayId },
+    });
+  });
+});

--- a/src/modules/team-matches/entities/optional-starts-at.ts
+++ b/src/modules/team-matches/entities/optional-starts-at.ts
@@ -1,0 +1,33 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export class OptionalStartsAt {
+  private constructor(readonly value: Date | null) {}
+
+  static from(raw: unknown): OptionalStartsAt {
+    if (raw == null || raw === "") {
+      return new OptionalStartsAt(null);
+    }
+    if (raw instanceof Date) {
+      if (Number.isNaN(raw.getTime())) {
+        throw new DomainError("startsAt must be a valid date");
+      }
+      return new OptionalStartsAt(raw);
+    }
+    if (typeof raw !== "string" || raw.trim().length === 0) {
+      throw new DomainError("startsAt must be a valid date");
+    }
+    const parsed = new Date(raw);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new DomainError("startsAt must be a valid date");
+    }
+    return new OptionalStartsAt(parsed);
+  }
+
+  get isSet(): boolean {
+    return this.value !== null;
+  }
+
+  toIsoString(): string | null {
+    return this.value?.toISOString() ?? null;
+  }
+}

--- a/src/modules/team-matches/entities/optional-venue-cms-id.ts
+++ b/src/modules/team-matches/entities/optional-venue-cms-id.ts
@@ -1,0 +1,20 @@
+import { DomainError } from "../../../lib/domain-error";
+
+const MAX_LENGTH = 120;
+
+export class OptionalVenueCmsId {
+  private constructor(readonly value: string | null) {}
+
+  static from(raw: unknown): OptionalVenueCmsId {
+    if (raw == null) return new OptionalVenueCmsId(null);
+    if (typeof raw !== "string") {
+      throw new DomainError("venueCmsId must be a string");
+    }
+    const value = raw.trim();
+    if (value.length === 0) return new OptionalVenueCmsId(null);
+    if (value.length > MAX_LENGTH) {
+      throw new DomainError(`venueCmsId must be at most ${MAX_LENGTH} characters`);
+    }
+    return new OptionalVenueCmsId(value);
+  }
+}

--- a/src/modules/team-matches/entities/team-match-already-accepted-error.ts
+++ b/src/modules/team-matches/entities/team-match-already-accepted-error.ts
@@ -1,0 +1,6 @@
+export class TeamMatchAlreadyAcceptedError extends Error {
+  constructor(message = "Challenge has already been accepted") {
+    super(message);
+    this.name = "TeamMatchAlreadyAcceptedError";
+  }
+}

--- a/src/modules/team-matches/entities/team-match-challenge-token.ts
+++ b/src/modules/team-matches/entities/team-match-challenge-token.ts
@@ -1,0 +1,31 @@
+import { randomBytes } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+export const TEAM_MATCH_CHALLENGE_TOKEN_LENGTH = 32;
+const TOKEN_PATTERN = /^[a-f0-9]+$/;
+
+export class TeamMatchChallengeToken {
+  private constructor(readonly value: string) {}
+
+  static generate(): TeamMatchChallengeToken {
+    return new TeamMatchChallengeToken(randomBytes(16).toString("hex"));
+  }
+
+  static from(raw: unknown): TeamMatchChallengeToken {
+    const value = requiredTrimmed(raw, "token").toLowerCase();
+    if (value.length !== TEAM_MATCH_CHALLENGE_TOKEN_LENGTH) {
+      throw new DomainError(
+        `token must be ${TEAM_MATCH_CHALLENGE_TOKEN_LENGTH} characters`,
+      );
+    }
+    if (!TOKEN_PATTERN.test(value)) {
+      throw new DomainError("token is invalid");
+    }
+    return new TeamMatchChallengeToken(value);
+  }
+
+  equals(other: TeamMatchChallengeToken): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/team-matches/entities/team-match-forbidden-error.ts
+++ b/src/modules/team-matches/entities/team-match-forbidden-error.ts
@@ -1,0 +1,6 @@
+export class TeamMatchForbiddenError extends Error {
+  constructor(message = "Not allowed for this team match") {
+    super(message);
+    this.name = "TeamMatchForbiddenError";
+  }
+}

--- a/src/modules/team-matches/entities/team-match-lineup.ts
+++ b/src/modules/team-matches/entities/team-match-lineup.ts
@@ -1,0 +1,79 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { TeamSport } from "../../teams/entities/team-sport";
+
+export const LINEUP_RULES: Record<
+  "padel" | "golf" | "darts",
+  { min: number; max: number }
+> = {
+  padel: { min: 2, max: 2 },
+  golf: { min: 1, max: 2 },
+  darts: { min: 1, max: 1 },
+};
+
+export type TeamMatchLineupSnapshot = {
+  teamId: string;
+  userIds: string[];
+};
+
+export class TeamMatchLineup {
+  private constructor(
+    readonly teamId: string,
+    readonly userIds: readonly string[],
+  ) {}
+
+  static from(teamId: string, userIds: unknown, sport: TeamSport): TeamMatchLineup {
+    const id = requiredTrimmed(teamId, "teamId");
+    const ids = parseUserIds(userIds);
+    const rule = LINEUP_RULES[sport.value];
+    if (ids.length < rule.min || ids.length > rule.max) {
+      throw new DomainError(
+        `${sport.value} lineup must include ${describeRule(rule)} player(s)`,
+      );
+    }
+    return new TeamMatchLineup(id, ids);
+  }
+
+  static empty(teamId: string): TeamMatchLineup {
+    return new TeamMatchLineup(requiredTrimmed(teamId, "teamId"), []);
+  }
+
+  static rehydrate(teamId: string, userIds: string[]): TeamMatchLineup {
+    return new TeamMatchLineup(teamId, [...userIds]);
+  }
+
+  get isEmpty(): boolean {
+    return this.userIds.length === 0;
+  }
+
+  includes(userId: string): boolean {
+    return this.userIds.includes(userId);
+  }
+
+  isValidFor(sport: TeamSport): boolean {
+    const rule = LINEUP_RULES[sport.value];
+    return this.userIds.length >= rule.min && this.userIds.length <= rule.max;
+  }
+
+  toSnapshot(): TeamMatchLineupSnapshot {
+    return { teamId: this.teamId, userIds: [...this.userIds] };
+  }
+}
+
+function parseUserIds(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    throw new DomainError("userIds is required");
+  }
+  const ids: string[] = [];
+  for (const item of raw) {
+    const id = requiredTrimmed(item, "userId");
+    if (ids.includes(id)) {
+      throw new DomainError("lineup userIds must be unique");
+    }
+    ids.push(id);
+  }
+  return ids;
+}
+
+function describeRule(rule: { min: number; max: number }): string {
+  return rule.min === rule.max ? `${rule.min}` : `${rule.min}–${rule.max}`;
+}

--- a/src/modules/team-matches/entities/team-match-not-found-error.ts
+++ b/src/modules/team-matches/entities/team-match-not-found-error.ts
@@ -1,0 +1,6 @@
+export class TeamMatchNotFoundError extends Error {
+  constructor(message = "Team match not found") {
+    super(message);
+    this.name = "TeamMatchNotFoundError";
+  }
+}

--- a/src/modules/team-matches/entities/team-match-not-ready-error.ts
+++ b/src/modules/team-matches/entities/team-match-not-ready-error.ts
@@ -1,0 +1,6 @@
+export class TeamMatchNotReadyError extends Error {
+  constructor(message = "Team match is not ready to start") {
+    super(message);
+    this.name = "TeamMatchNotReadyError";
+  }
+}

--- a/src/modules/team-matches/entities/team-match-persistence-error.ts
+++ b/src/modules/team-matches/entities/team-match-persistence-error.ts
@@ -1,0 +1,6 @@
+export class TeamMatchPersistenceError extends Error {
+  constructor(message = "Unable to save team match", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "TeamMatchPersistenceError";
+  }
+}

--- a/src/modules/team-matches/entities/team-match-scorecard.ts
+++ b/src/modules/team-matches/entities/team-match-scorecard.ts
@@ -1,0 +1,49 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { TeamSport } from "../../teams/entities/team-sport";
+
+export type TeamMatchScorecardSnapshot = {
+  sport: "padel" | "golf" | "darts";
+  id: string;
+  path: string;
+};
+
+export class TeamMatchScorecard {
+  private constructor(
+    readonly sport: TeamSport,
+    readonly id: string,
+    readonly path: string,
+  ) {}
+
+  static from(props: {
+    sport: TeamSport;
+    id: string;
+    path?: string;
+  }): TeamMatchScorecard {
+    const id = requiredTrimmed(props.id, "scorecard id");
+    const path = props.path?.trim() || livePath(props.sport, id);
+    return new TeamMatchScorecard(props.sport, id, path);
+  }
+
+  static rehydrate(snapshot: TeamMatchScorecardSnapshot): TeamMatchScorecard {
+    return new TeamMatchScorecard(
+      TeamSport.from(snapshot.sport),
+      snapshot.id,
+      snapshot.path,
+    );
+  }
+
+  toSnapshot(): TeamMatchScorecardSnapshot {
+    return {
+      sport: this.sport.value,
+      id: this.id,
+      path: this.path,
+    };
+  }
+}
+
+export function livePath(sport: TeamSport, id: string): string {
+  if (sport.value === "padel") return `/padel/${id}`;
+  if (sport.value === "golf") return `/golf/${id}`;
+  if (sport.value === "darts") return `/darts/${id}`;
+  throw new DomainError("unsupported scorecard sport");
+}

--- a/src/modules/team-matches/entities/team-match-sport-mismatch-error.ts
+++ b/src/modules/team-matches/entities/team-match-sport-mismatch-error.ts
@@ -1,0 +1,6 @@
+export class TeamMatchSportMismatchError extends Error {
+  constructor(message = "Both teams must play the same sport") {
+    super(message);
+    this.name = "TeamMatchSportMismatchError";
+  }
+}

--- a/src/modules/team-matches/entities/team-match-status.ts
+++ b/src/modules/team-matches/entities/team-match-status.ts
@@ -1,0 +1,75 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const TEAM_MATCH_STATUSES = [
+  "pending",
+  "scheduled",
+  "live",
+  "completed",
+  "declined",
+  "cancelled",
+] as const;
+
+export type TeamMatchStatusValue = (typeof TEAM_MATCH_STATUSES)[number];
+
+export class TeamMatchStatus {
+  static readonly PENDING = new TeamMatchStatus("pending");
+  static readonly SCHEDULED = new TeamMatchStatus("scheduled");
+  static readonly LIVE = new TeamMatchStatus("live");
+  static readonly COMPLETED = new TeamMatchStatus("completed");
+  static readonly DECLINED = new TeamMatchStatus("declined");
+  static readonly CANCELLED = new TeamMatchStatus("cancelled");
+
+  private constructor(readonly value: TeamMatchStatusValue) {}
+
+  static from(raw: unknown): TeamMatchStatus {
+    if (raw === "pending") return TeamMatchStatus.PENDING;
+    if (raw === "scheduled") return TeamMatchStatus.SCHEDULED;
+    if (raw === "live") return TeamMatchStatus.LIVE;
+    if (raw === "completed") return TeamMatchStatus.COMPLETED;
+    if (raw === "declined") return TeamMatchStatus.DECLINED;
+    if (raw === "cancelled") return TeamMatchStatus.CANCELLED;
+    throw new DomainError(
+      "status must be pending, scheduled, live, completed, declined, or cancelled",
+    );
+  }
+
+  get isPending(): boolean {
+    return this.value === "pending";
+  }
+
+  get isScheduled(): boolean {
+    return this.value === "scheduled";
+  }
+
+  get isLive(): boolean {
+    return this.value === "live";
+  }
+
+  get isCompleted(): boolean {
+    return this.value === "completed";
+  }
+
+  get isDeclined(): boolean {
+    return this.value === "declined";
+  }
+
+  get isCancelled(): boolean {
+    return this.value === "cancelled";
+  }
+
+  get isOpen(): boolean {
+    return this.isPending || this.isScheduled;
+  }
+
+  get hasStarted(): boolean {
+    return this.isLive || this.isCompleted;
+  }
+
+  get isTerminal(): boolean {
+    return this.isCompleted || this.isDeclined || this.isCancelled;
+  }
+
+  equals(other: TeamMatchStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/team-matches/entities/team-match.test.ts
+++ b/src/modules/team-matches/entities/team-match.test.ts
@@ -1,0 +1,168 @@
+import { DomainError } from "../../../lib/domain-error";
+import { TeamSport } from "../../teams/entities/team-sport";
+import { OptionalStartsAt } from "./optional-starts-at";
+import { OptionalVenueCmsId } from "./optional-venue-cms-id";
+import { TeamMatch } from "./team-match";
+import { TeamMatchAlreadyAcceptedError } from "./team-match-already-accepted-error";
+import { TeamMatchChallengeToken } from "./team-match-challenge-token";
+import { TeamMatchNotReadyError } from "./team-match-not-ready-error";
+import { TeamMatchScorecard } from "./team-match-scorecard";
+import { TeamMatchStatus } from "./team-match-status";
+
+function targeted() {
+  return TeamMatch.create({
+    homeTeamId: "team-a",
+    awayTeamId: "team-b",
+    sport: TeamSport.PADEL,
+    createdBy: "user-a",
+    venueCmsId: OptionalVenueCmsId.from("sanity-court-1"),
+  });
+}
+
+describe("team match value objects", () => {
+  test("status is a closed enum", () => {
+    expect(TeamMatchStatus.from("pending").isPending).toBe(true);
+    expect(TeamMatchStatus.from("scheduled").isOpen).toBe(true);
+    expect(() => TeamMatchStatus.from("open")).toThrow(DomainError);
+  });
+
+  test("challenge token is 32 hex chars", () => {
+    const token = TeamMatchChallengeToken.generate();
+    expect(token.value).toHaveLength(32);
+    expect(TeamMatchChallengeToken.from(token.value).equals(token)).toBe(true);
+    expect(() => TeamMatchChallengeToken.from("nope")).toThrow(DomainError);
+  });
+});
+
+describe(TeamMatch, () => {
+  test("targeted create is pending with both sides and no token", () => {
+    const match = targeted();
+    const snapshot = match.toSnapshot();
+    expect(snapshot).toMatchObject({
+      homeTeamId: "team-a",
+      awayTeamId: "team-b",
+      sport: "padel",
+      status: "pending",
+      venueCmsId: "sanity-court-1",
+      challengeToken: null,
+      createdBy: "user-a",
+    });
+    expect(match.homeLineup().isEmpty).toBe(true);
+  });
+
+  test("open challenge mints a token and leaves away empty", () => {
+    const match = TeamMatch.create({
+      homeTeamId: "team-a",
+      sport: TeamSport.GOLF,
+      createdBy: "user-a",
+      generateChallengeLink: true,
+    });
+    expect(match.awayTeamId).toBeNull();
+    expect(match.challengeToken?.value).toHaveLength(32);
+    expect(match.status.isPending).toBe(true);
+  });
+
+  test("cannot challenge the same team", () => {
+    expect(() =>
+      TeamMatch.create({
+        homeTeamId: "team-a",
+        awayTeamId: "team-a",
+        sport: TeamSport.DARTS,
+        createdBy: "user-a",
+      }),
+    ).toThrow(DomainError);
+  });
+
+  test("accept moves to scheduled; decline and cancel are terminal", () => {
+    const accepted = targeted();
+    accepted.accept("team-b");
+    expect(accepted.status.isScheduled).toBe(true);
+
+    const declined = targeted();
+    declined.decline();
+    expect(declined.status.isDeclined).toBe(true);
+    expect(() => declined.accept("team-b")).toThrow(DomainError);
+
+    const cancelled = targeted();
+    cancelled.cancel();
+    expect(cancelled.status.isCancelled).toBe(true);
+    expect(() => cancelled.setLineup("team-a", ["u1", "u2"])).toThrow(
+      DomainError,
+    );
+  });
+
+  test("cannot accept a different away team", () => {
+    const match = targeted();
+    expect(() => match.accept("team-c")).toThrow(TeamMatchAlreadyAcceptedError);
+  });
+
+  test("join via token attaches away and schedules", () => {
+    const match = TeamMatch.create({
+      homeTeamId: "team-a",
+      sport: TeamSport.DARTS,
+      createdBy: "user-a",
+      generateChallengeLink: true,
+    });
+    match.joinWithToken(match.challengeToken!, "team-b");
+    expect(match.awayTeamId).toBe("team-b");
+    expect(match.status.isScheduled).toBe(true);
+    expect(() => match.joinWithToken(match.challengeToken!, "team-c")).toThrow(
+      TeamMatchAlreadyAcceptedError,
+    );
+  });
+
+  test("lineup must match sport player count", () => {
+    const match = targeted();
+    expect(() => match.setLineup("team-a", ["u1"])).toThrow(DomainError);
+    match.setLineup("team-a", ["u1", "u2"]);
+    expect(match.homeLineup().userIds).toEqual(["u1", "u2"]);
+    expect(() => match.setLineup("team-c", ["u3", "u4"])).toThrow(DomainError);
+  });
+
+  test("cannot start until accepted and both lineups are valid", () => {
+    const match = targeted();
+    match.setLineup("team-a", ["a1", "a2"]);
+    expect(() => match.assertCanStart()).toThrow(TeamMatchNotReadyError);
+    match.accept("team-b");
+    expect(() => match.assertCanStart()).toThrow(TeamMatchNotReadyError);
+    match.setLineup("team-b", ["b1", "b2"]);
+    match.assertCanStart();
+
+    const scorecard = TeamMatchScorecard.from({
+      sport: TeamSport.PADEL,
+      id: "match-1",
+    });
+    match.start(scorecard);
+    expect(match.status.isLive).toBe(true);
+    expect(match.scorecard?.path).toBe("/padel/match-1");
+
+    match.complete("team-a");
+    expect(match.status.isCompleted).toBe(true);
+    expect(match.winnerTeamId).toBe("team-a");
+    expect(() => match.cancel()).toThrow(DomainError);
+  });
+
+  test("padel and golf require a venue to start", () => {
+    const golf = TeamMatch.create({
+      homeTeamId: "team-a",
+      awayTeamId: "team-b",
+      sport: TeamSport.GOLF,
+      createdBy: "user-a",
+    });
+    golf.accept("team-b");
+    golf.setLineup("team-a", ["a1"]);
+    golf.setLineup("team-b", ["b1"]);
+    expect(() => golf.assertCanStart()).toThrow(TeamMatchNotReadyError);
+    golf.schedule({ venueCmsId: OptionalVenueCmsId.from("course-1") });
+    golf.assertCanStart();
+  });
+
+  test("schedule and snapshot round-trip", () => {
+    const match = targeted();
+    match.schedule({
+      startsAt: OptionalStartsAt.from("2026-09-08T10:00:00.000Z"),
+    });
+    const copy = TeamMatch.fromSnapshot(match.toSnapshot());
+    expect(copy.toSnapshot()).toEqual(match.toSnapshot());
+  });
+});

--- a/src/modules/team-matches/entities/team-match.ts
+++ b/src/modules/team-matches/entities/team-match.ts
@@ -1,0 +1,421 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { TeamSport } from "../../teams/entities/team-sport";
+import { OptionalStartsAt } from "./optional-starts-at";
+import { OptionalVenueCmsId } from "./optional-venue-cms-id";
+import { TeamMatchAlreadyAcceptedError } from "./team-match-already-accepted-error";
+import { TeamMatchChallengeToken } from "./team-match-challenge-token";
+import { TeamMatchLineup } from "./team-match-lineup";
+import { TeamMatchNotReadyError } from "./team-match-not-ready-error";
+import { TeamMatchScorecard } from "./team-match-scorecard";
+import { TeamMatchStatus, TeamMatchStatusValue } from "./team-match-status";
+
+export type TeamMatchSnapshot = {
+  id: string;
+  homeTeamId: string;
+  awayTeamId: string | null;
+  sport: "padel" | "golf" | "darts";
+  status: TeamMatchStatusValue;
+  venueCmsId: string | null;
+  startsAt: string | null;
+  challengeToken: string | null;
+  createdBy: string;
+  winnerTeamId: string | null;
+  scorecard: ReturnType<TeamMatchScorecard["toSnapshot"]> | null;
+  createdAt: string;
+  updatedAt: string;
+  lineups: ReturnType<TeamMatchLineup["toSnapshot"]>[];
+};
+
+export type CreateTeamMatchProps = {
+  homeTeamId: string;
+  awayTeamId?: string | null;
+  sport: TeamSport;
+  createdBy: string;
+  venueCmsId?: OptionalVenueCmsId;
+  startsAt?: OptionalStartsAt;
+  generateChallengeLink?: boolean;
+};
+
+export class TeamMatch {
+  private constructor(
+    readonly id: string,
+    readonly homeTeamId: string,
+    private awayTeamIdValue: string | null,
+    readonly sport: TeamSport,
+    private statusValue: TeamMatchStatus,
+    private venueCmsIdValue: OptionalVenueCmsId,
+    private startsAtValue: OptionalStartsAt,
+    private challengeTokenValue: TeamMatchChallengeToken | null,
+    readonly createdBy: string,
+    private winnerTeamIdValue: string | null,
+    private scorecardValue: TeamMatchScorecard | null,
+    readonly createdAt: Date,
+    private updatedAtValue: Date,
+    private lineupsValue: Map<string, TeamMatchLineup>,
+  ) {}
+
+  static create(props: CreateTeamMatchProps): TeamMatch {
+    const homeTeamId = requiredTrimmed(props.homeTeamId, "homeTeamId");
+    const createdBy = requiredTrimmed(props.createdBy, "userId");
+    const awayTeamId = props.awayTeamId
+      ? requiredTrimmed(props.awayTeamId, "awayTeamId")
+      : null;
+
+    if (awayTeamId && awayTeamId === homeTeamId) {
+      throw new DomainError("Cannot challenge the same team");
+    }
+
+    const openLink = props.generateChallengeLink === true || awayTeamId === null;
+    if (!openLink && !awayTeamId) {
+      throw new DomainError("awayTeamId or generateChallengeLink is required");
+    }
+
+    const now = new Date();
+    const lineups = new Map<string, TeamMatchLineup>([
+      [homeTeamId, TeamMatchLineup.empty(homeTeamId)],
+    ]);
+    if (awayTeamId) {
+      lineups.set(awayTeamId, TeamMatchLineup.empty(awayTeamId));
+    }
+
+    return new TeamMatch(
+      randomUUID(),
+      homeTeamId,
+      awayTeamId,
+      props.sport,
+      TeamMatchStatus.PENDING,
+      props.venueCmsId ?? OptionalVenueCmsId.from(null),
+      props.startsAt ?? OptionalStartsAt.from(null),
+      openLink ? TeamMatchChallengeToken.generate() : null,
+      createdBy,
+      null,
+      null,
+      now,
+      now,
+      lineups,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    homeTeamId: string;
+    awayTeamId: string | null;
+    sport: TeamSport;
+    status: TeamMatchStatus;
+    venueCmsId: OptionalVenueCmsId;
+    startsAt: OptionalStartsAt;
+    challengeToken: TeamMatchChallengeToken | null;
+    createdBy: string;
+    winnerTeamId: string | null;
+    scorecard: TeamMatchScorecard | null;
+    createdAt: Date;
+    updatedAt: Date;
+    lineups: TeamMatchLineup[];
+  }): TeamMatch {
+    const lineups = new Map<string, TeamMatchLineup>();
+    for (const lineup of props.lineups) {
+      lineups.set(lineup.teamId, lineup);
+    }
+    if (!lineups.has(props.homeTeamId)) {
+      lineups.set(props.homeTeamId, TeamMatchLineup.empty(props.homeTeamId));
+    }
+    if (props.awayTeamId && !lineups.has(props.awayTeamId)) {
+      lineups.set(props.awayTeamId, TeamMatchLineup.empty(props.awayTeamId));
+    }
+    return new TeamMatch(
+      props.id,
+      props.homeTeamId,
+      props.awayTeamId,
+      props.sport,
+      props.status,
+      props.venueCmsId,
+      props.startsAt,
+      props.challengeToken,
+      props.createdBy,
+      props.winnerTeamId,
+      props.scorecard,
+      props.createdAt,
+      props.updatedAt,
+      lineups,
+    );
+  }
+
+  static fromSnapshot(snapshot: TeamMatchSnapshot): TeamMatch {
+    return TeamMatch.rehydrate({
+      id: snapshot.id,
+      homeTeamId: snapshot.homeTeamId,
+      awayTeamId: snapshot.awayTeamId,
+      sport: TeamSport.from(snapshot.sport),
+      status: TeamMatchStatus.from(snapshot.status),
+      venueCmsId: OptionalVenueCmsId.from(snapshot.venueCmsId),
+      startsAt: OptionalStartsAt.from(snapshot.startsAt),
+      challengeToken: snapshot.challengeToken
+        ? TeamMatchChallengeToken.from(snapshot.challengeToken)
+        : null,
+      createdBy: snapshot.createdBy,
+      winnerTeamId: snapshot.winnerTeamId,
+      scorecard: snapshot.scorecard
+        ? TeamMatchScorecard.rehydrate(snapshot.scorecard)
+        : null,
+      createdAt: new Date(snapshot.createdAt),
+      updatedAt: new Date(snapshot.updatedAt),
+      lineups: snapshot.lineups.map((lineup) =>
+        TeamMatchLineup.rehydrate(lineup.teamId, lineup.userIds),
+      ),
+    });
+  }
+
+  get awayTeamId(): string | null {
+    return this.awayTeamIdValue;
+  }
+
+  get status(): TeamMatchStatus {
+    return this.statusValue;
+  }
+
+  get venueCmsId(): string | null {
+    return this.venueCmsIdValue.value;
+  }
+
+  get startsAt(): Date | null {
+    return this.startsAtValue.value;
+  }
+
+  get challengeToken(): TeamMatchChallengeToken | null {
+    return this.challengeTokenValue;
+  }
+
+  get winnerTeamId(): string | null {
+    return this.winnerTeamIdValue;
+  }
+
+  get scorecard(): TeamMatchScorecard | null {
+    return this.scorecardValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  get teamIds(): string[] {
+    return this.awayTeamIdValue
+      ? [this.homeTeamId, this.awayTeamIdValue]
+      : [this.homeTeamId];
+  }
+
+  lineupOf(teamId: string): TeamMatchLineup {
+    return (
+      this.lineupsValue.get(teamId) ?? TeamMatchLineup.empty(teamId)
+    );
+  }
+
+  homeLineup(): TeamMatchLineup {
+    return this.lineupOf(this.homeTeamId);
+  }
+
+  awayLineup(): TeamMatchLineup | null {
+    if (!this.awayTeamIdValue) return null;
+    return this.lineupOf(this.awayTeamIdValue);
+  }
+
+  isHome(teamId: string): boolean {
+    return teamId === this.homeTeamId;
+  }
+
+  isAway(teamId: string): boolean {
+    return this.awayTeamIdValue !== null && teamId === this.awayTeamIdValue;
+  }
+
+  involvesTeam(teamId: string): boolean {
+    return this.isHome(teamId) || this.isAway(teamId);
+  }
+
+  isLineupMember(userId: string): boolean {
+    for (const lineup of this.lineupsValue.values()) {
+      if (lineup.includes(userId)) return true;
+    }
+    return false;
+  }
+
+  schedule(details: {
+    startsAt?: OptionalStartsAt;
+    venueCmsId?: OptionalVenueCmsId;
+  }): void {
+    this.assertBeforeStart();
+    if (!details.startsAt && !details.venueCmsId) {
+      throw new DomainError("At least one field is required");
+    }
+    if (details.startsAt) this.startsAtValue = details.startsAt;
+    if (details.venueCmsId) this.venueCmsIdValue = details.venueCmsId;
+    this.touch();
+  }
+
+  setLineup(teamId: string, userIds: unknown): void {
+    this.assertBeforeStart();
+    const id = requiredTrimmed(teamId, "teamId");
+    if (!this.involvesTeam(id)) {
+      throw new DomainError("Team is not part of this match");
+    }
+    this.lineupsValue.set(id, TeamMatchLineup.from(id, userIds, this.sport));
+    this.touch();
+  }
+
+  accept(awayTeamId: string): void {
+    const id = requiredTrimmed(awayTeamId, "awayTeamId");
+    if (this.statusValue.isDeclined) {
+      throw new DomainError("Challenge was declined");
+    }
+    if (this.statusValue.isCancelled) {
+      throw new DomainError("Challenge was cancelled");
+    }
+    if (this.statusValue.hasStarted) {
+      throw new TeamMatchAlreadyAcceptedError();
+    }
+    if (this.awayTeamIdValue && this.awayTeamIdValue !== id) {
+      throw new TeamMatchAlreadyAcceptedError();
+    }
+    if (id === this.homeTeamId) {
+      throw new DomainError("Cannot accept your own challenge");
+    }
+    if (this.statusValue.isScheduled && this.awayTeamIdValue === id) {
+      return;
+    }
+    this.awayTeamIdValue = id;
+    if (!this.lineupsValue.has(id)) {
+      this.lineupsValue.set(id, TeamMatchLineup.empty(id));
+    }
+    this.statusValue = TeamMatchStatus.SCHEDULED;
+    this.touch();
+  }
+
+  joinWithToken(token: TeamMatchChallengeToken, awayTeamId: string): void {
+    if (
+      !this.challengeTokenValue ||
+      !this.challengeTokenValue.equals(token)
+    ) {
+      throw new DomainError("token is invalid");
+    }
+    if (this.awayTeamIdValue) {
+      throw new TeamMatchAlreadyAcceptedError();
+    }
+    this.accept(awayTeamId);
+  }
+
+  decline(): void {
+    if (!this.statusValue.isPending) {
+      throw new DomainError("Only a pending challenge can be declined");
+    }
+    if (!this.awayTeamIdValue) {
+      throw new DomainError("Open challenges cannot be declined");
+    }
+    this.statusValue = TeamMatchStatus.DECLINED;
+    this.touch();
+  }
+
+  cancel(): void {
+    if (this.statusValue.hasStarted || this.statusValue.isTerminal) {
+      throw new DomainError("Cannot cancel after the match has started");
+    }
+    this.statusValue = TeamMatchStatus.CANCELLED;
+    this.touch();
+  }
+
+  assertCanStart(): void {
+    if (this.statusValue.isLive && this.scorecardValue) {
+      return;
+    }
+    if (!this.statusValue.isScheduled && !this.statusValue.isPending) {
+      throw new TeamMatchNotReadyError("Match cannot be started in this status");
+    }
+    if (!this.awayTeamIdValue) {
+      throw new TeamMatchNotReadyError("Opponent has not joined yet");
+    }
+    if (this.statusValue.isPending) {
+      throw new TeamMatchNotReadyError("Challenge has not been accepted");
+    }
+    const home = this.homeLineup();
+    const away = this.awayLineup();
+    if (!home.isValidFor(this.sport) || !away?.isValidFor(this.sport)) {
+      throw new TeamMatchNotReadyError(
+        `Both teams need a valid ${this.sport.value} lineup`,
+      );
+    }
+    if (this.sport.value === "golf" && home.userIds.length !== away.userIds.length) {
+      throw new TeamMatchNotReadyError("Golf lineups must be the same size");
+    }
+    if (this.sport.value !== "darts" && !this.venueCmsIdValue.value) {
+      throw new TeamMatchNotReadyError("venueCmsId is required to start");
+    }
+  }
+
+  start(scorecard: TeamMatchScorecard): void {
+    if (this.statusValue.isLive && this.scorecardValue) {
+      return;
+    }
+    this.assertCanStart();
+    if (!scorecard.sport.equals(this.sport)) {
+      throw new DomainError("Scorecard sport must match the team match");
+    }
+    this.scorecardValue = scorecard;
+    this.statusValue = TeamMatchStatus.LIVE;
+    if (!this.startsAtValue.isSet) {
+      this.startsAtValue = OptionalStartsAt.from(new Date());
+    }
+    this.touch();
+  }
+
+  complete(winnerTeamId: string | null): void {
+    if (this.statusValue.isCompleted) {
+      if (this.winnerTeamIdValue === winnerTeamId) return;
+      throw new DomainError("Match is already completed");
+    }
+    if (!this.statusValue.isLive) {
+      throw new DomainError("Only a live match can be completed");
+    }
+    if (winnerTeamId !== null) {
+      const id = requiredTrimmed(winnerTeamId, "winnerTeamId");
+      if (!this.involvesTeam(id)) {
+        throw new DomainError("winnerTeamId must be home or away");
+      }
+      this.winnerTeamIdValue = id;
+    } else {
+      this.winnerTeamIdValue = null;
+    }
+    this.statusValue = TeamMatchStatus.COMPLETED;
+    this.touch();
+  }
+
+  toSnapshot(): TeamMatchSnapshot {
+    const lineups = [...this.lineupsValue.values()].map((lineup) =>
+      lineup.toSnapshot(),
+    );
+    return {
+      id: this.id,
+      homeTeamId: this.homeTeamId,
+      awayTeamId: this.awayTeamIdValue,
+      sport: this.sport.value,
+      status: this.statusValue.value,
+      venueCmsId: this.venueCmsIdValue.value,
+      startsAt: this.startsAtValue.toIsoString(),
+      challengeToken: this.challengeTokenValue?.value ?? null,
+      createdBy: this.createdBy,
+      winnerTeamId: this.winnerTeamIdValue,
+      scorecard: this.scorecardValue?.toSnapshot() ?? null,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+      lineups,
+    };
+  }
+
+  private assertBeforeStart(): void {
+    if (this.statusValue.hasStarted || this.statusValue.isTerminal) {
+      throw new DomainError("Cannot change a match after it has started");
+    }
+  }
+
+  private touch(now = new Date()): void {
+    this.updatedAtValue = now;
+  }
+}

--- a/src/modules/team-matches/index.ts
+++ b/src/modules/team-matches/index.ts
@@ -1,0 +1,186 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { DartsMatchRepository } from "../darts/repositories/darts-match.repository";
+import { CreateDartsMatch } from "../darts/services/create-darts-match.service";
+import { GetDartsMatchById } from "../darts/services/get-darts-match-by-id.service";
+import { FriendProfileLookup } from "../friends/repositories/friendship.repository";
+import { GolfRoundRepository } from "../golf-round/repositories/golf-round.repository";
+import { CreateGolfRound } from "../golf-round/services/create-golf-round.service";
+import { GetGolfRoundById } from "../golf-round/services/get-golf-round-by-id.service";
+import { MatchRepository } from "../match/repositories/match.repository";
+import { CreateMatch } from "../match/services/create-match.service";
+import { GetMatchById } from "../match/services/get-match-by-id.service";
+import { OnScorecardLocked } from "../scorecards/on-scorecard-locked";
+import { TeamRepository } from "../teams/repositories/team.repository";
+import { VenueRepository } from "../venue/repositories/venue.repository";
+import { createTeamMatchesController } from "./controllers/team-matches.controller";
+import { PrismaTeamMatchRepository } from "./repositories/prisma-team-match.repository";
+import { TeamMatchRepository } from "./repositories/team-match.repository";
+import { createTeamMatchesRoutes } from "./routes/team-matches.routes";
+import { CompleteTeamMatchOnScorecardLock } from "./services/complete-on-scorecard-lock";
+import {
+  AcceptTeamMatch,
+  CancelTeamMatch,
+  CompleteTeamMatch,
+  CreateTeamMatch,
+  DeclineTeamMatch,
+  GetTeamMatch,
+  JoinTeamMatch,
+  ListMyTeamMatches,
+  ListTeamMatches,
+  ScheduleTeamMatch,
+  SetTeamMatchLineup,
+  StartTeamMatch,
+} from "./services/team-matches.service";
+
+export type CreateTeamMatchesModuleParams = {
+  prisma: PrismaClient;
+  teamRepository: TeamRepository;
+  venueRepository: VenueRepository;
+  matchRepository: MatchRepository;
+  golfRoundRepository: GolfRoundRepository;
+  dartsMatchRepository: DartsMatchRepository;
+  friendProfileLookup: FriendProfileLookup;
+  teamMatchRepository?: TeamMatchRepository;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type TeamMatchesModule = {
+  router: Router;
+  teamMatchRepository: TeamMatchRepository;
+  onScorecardLocked: OnScorecardLocked;
+};
+
+export function createTeamMatchesModule({
+  prisma,
+  teamRepository,
+  venueRepository,
+  matchRepository,
+  golfRoundRepository,
+  dartsMatchRepository,
+  friendProfileLookup,
+  teamMatchRepository: teamMatchRepositoryOverride,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreateTeamMatchesModuleParams): TeamMatchesModule {
+  const teamMatchRepository =
+    teamMatchRepositoryOverride ?? new PrismaTeamMatchRepository(prisma);
+
+  const getMatchById = new GetMatchById(matchRepository);
+  const getGolfRoundById = new GetGolfRoundById(golfRoundRepository);
+  const getDartsMatchById = new GetDartsMatchById(dartsMatchRepository);
+  const completeOnLock = new CompleteTeamMatchOnScorecardLock(
+    teamMatchRepository,
+  );
+
+  const controller = createTeamMatchesController({
+    createTeamMatch: new CreateTeamMatch(
+      teamRepository,
+      teamMatchRepository,
+      friendProfileLookup,
+    ),
+    joinTeamMatch: new JoinTeamMatch(
+      teamRepository,
+      teamMatchRepository,
+      friendProfileLookup,
+    ),
+    acceptTeamMatch: new AcceptTeamMatch(
+      teamRepository,
+      teamMatchRepository,
+      friendProfileLookup,
+    ),
+    declineTeamMatch: new DeclineTeamMatch(
+      teamRepository,
+      teamMatchRepository,
+      friendProfileLookup,
+    ),
+    scheduleTeamMatch: new ScheduleTeamMatch(
+      teamRepository,
+      teamMatchRepository,
+      friendProfileLookup,
+    ),
+    setTeamMatchLineup: new SetTeamMatchLineup(
+      teamRepository,
+      teamMatchRepository,
+      friendProfileLookup,
+    ),
+    startTeamMatch: new StartTeamMatch(
+      teamRepository,
+      teamMatchRepository,
+      friendProfileLookup,
+      venueRepository,
+      new CreateMatch(matchRepository, venueRepository),
+      new CreateGolfRound(golfRoundRepository, venueRepository),
+      new CreateDartsMatch(dartsMatchRepository, venueRepository),
+    ),
+    cancelTeamMatch: new CancelTeamMatch(
+      teamRepository,
+      teamMatchRepository,
+      friendProfileLookup,
+    ),
+    completeTeamMatch: new CompleteTeamMatch(
+      teamRepository,
+      teamMatchRepository,
+      friendProfileLookup,
+      getMatchById,
+      getGolfRoundById,
+      getDartsMatchById,
+    ),
+    getTeamMatch: new GetTeamMatch(
+      teamRepository,
+      teamMatchRepository,
+      friendProfileLookup,
+    ),
+    listTeamMatches: new ListTeamMatches(
+      teamRepository,
+      teamMatchRepository,
+      friendProfileLookup,
+    ),
+    listMyTeamMatches: new ListMyTeamMatches(
+      teamRepository,
+      teamMatchRepository,
+      friendProfileLookup,
+    ),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createTeamMatchesRoutes(controller, { requireAuth }),
+    teamMatchRepository,
+    onScorecardLocked: (event) => completeOnLock.execute(event),
+  };
+}
+
+export { createTeamMatchesController } from "./controllers/team-matches.controller";
+export { InMemoryTeamMatchRepository } from "./repositories/in-memory-team-match.repository";
+export { PrismaTeamMatchRepository } from "./repositories/prisma-team-match.repository";
+export type { TeamMatchRepository } from "./repositories/team-match.repository";
+export { TeamMatch } from "./entities/team-match";
+export { CompleteTeamMatchOnScorecardLock } from "./services/complete-on-scorecard-lock";
+export {
+  AcceptTeamMatch,
+  CancelTeamMatch,
+  CompleteTeamMatch,
+  CreateTeamMatch,
+  DeclineTeamMatch,
+  GetTeamMatch,
+  JoinTeamMatch,
+  ListMyTeamMatches,
+  ListTeamMatches,
+  ScheduleTeamMatch,
+  SetTeamMatchLineup,
+  StartTeamMatch,
+} from "./services/team-matches.service";
+export type {
+  PublicScorecard,
+  PublicTeamMatch,
+  PublicTeamRef,
+  PublicUser,
+} from "./services/team-matches.service";

--- a/src/modules/team-matches/repositories/in-memory-team-match.repository.ts
+++ b/src/modules/team-matches/repositories/in-memory-team-match.repository.ts
@@ -1,0 +1,59 @@
+import { TeamMatch } from "../entities/team-match";
+import { TeamMatchPersistenceError } from "../entities/team-match-persistence-error";
+import { TeamMatchRepository } from "./team-match.repository";
+
+export class InMemoryTeamMatchRepository implements TeamMatchRepository {
+  private readonly byId = new Map<string, TeamMatch>();
+
+  async findById(id: string): Promise<TeamMatch | null> {
+    return clone(this.byId.get(id) ?? null);
+  }
+
+  async findByChallengeToken(token: string): Promise<TeamMatch | null> {
+    const value = token.trim().toLowerCase();
+    for (const match of this.byId.values()) {
+      if (match.challengeToken?.value === value) {
+        return clone(match);
+      }
+    }
+    return null;
+  }
+
+  async findByScorecardId(scorecardId: string): Promise<TeamMatch | null> {
+    const id = scorecardId.trim();
+    for (const match of this.byId.values()) {
+      if (match.scorecard?.id === id) {
+        return clone(match);
+      }
+    }
+    return null;
+  }
+
+  async create(match: TeamMatch): Promise<TeamMatch> {
+    const stored = clone(match)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async persist(match: TeamMatch): Promise<TeamMatch> {
+    if (!this.byId.has(match.id)) {
+      throw new TeamMatchPersistenceError("Unable to save team match");
+    }
+    const stored = clone(match)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async listForTeams(teamIds: string[]): Promise<TeamMatch[]> {
+    const ids = new Set(teamIds);
+    return [...this.byId.values()]
+      .filter((match) => match.teamIds.some((id) => ids.has(id)))
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+      .map((match) => clone(match)!);
+  }
+}
+
+function clone(match: TeamMatch | null): TeamMatch | null {
+  if (!match) return null;
+  return TeamMatch.fromSnapshot(match.toSnapshot());
+}

--- a/src/modules/team-matches/repositories/prisma-team-match.repository.ts
+++ b/src/modules/team-matches/repositories/prisma-team-match.repository.ts
@@ -1,0 +1,245 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { TeamSport } from "../../teams/entities/team-sport";
+import { OptionalStartsAt } from "../entities/optional-starts-at";
+import { OptionalVenueCmsId } from "../entities/optional-venue-cms-id";
+import { TeamMatch } from "../entities/team-match";
+import { TeamMatchChallengeToken } from "../entities/team-match-challenge-token";
+import { TeamMatchLineup } from "../entities/team-match-lineup";
+import { TeamMatchPersistenceError } from "../entities/team-match-persistence-error";
+import { TeamMatchScorecard } from "../entities/team-match-scorecard";
+import { TeamMatchStatus } from "../entities/team-match-status";
+import { TeamMatchRepository } from "./team-match.repository";
+
+type LineupRow = {
+  teamId: string;
+  userId: string;
+  slot: number;
+};
+
+type TeamMatchRow = {
+  id: string;
+  homeTeamId: string;
+  awayTeamId: string | null;
+  sport: "padel" | "golf" | "darts";
+  status:
+    | "pending"
+    | "scheduled"
+    | "live"
+    | "completed"
+    | "declined"
+    | "cancelled";
+  venueCmsId: string | null;
+  startsAt: Date | null;
+  challengeToken: string | null;
+  createdBy: string;
+  winnerTeamId: string | null;
+  scorecardSport: string | null;
+  scorecardId: string | null;
+  scorecardPath: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  lineups: LineupRow[];
+};
+
+function toDomain(row: TeamMatchRow): TeamMatch {
+  const byTeam = new Map<string, string[]>();
+  const ordered = [...row.lineups].sort((a, b) => a.slot - b.slot);
+  for (const lineup of ordered) {
+    const ids = byTeam.get(lineup.teamId) ?? [];
+    ids.push(lineup.userId);
+    byTeam.set(lineup.teamId, ids);
+  }
+
+  return TeamMatch.rehydrate({
+    id: row.id,
+    homeTeamId: row.homeTeamId,
+    awayTeamId: row.awayTeamId,
+    sport: TeamSport.from(row.sport),
+    status: TeamMatchStatus.from(row.status),
+    venueCmsId: OptionalVenueCmsId.from(row.venueCmsId),
+    startsAt: OptionalStartsAt.from(row.startsAt),
+    challengeToken: row.challengeToken
+      ? TeamMatchChallengeToken.from(row.challengeToken)
+      : null,
+    createdBy: row.createdBy,
+    winnerTeamId: row.winnerTeamId,
+    scorecard:
+      row.scorecardId && row.scorecardSport && row.scorecardPath
+        ? TeamMatchScorecard.rehydrate({
+            sport: row.scorecardSport as "padel" | "golf" | "darts",
+            id: row.scorecardId,
+            path: row.scorecardPath,
+          })
+        : null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    lineups: [...byTeam.entries()].map(([teamId, userIds]) =>
+      TeamMatchLineup.rehydrate(teamId, userIds),
+    ),
+  });
+}
+
+const includeRelations = {
+  lineups: { orderBy: { slot: "asc" as const } },
+};
+
+export class PrismaTeamMatchRepository implements TeamMatchRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(id: string): Promise<TeamMatch | null> {
+    try {
+      const row = await this.prisma.teamMatch.findUnique({
+        where: { id },
+        include: includeRelations,
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new TeamMatchPersistenceError("Failed to load team match", {
+        cause: error,
+      });
+    }
+  }
+
+  async findByChallengeToken(token: string): Promise<TeamMatch | null> {
+    try {
+      const row = await this.prisma.teamMatch.findUnique({
+        where: { challengeToken: token.trim().toLowerCase() },
+        include: includeRelations,
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new TeamMatchPersistenceError("Failed to load team match", {
+        cause: error,
+      });
+    }
+  }
+
+  async findByScorecardId(scorecardId: string): Promise<TeamMatch | null> {
+    try {
+      const row = await this.prisma.teamMatch.findFirst({
+        where: { scorecardId: scorecardId.trim() },
+        include: includeRelations,
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new TeamMatchPersistenceError("Failed to load team match", {
+        cause: error,
+      });
+    }
+  }
+
+  async create(match: TeamMatch): Promise<TeamMatch> {
+    const snapshot = match.toSnapshot();
+    try {
+      const row = await this.prisma.teamMatch.create({
+        data: {
+          id: snapshot.id,
+          homeTeamId: snapshot.homeTeamId,
+          awayTeamId: snapshot.awayTeamId,
+          sport: snapshot.sport,
+          status: snapshot.status,
+          venueCmsId: snapshot.venueCmsId,
+          startsAt: match.startsAt,
+          challengeToken: snapshot.challengeToken,
+          createdBy: snapshot.createdBy,
+          winnerTeamId: snapshot.winnerTeamId,
+          scorecardSport: snapshot.scorecard?.sport ?? null,
+          scorecardId: snapshot.scorecard?.id ?? null,
+          scorecardPath: snapshot.scorecard?.path ?? null,
+          createdAt: match.createdAt,
+          updatedAt: match.updatedAt,
+          lineups: { create: lineupRows(snapshot) },
+        },
+        include: includeRelations,
+      });
+      return toDomain(row);
+    } catch (error) {
+      throw new TeamMatchPersistenceError("Failed to create team match", {
+        cause: error,
+      });
+    }
+  }
+
+  async persist(match: TeamMatch): Promise<TeamMatch> {
+    const snapshot = match.toSnapshot();
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.teamMatch.update({
+          where: { id: snapshot.id },
+          data: {
+            awayTeamId: snapshot.awayTeamId,
+            status: snapshot.status,
+            venueCmsId: snapshot.venueCmsId,
+            startsAt: match.startsAt,
+            challengeToken: snapshot.challengeToken,
+            winnerTeamId: snapshot.winnerTeamId,
+            scorecardSport: snapshot.scorecard?.sport ?? null,
+            scorecardId: snapshot.scorecard?.id ?? null,
+            scorecardPath: snapshot.scorecard?.path ?? null,
+            updatedAt: match.updatedAt,
+          },
+        });
+        await tx.teamMatchLineup.deleteMany({
+          where: { teamMatchId: snapshot.id },
+        });
+        if (snapshot.lineups.some((lineup) => lineup.userIds.length > 0)) {
+          await tx.teamMatchLineup.createMany({
+            data: lineupRows(snapshot),
+          });
+        }
+      });
+
+      const reloaded = await this.findById(snapshot.id);
+      if (!reloaded) {
+        throw new TeamMatchPersistenceError("Failed to load team match");
+      }
+      return reloaded;
+    } catch (error) {
+      if (error instanceof TeamMatchPersistenceError) throw error;
+      throw new TeamMatchPersistenceError("Failed to save team match", {
+        cause: error,
+      });
+    }
+  }
+
+  async listForTeams(teamIds: string[]): Promise<TeamMatch[]> {
+    if (teamIds.length === 0) return [];
+    try {
+      const rows = await this.prisma.teamMatch.findMany({
+        where: {
+          OR: [
+            { homeTeamId: { in: teamIds } },
+            { awayTeamId: { in: teamIds } },
+          ],
+        },
+        include: includeRelations,
+        orderBy: { updatedAt: "desc" },
+      });
+      return rows.map(toDomain);
+    } catch (error) {
+      throw new TeamMatchPersistenceError("Failed to list team matches", {
+        cause: error,
+      });
+    }
+  }
+}
+
+function lineupRows(snapshot: ReturnType<TeamMatch["toSnapshot"]>) {
+  const rows: Array<{
+    teamMatchId: string;
+    teamId: string;
+    userId: string;
+    slot: number;
+  }> = [];
+  for (const lineup of snapshot.lineups) {
+    lineup.userIds.forEach((userId, index) => {
+      rows.push({
+        teamMatchId: snapshot.id,
+        teamId: lineup.teamId,
+        userId,
+        slot: index + 1,
+      });
+    });
+  }
+  return rows;
+}

--- a/src/modules/team-matches/repositories/team-match.repository.ts
+++ b/src/modules/team-matches/repositories/team-match.repository.ts
@@ -1,0 +1,10 @@
+import { TeamMatch } from "../entities/team-match";
+
+export interface TeamMatchRepository {
+  findById(id: string): Promise<TeamMatch | null>;
+  findByChallengeToken(token: string): Promise<TeamMatch | null>;
+  findByScorecardId(scorecardId: string): Promise<TeamMatch | null>;
+  create(match: TeamMatch): Promise<TeamMatch>;
+  persist(match: TeamMatch): Promise<TeamMatch>;
+  listForTeams(teamIds: string[]): Promise<TeamMatch[]>;
+}

--- a/src/modules/team-matches/routes/team-matches.routes.ts
+++ b/src/modules/team-matches/routes/team-matches.routes.ts
@@ -1,0 +1,78 @@
+import { Router } from "express";
+
+import { createTeamMatchesController } from "../controllers/team-matches.controller";
+
+export function createTeamMatchesRoutes(
+  controller: ReturnType<typeof createTeamMatchesController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.post("/api/team-matches", options.requireAuth, (req, res) => {
+    void controller.create(req, res);
+  });
+
+  router.post("/api/team-matches/join", options.requireAuth, (req, res) => {
+    void controller.join(req, res);
+  });
+
+  router.get("/api/team-matches/mine", options.requireAuth, (req, res) => {
+    void controller.listMine(req, res);
+  });
+
+  router.get("/api/team-matches", options.requireAuth, (req, res) => {
+    void controller.list(req, res);
+  });
+
+  router.get("/api/team-matches/:id", options.requireAuth, (req, res) => {
+    void controller.get(req, res);
+  });
+
+  router.patch("/api/team-matches/:id", options.requireAuth, (req, res) => {
+    void controller.schedule(req, res);
+  });
+
+  router.put("/api/team-matches/:id/lineup", options.requireAuth, (req, res) => {
+    void controller.lineup(req, res);
+  });
+
+  router.post("/api/team-matches/:id/accept", options.requireAuth, (req, res) => {
+    void controller.accept(req, res);
+  });
+
+  router.post(
+    "/api/team-matches/:id/decline",
+    options.requireAuth,
+    (req, res) => {
+      void controller.decline(req, res);
+    },
+  );
+
+  router.post("/api/team-matches/:id/start", options.requireAuth, (req, res) => {
+    void controller.start(req, res);
+  });
+
+  router.post("/api/team-matches/:id/cancel", options.requireAuth, (req, res) => {
+    void controller.cancel(req, res);
+  });
+
+  router.post(
+    "/api/team-matches/:id/complete",
+    options.requireAuth,
+    (req, res) => {
+      void controller.complete(req, res);
+    },
+  );
+
+  router.get("/api/teams/:id/matches", options.requireAuth, (req, res) => {
+    void controller.listForTeam(req, res);
+  });
+
+  return router;
+}

--- a/src/modules/team-matches/services/complete-on-scorecard-lock.ts
+++ b/src/modules/team-matches/services/complete-on-scorecard-lock.ts
@@ -1,0 +1,44 @@
+import { ScorecardLockedEvent } from "../../scorecards/on-scorecard-locked";
+import { TeamMatch } from "../entities/team-match";
+import { TeamMatchPersistenceError } from "../entities/team-match-persistence-error";
+import { TeamMatchRepository } from "../repositories/team-match.repository";
+import { inferGolfWinner } from "./team-matches.service";
+
+export class CompleteTeamMatchOnScorecardLock {
+  constructor(private readonly matches: TeamMatchRepository) {}
+
+  async execute(event: ScorecardLockedEvent): Promise<void> {
+    try {
+      const match = await this.matches.findByScorecardId(event.scorecardId);
+      if (!match || !match.status.isLive) return;
+
+      const winnerTeamId = inferWinnerFromEvent(match, event);
+      match.complete(winnerTeamId);
+      await this.matches.persist(match);
+    } catch (error) {
+      if (error instanceof TeamMatchPersistenceError) return;
+      console.error("Failed to complete team match from scorecard lock", error);
+    }
+  }
+}
+
+function inferWinnerFromEvent(
+  match: TeamMatch,
+  event: ScorecardLockedEvent,
+): string | null {
+  if (event.sport === "padel" && event.padelWinner) {
+    return event.padelWinner === "A" ? match.homeTeamId : match.awayTeamId;
+  }
+  if (event.sport === "darts" && event.dartsWinnerUserId) {
+    if (match.homeLineup().includes(event.dartsWinnerUserId)) {
+      return match.homeTeamId;
+    }
+    if (match.awayLineup()?.includes(event.dartsWinnerUserId)) {
+      return match.awayTeamId;
+    }
+  }
+  if (event.sport === "golf" && event.golf) {
+    return inferGolfWinner(match, event.golf);
+  }
+  return null;
+}

--- a/src/modules/team-matches/services/seat-lineups.ts
+++ b/src/modules/team-matches/services/seat-lineups.ts
@@ -1,0 +1,80 @@
+import { FriendProfile } from "../../friends/repositories/friendship.repository";
+import { DartsPlayerInput } from "../../darts/entities/darts-player";
+import { GolfPlayerInput } from "../../golf-round/entities/golf-player";
+import { PairingsInput } from "../../match/entities/pairings";
+import { TeamMatch } from "../entities/team-match";
+
+export type SeatedProfile = Pick<FriendProfile, "userId" | "displayName">;
+
+function named(profile: SeatedProfile) {
+  return {
+    displayName: profile.displayName,
+    isGuest: false,
+    userId: profile.userId,
+  };
+}
+
+export function pairingsFromLineups(
+  match: TeamMatch,
+  profiles: Map<string, SeatedProfile>,
+): PairingsInput {
+  const home = match.homeLineup().userIds;
+  const away = match.awayLineup()?.userIds ?? [];
+  return {
+    teamA: [named(must(profiles, home[0])), named(must(profiles, home[1]))],
+    teamB: [named(must(profiles, away[0])), named(must(profiles, away[1]))],
+  };
+}
+
+export function golfPlayersFromLineups(
+  match: TeamMatch,
+  profiles: Map<string, SeatedProfile>,
+): GolfPlayerInput[] {
+  const home = match.homeLineup().userIds;
+  const away = match.awayLineup()?.userIds ?? [];
+  const players: GolfPlayerInput[] = [];
+  let slot = 1 as 1 | 2 | 3 | 4;
+  for (const userId of [...home, ...away]) {
+    const profile = must(profiles, userId);
+    players.push({
+      slot,
+      displayName: profile.displayName,
+      isGuest: false,
+      userId: profile.userId,
+    });
+    slot = (slot + 1) as 1 | 2 | 3 | 4;
+  }
+  return players;
+}
+
+export function dartsPlayersFromLineups(
+  match: TeamMatch,
+  profiles: Map<string, SeatedProfile>,
+): DartsPlayerInput[] {
+  const home = match.homeLineup().userIds;
+  const away = match.awayLineup()?.userIds ?? [];
+  return [...home, ...away].map((userId, index) => {
+    const profile = must(profiles, userId);
+    return {
+      slot: index + 1,
+      displayName: profile.displayName,
+      isGuest: false,
+      userId: profile.userId,
+    };
+  });
+}
+
+function must(
+  profiles: Map<string, SeatedProfile>,
+  userId: string | undefined,
+): SeatedProfile {
+  if (!userId) {
+    throw new Error("lineup is missing a player");
+  }
+  return (
+    profiles.get(userId) ?? {
+      userId,
+      displayName: "Player",
+    }
+  );
+}

--- a/src/modules/team-matches/services/team-matches.service.test.ts
+++ b/src/modules/team-matches/services/team-matches.service.test.ts
@@ -1,0 +1,319 @@
+import { InMemoryDartsMatchRepository } from "../../darts/repositories/in-memory-darts-match.repository";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { InMemoryGolfRoundRepository } from "../../golf-round/repositories/in-memory-golf-round.repository";
+import { InMemoryMatchRepository } from "../../match/repositories/in-memory-match.repository";
+import { Team } from "../../teams/entities/team";
+import { TeamName } from "../../teams/entities/team-name";
+import { TeamSport } from "../../teams/entities/team-sport";
+import { InMemoryTeamRepository } from "../../teams/repositories/in-memory-team.repository";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { TeamMatchForbiddenError } from "../entities/team-match-forbidden-error";
+import { TeamMatchNotReadyError } from "../entities/team-match-not-ready-error";
+import { TeamMatchSportMismatchError } from "../entities/team-match-sport-mismatch-error";
+import { InMemoryTeamMatchRepository } from "../repositories/in-memory-team-match.repository";
+import {
+  AcceptTeamMatch,
+  CancelTeamMatch,
+  CompleteTeamMatch,
+  CreateTeamMatch,
+  DeclineTeamMatch,
+  JoinTeamMatch,
+  ListMyTeamMatches,
+  ScheduleTeamMatch,
+  SetTeamMatchLineup,
+  StartTeamMatch,
+} from "./team-matches.service";
+import { CreateDartsMatch } from "../../darts/services/create-darts-match.service";
+import { CreateGolfRound } from "../../golf-round/services/create-golf-round.service";
+import { CreateMatch } from "../../match/services/create-match.service";
+
+async function becomeFriends(
+  friendships: InMemoryFriendshipRepository,
+  a: string,
+  b: string,
+) {
+  const pending = await friendships.createPending(a, b);
+  await friendships.accept(pending.id);
+}
+
+async function seedTeam(
+  teams: InMemoryTeamRepository,
+  friendships: InMemoryFriendshipRepository,
+  ownerId: string,
+  name: string,
+  sport: string,
+  extraMemberIds: string[] = [],
+) {
+  const team = Team.create({
+    name: TeamName.from(name),
+    sport: TeamSport.from(sport),
+    createdBy: ownerId,
+  });
+  for (const memberId of extraMemberIds) {
+    await becomeFriends(friendships, ownerId, memberId);
+    team.inviteFriend(ownerId, memberId);
+  }
+  return teams.create(team);
+}
+
+function setup() {
+  const teams = new InMemoryTeamRepository();
+  const matches = new InMemoryTeamMatchRepository();
+  const friendships = new InMemoryFriendshipRepository();
+  const profiles = new InMemoryFriendProfileLookup();
+  const venues = new InMemoryVenueRepository();
+  const padel = new InMemoryMatchRepository();
+  const golf = new InMemoryGolfRoundRepository();
+  const darts = new InMemoryDartsMatchRepository();
+
+  for (const [userId, displayName, handle] of [
+    ["user-a", "Alex", "alex"],
+    ["user-a2", "Avery", "avery"],
+    ["user-b", "Blake", "blake"],
+    ["user-b2", "Blair", "blair"],
+    ["user-c", "Casey", "casey"],
+  ] as const) {
+    profiles.seed({ userId, displayName, handle, avatarUrl: null });
+  }
+
+  return {
+    teams,
+    matches,
+    friendships,
+    profiles,
+    venues,
+    padel,
+    golf,
+    darts,
+    create: new CreateTeamMatch(teams, matches, profiles),
+    join: new JoinTeamMatch(teams, matches, profiles),
+    accept: new AcceptTeamMatch(teams, matches, profiles),
+    decline: new DeclineTeamMatch(teams, matches, profiles),
+    schedule: new ScheduleTeamMatch(teams, matches, profiles),
+    lineup: new SetTeamMatchLineup(teams, matches, profiles),
+    cancel: new CancelTeamMatch(teams, matches, profiles),
+    complete: new CompleteTeamMatch(teams, matches, profiles),
+    listMine: new ListMyTeamMatches(teams, matches, profiles),
+    start: new StartTeamMatch(
+      teams,
+      matches,
+      profiles,
+      venues,
+      new CreateMatch(padel, venues),
+      new CreateGolfRound(golf, venues),
+      new CreateDartsMatch(darts, venues),
+    ),
+  };
+}
+
+describe("team match services", () => {
+  test("creates a targeted challenge and rejects sport mismatch", async () => {
+    const ctx = setup();
+    const home = await seedTeam(ctx.teams, ctx.friendships, "user-a", "Smash", "padel");
+    const away = await seedTeam(ctx.teams, ctx.friendships, "user-b", "Drive", "golf");
+
+    await expect(
+      ctx.create.execute({
+        userId: "user-a",
+        homeTeamId: home.id,
+        awayTeamId: away.id,
+      }),
+    ).rejects.toBeInstanceOf(TeamMatchSportMismatchError);
+
+    const golfAway = await seedTeam(
+      ctx.teams,
+      ctx.friendships,
+      "user-c",
+      "Walls",
+      "padel",
+    );
+    const created = await ctx.create.execute({
+      userId: "user-a",
+      homeTeamId: home.id,
+      awayTeamId: golfAway.id,
+      venueCmsId: "sanity-court-1",
+    });
+    expect(created.match).toMatchObject({
+      sport: "padel",
+      status: "pending",
+      homeTeam: { id: home.id, name: "Smash" },
+      awayTeam: { id: golfAway.id, name: "Walls" },
+      challengeToken: null,
+      viewer: { role: "home_staff" },
+    });
+  });
+
+  test("open challenge join, accept/decline, lineup, schedule, start, complete", async () => {
+    const ctx = setup();
+    await ctx.venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-court-1"),
+        VenueName.from("Padel Club"),
+        Slug.from("padel-club"),
+      ),
+      { refreshDetails: false },
+    );
+
+    const home = await seedTeam(
+      ctx.teams,
+      ctx.friendships,
+      "user-a",
+      "Smash",
+      "padel",
+      ["user-a2"],
+    );
+    const away = await seedTeam(
+      ctx.teams,
+      ctx.friendships,
+      "user-b",
+      "Walls",
+      "padel",
+      ["user-b2"],
+    );
+
+    const open = await ctx.create.execute({
+      userId: "user-a",
+      homeTeamId: home.id,
+      generateChallengeLink: true,
+      venueCmsId: "sanity-court-1",
+    });
+    expect(open.match.challengeToken).toHaveLength(32);
+    expect(open.match.awayTeam).toBeNull();
+
+    const joined = await ctx.join.execute({
+      userId: "user-b",
+      token: open.match.challengeToken,
+      teamId: away.id,
+    });
+    expect(joined.match.status).toBe("scheduled");
+    expect(joined.match.awayTeam?.id).toBe(away.id);
+
+    const targeted = await ctx.create.execute({
+      userId: "user-a",
+      homeTeamId: home.id,
+      awayTeamId: away.id,
+      venueCmsId: "sanity-court-1",
+    });
+    await expect(
+      ctx.accept.execute({ userId: "user-a", matchId: targeted.match.id }),
+    ).rejects.toBeInstanceOf(TeamMatchForbiddenError);
+    const declined = await ctx.decline.execute({
+      userId: "user-b",
+      matchId: targeted.match.id,
+    });
+    expect(declined.match.status).toBe("declined");
+
+    const accepted = await ctx.create.execute({
+      userId: "user-a",
+      homeTeamId: home.id,
+      awayTeamId: away.id,
+      venueCmsId: "sanity-court-1",
+    });
+    await ctx.accept.execute({ userId: "user-b", matchId: accepted.match.id });
+    await ctx.schedule.execute({
+      userId: "user-a",
+      matchId: accepted.match.id,
+      startsAt: "2026-09-08T18:00:00.000Z",
+      hasStartsAt: true,
+      hasVenueCmsId: false,
+    });
+    await ctx.lineup.execute({
+      userId: "user-a",
+      matchId: accepted.match.id,
+      userIds: ["user-a", "user-a2"],
+    });
+    await ctx.lineup.execute({
+      userId: "user-b",
+      matchId: accepted.match.id,
+      userIds: ["user-b", "user-b2"],
+    });
+
+    const started = await ctx.start.execute({
+      userId: "user-a",
+      matchId: accepted.match.id,
+    });
+    expect(started.match.status).toBe("live");
+    expect(started.scorecard).toMatchObject({
+      sport: "padel",
+      path: `/padel/${started.scorecard.id}`,
+    });
+    expect(await ctx.padel.findById(started.scorecard.id)).not.toBeNull();
+
+    const completed = await ctx.complete.execute({
+      userId: "user-a",
+      matchId: accepted.match.id,
+      winnerTeamId: home.id,
+    });
+    expect(completed.match).toMatchObject({
+      status: "completed",
+      winnerTeamId: home.id,
+    });
+
+    const mine = await ctx.listMine.execute({ userId: "user-a" });
+    expect(mine.upcoming.some((row) => row.id === joined.match.id)).toBe(true);
+    expect(mine.recent.some((row) => row.id === completed.match.id)).toBe(true);
+  });
+
+  test("member cannot create, cancel, or set the other team's lineup", async () => {
+    const ctx = setup();
+    const home = await seedTeam(
+      ctx.teams,
+      ctx.friendships,
+      "user-a",
+      "Smash",
+      "darts",
+      ["user-a2"],
+    );
+    const away = await seedTeam(
+      ctx.teams,
+      ctx.friendships,
+      "user-b",
+      "Arrows",
+      "darts",
+    );
+
+    await expect(
+      ctx.create.execute({
+        userId: "user-a2",
+        homeTeamId: home.id,
+        awayTeamId: away.id,
+      }),
+    ).rejects.toBeInstanceOf(TeamMatchForbiddenError);
+
+    const created = await ctx.create.execute({
+      userId: "user-a",
+      homeTeamId: home.id,
+      awayTeamId: away.id,
+    });
+    await expect(
+      ctx.cancel.execute({ userId: "user-b", matchId: created.match.id }),
+    ).rejects.toBeInstanceOf(TeamMatchForbiddenError);
+    await expect(
+      ctx.lineup.execute({
+        userId: "user-a",
+        matchId: created.match.id,
+        teamId: away.id,
+        userIds: ["user-b"],
+      }),
+    ).rejects.toBeInstanceOf(TeamMatchForbiddenError);
+  });
+
+  test("cannot start without accepted opponent or valid lineups", async () => {
+    const ctx = setup();
+    const home = await seedTeam(ctx.teams, ctx.friendships, "user-a", "Smash", "darts");
+    const away = await seedTeam(ctx.teams, ctx.friendships, "user-b", "Arrows", "darts");
+    const created = await ctx.create.execute({
+      userId: "user-a",
+      homeTeamId: home.id,
+      awayTeamId: away.id,
+    });
+    await expect(
+      ctx.start.execute({ userId: "user-a", matchId: created.match.id }),
+    ).rejects.toBeInstanceOf(TeamMatchNotReadyError);
+  });
+});

--- a/src/modules/team-matches/services/team-matches.service.ts
+++ b/src/modules/team-matches/services/team-matches.service.ts
@@ -1,0 +1,846 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { CreateDartsMatch } from "../../darts/services/create-darts-match.service";
+import { GetDartsMatchById } from "../../darts/services/get-darts-match-by-id.service";
+import {
+  FriendProfile,
+  FriendProfileLookup,
+} from "../../friends/repositories/friendship.repository";
+import { CreateGolfRound } from "../../golf-round/services/create-golf-round.service";
+import { GetGolfRoundById } from "../../golf-round/services/get-golf-round-by-id.service";
+import { CreateMatch } from "../../match/services/create-match.service";
+import { GetMatchById } from "../../match/services/get-match-by-id.service";
+import { Team } from "../../teams/entities/team";
+import { TeamForbiddenError } from "../../teams/entities/team-forbidden-error";
+import { TeamNotFoundError } from "../../teams/entities/team-not-found-error";
+import { TeamSport } from "../../teams/entities/team-sport";
+import { TeamRepository } from "../../teams/repositories/team.repository";
+import { CmsId } from "../../venue/entities/cms-id";
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { defaultNineHoleCourse } from "../../organised-games/services/default-golf-course";
+import { OptionalStartsAt } from "../entities/optional-starts-at";
+import { OptionalVenueCmsId } from "../entities/optional-venue-cms-id";
+import { TeamMatch } from "../entities/team-match";
+import { TeamMatchAlreadyAcceptedError } from "../entities/team-match-already-accepted-error";
+import { TeamMatchChallengeToken } from "../entities/team-match-challenge-token";
+import { TeamMatchForbiddenError } from "../entities/team-match-forbidden-error";
+import { TeamMatchNotFoundError } from "../entities/team-match-not-found-error";
+import { TeamMatchNotReadyError } from "../entities/team-match-not-ready-error";
+import { TeamMatchScorecard } from "../entities/team-match-scorecard";
+import { TeamMatchSportMismatchError } from "../entities/team-match-sport-mismatch-error";
+import { TeamMatchRepository } from "../repositories/team-match.repository";
+import {
+  dartsPlayersFromLineups,
+  golfPlayersFromLineups,
+  pairingsFromLineups,
+  SeatedProfile,
+} from "./seat-lineups";
+
+export type PublicUser = {
+  id: string;
+  displayName: string;
+  handle: string;
+  avatarUrl: string | null;
+};
+
+export type PublicTeamRef = {
+  id: string;
+  name: string;
+  sport: "padel" | "golf" | "darts";
+};
+
+export type PublicScorecard = {
+  sport: "padel" | "golf" | "darts";
+  id: string;
+  path: string;
+};
+
+export type PublicTeamMatch = {
+  id: string;
+  sport: "padel" | "golf" | "darts";
+  status:
+    | "pending"
+    | "scheduled"
+    | "live"
+    | "completed"
+    | "declined"
+    | "cancelled";
+  homeTeam: PublicTeamRef;
+  awayTeam: PublicTeamRef | null;
+  venueCmsId: string | null;
+  startsAt: string | null;
+  challengeToken: string | null;
+  lineups: {
+    home: PublicUser[];
+    away: PublicUser[];
+  };
+  scorecard: PublicScorecard | null;
+  winnerTeamId: string | null;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+  viewer: {
+    role: "home_staff" | "away_staff" | "member";
+    teamId: string | null;
+  };
+};
+
+async function resolveProfile(
+  lookup: FriendProfileLookup,
+  userId: string,
+): Promise<FriendProfile> {
+  const profile = await lookup.findByUserId(userId);
+  if (profile) return profile;
+  return {
+    userId,
+    displayName: "Player",
+    handle: userId.slice(0, 8),
+    avatarUrl: null,
+  };
+}
+
+function toPublicUser(profile: FriendProfile): PublicUser {
+  return {
+    id: profile.userId,
+    displayName: profile.displayName,
+    handle: profile.handle,
+    avatarUrl: profile.avatarUrl,
+  };
+}
+
+function toTeamRef(team: Team): PublicTeamRef {
+  return {
+    id: team.id,
+    name: team.name.value,
+    sport: team.sport.value,
+  };
+}
+
+function isStaff(team: Team, userId: string): boolean {
+  const membership = team.membershipOf(userId);
+  return membership?.status.isActive === true && membership.role.canInvite;
+}
+
+function requireStaff(team: Team, userId: string, message: string): void {
+  if (!isStaff(team, userId)) {
+    throw new TeamMatchForbiddenError(message);
+  }
+}
+
+function viewerRole(
+  userId: string,
+  home: Team,
+  away: Team | null,
+): PublicTeamMatch["viewer"] {
+  if (isStaff(home, userId)) {
+    return { role: "home_staff", teamId: home.id };
+  }
+  if (away && isStaff(away, userId)) {
+    return { role: "away_staff", teamId: away.id };
+  }
+  if (home.isActiveMember(userId)) {
+    return { role: "member", teamId: home.id };
+  }
+  if (away?.isActiveMember(userId)) {
+    return { role: "member", teamId: away.id };
+  }
+  return { role: "member", teamId: null };
+}
+
+function assertCanView(userId: string, home: Team, away: Team | null): void {
+  if (home.isMember(userId) || away?.isMember(userId)) return;
+  throw new TeamMatchForbiddenError("Only a participating team member can view");
+}
+
+async function loadTeam(teams: TeamRepository, teamId: string): Promise<Team> {
+  const id = requiredTrimmed(teamId, "team id");
+  const team = await teams.findById(id);
+  if (!team) throw new TeamNotFoundError();
+  return team;
+}
+
+async function loadMatch(
+  matches: TeamMatchRepository,
+  matchId: string,
+): Promise<TeamMatch> {
+  const id = requiredTrimmed(matchId, "team match id");
+  const match = await matches.findById(id);
+  if (!match) throw new TeamMatchNotFoundError();
+  return match;
+}
+
+async function toPublicMatch(
+  match: TeamMatch,
+  home: Team,
+  away: Team | null,
+  lookup: FriendProfileLookup,
+  viewerUserId: string,
+): Promise<PublicTeamMatch> {
+  const snapshot = match.toSnapshot();
+  const homeUsers: PublicUser[] = [];
+  for (const userId of match.homeLineup().userIds) {
+    homeUsers.push(toPublicUser(await resolveProfile(lookup, userId)));
+  }
+  const awayUsers: PublicUser[] = [];
+  for (const userId of match.awayLineup()?.userIds ?? []) {
+    awayUsers.push(toPublicUser(await resolveProfile(lookup, userId)));
+  }
+  const viewer = viewerRole(viewerUserId, home, away);
+  return {
+    id: snapshot.id,
+    sport: snapshot.sport,
+    status: snapshot.status,
+    homeTeam: toTeamRef(home),
+    awayTeam: away ? toTeamRef(away) : null,
+    venueCmsId: snapshot.venueCmsId,
+    startsAt: snapshot.startsAt,
+    challengeToken:
+      viewer.role === "home_staff" ? snapshot.challengeToken : null,
+    lineups: { home: homeUsers, away: awayUsers },
+    scorecard: snapshot.scorecard,
+    winnerTeamId: snapshot.winnerTeamId,
+    createdBy: snapshot.createdBy,
+    createdAt: snapshot.createdAt,
+    updatedAt: snapshot.updatedAt,
+    viewer,
+  };
+}
+
+export class TeamMatchContext {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async loadSides(match: TeamMatch): Promise<{ home: Team; away: Team | null }> {
+    const home = await loadTeam(this.teams, match.homeTeamId);
+    const away = match.awayTeamId
+      ? await loadTeam(this.teams, match.awayTeamId)
+      : null;
+    return { home, away };
+  }
+
+  async toPublic(match: TeamMatch, userId: string): Promise<PublicTeamMatch> {
+    const { home, away } = await this.loadSides(match);
+    return toPublicMatch(match, home, away, this.profiles, userId);
+  }
+}
+
+export class CreateTeamMatch {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    homeTeamId: unknown;
+    awayTeamId?: unknown;
+    generateChallengeLink?: unknown;
+    venueCmsId?: unknown;
+    startsAt?: unknown;
+  }): Promise<{ match: PublicTeamMatch }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const home = await loadTeam(this.teams, String(input.homeTeamId ?? ""));
+    requireStaff(home, userId, "Only an owner or captain can create a challenge");
+
+    const generateLink = input.generateChallengeLink === true;
+    const awayId =
+      input.awayTeamId == null || input.awayTeamId === ""
+        ? null
+        : requiredTrimmed(input.awayTeamId, "awayTeamId");
+
+    if (!awayId && !generateLink) {
+      throw new DomainError("awayTeamId or generateChallengeLink is required");
+    }
+
+    let away: Team | null = null;
+    if (awayId) {
+      away = await loadTeam(this.teams, awayId);
+      if (!away.sport.equals(home.sport)) {
+        throw new TeamMatchSportMismatchError();
+      }
+    }
+
+    const match = TeamMatch.create({
+      homeTeamId: home.id,
+      awayTeamId: away?.id ?? null,
+      sport: home.sport,
+      createdBy: userId,
+      venueCmsId: OptionalVenueCmsId.from(input.venueCmsId),
+      startsAt: OptionalStartsAt.from(input.startsAt ?? null),
+      generateChallengeLink: generateLink && !away,
+    });
+    const saved = await this.matches.create(match);
+    return {
+      match: await toPublicMatch(saved, home, away, this.profiles, userId),
+    };
+  }
+}
+
+export class JoinTeamMatch {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    token: unknown;
+    teamId: unknown;
+  }): Promise<{ match: PublicTeamMatch }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const token = TeamMatchChallengeToken.from(input.token);
+    const joining = await loadTeam(this.teams, String(input.teamId ?? ""));
+    requireStaff(joining, userId, "Only an owner or captain can join a challenge");
+
+    const match = await this.matches.findByChallengeToken(token.value);
+    if (!match) throw new TeamMatchNotFoundError();
+    if (!joining.sport.equals(match.sport)) {
+      throw new TeamMatchSportMismatchError();
+    }
+
+    match.joinWithToken(token, joining.id);
+    const saved = await this.matches.persist(match);
+    const home = await loadTeam(this.teams, saved.homeTeamId);
+    return {
+      match: await toPublicMatch(saved, home, joining, this.profiles, userId),
+    };
+  }
+}
+
+export class AcceptTeamMatch {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    matchId: string;
+  }): Promise<{ match: PublicTeamMatch }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const match = await loadMatch(this.matches, input.matchId);
+    if (!match.awayTeamId) {
+      throw new DomainError("Open challenges are joined via token");
+    }
+    const away = await loadTeam(this.teams, match.awayTeamId);
+    requireStaff(away, userId, "Only the challenged team's owner or captain can accept");
+    if (!away.sport.equals(match.sport)) {
+      throw new TeamMatchSportMismatchError();
+    }
+    match.accept(away.id);
+    const saved = await this.matches.persist(match);
+    const home = await loadTeam(this.teams, saved.homeTeamId);
+    return {
+      match: await toPublicMatch(saved, home, away, this.profiles, userId),
+    };
+  }
+}
+
+export class DeclineTeamMatch {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    matchId: string;
+  }): Promise<{ match: PublicTeamMatch }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const match = await loadMatch(this.matches, input.matchId);
+    if (!match.awayTeamId) {
+      throw new DomainError("Open challenges are joined via token");
+    }
+    const away = await loadTeam(this.teams, match.awayTeamId);
+    requireStaff(away, userId, "Only the challenged team's owner or captain can decline");
+    match.decline();
+    const saved = await this.matches.persist(match);
+    const home = await loadTeam(this.teams, saved.homeTeamId);
+    return {
+      match: await toPublicMatch(saved, home, away, this.profiles, userId),
+    };
+  }
+}
+
+export class ScheduleTeamMatch {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    matchId: string;
+    startsAt?: unknown;
+    venueCmsId?: unknown;
+    hasStartsAt: boolean;
+    hasVenueCmsId: boolean;
+  }): Promise<{ match: PublicTeamMatch }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const match = await loadMatch(this.matches, input.matchId);
+    const home = await loadTeam(this.teams, match.homeTeamId);
+    requireStaff(home, userId, "Only the challenging team's owner or captain can schedule");
+    match.schedule({
+      ...(input.hasStartsAt
+        ? { startsAt: OptionalStartsAt.from(input.startsAt ?? null) }
+        : {}),
+      ...(input.hasVenueCmsId
+        ? { venueCmsId: OptionalVenueCmsId.from(input.venueCmsId) }
+        : {}),
+    });
+    const saved = await this.matches.persist(match);
+    const away = saved.awayTeamId
+      ? await loadTeam(this.teams, saved.awayTeamId)
+      : null;
+    return {
+      match: await toPublicMatch(saved, home, away, this.profiles, userId),
+    };
+  }
+}
+
+export class SetTeamMatchLineup {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    matchId: string;
+    userIds: unknown;
+    teamId?: unknown;
+  }): Promise<{ match: PublicTeamMatch }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const match = await loadMatch(this.matches, input.matchId);
+    const home = await loadTeam(this.teams, match.homeTeamId);
+    const away = match.awayTeamId
+      ? await loadTeam(this.teams, match.awayTeamId)
+      : null;
+
+    let team: Team;
+    if (input.teamId != null && input.teamId !== "") {
+      const requested = requiredTrimmed(input.teamId, "teamId");
+      if (requested === home.id) team = home;
+      else if (away && requested === away.id) team = away;
+      else throw new DomainError("Team is not part of this match");
+    } else if (isStaff(home, userId) && !(away && isStaff(away, userId))) {
+      team = home;
+    } else if (away && isStaff(away, userId) && !isStaff(home, userId)) {
+      team = away;
+    } else if (isStaff(home, userId) && away && isStaff(away, userId)) {
+      throw new DomainError("teamId is required when you staff both teams");
+    } else {
+      throw new TeamMatchForbiddenError(
+        "Only an owner or captain can set this team's lineup",
+      );
+    }
+
+    requireStaff(team, userId, "Only an owner or captain can set this team's lineup");
+
+    const userIds = Array.isArray(input.userIds) ? input.userIds : [];
+    for (const raw of userIds) {
+      const memberId = requiredTrimmed(raw, "userId");
+      if (!team.isActiveMember(memberId)) {
+        throw new DomainError("Lineup players must be active members of the team");
+      }
+    }
+
+    match.setLineup(team.id, input.userIds);
+    const saved = await this.matches.persist(match);
+    return {
+      match: await toPublicMatch(saved, home, away, this.profiles, userId),
+    };
+  }
+}
+
+export class CancelTeamMatch {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    matchId: string;
+  }): Promise<{ match: PublicTeamMatch }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const match = await loadMatch(this.matches, input.matchId);
+    const home = await loadTeam(this.teams, match.homeTeamId);
+    requireStaff(home, userId, "Only the challenging team's owner or captain can cancel");
+    match.cancel();
+    const saved = await this.matches.persist(match);
+    const away = saved.awayTeamId
+      ? await loadTeam(this.teams, saved.awayTeamId)
+      : null;
+    return {
+      match: await toPublicMatch(saved, home, away, this.profiles, userId),
+    };
+  }
+}
+
+export type StartTeamMatchInput = {
+  userId: string;
+  matchId: string;
+  ruleset?: unknown;
+  servingTeam?: unknown;
+  holesPlayed?: unknown;
+  startingHole?: unknown;
+  teeName?: unknown;
+  course?: unknown;
+};
+
+export class StartTeamMatch {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+    private readonly venues: VenueRepository,
+    private readonly createMatch: CreateMatch,
+    private readonly createGolfRound: CreateGolfRound,
+    private readonly createDartsMatch: CreateDartsMatch,
+  ) {}
+
+  async execute(input: StartTeamMatchInput): Promise<{
+    match: PublicTeamMatch;
+    scorecard: PublicScorecard;
+  }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const match = await loadMatch(this.matches, input.matchId);
+    const home = await loadTeam(this.teams, match.homeTeamId);
+    const away = match.awayTeamId
+      ? await loadTeam(this.teams, match.awayTeamId)
+      : null;
+
+    if (!isStaff(home, userId) && !(away && isStaff(away, userId))) {
+      throw new TeamMatchForbiddenError(
+        "Only an owner or captain of either team can start",
+      );
+    }
+
+    if (match.status.isLive && match.scorecard) {
+      const publicMatch = await toPublicMatch(
+        match,
+        home,
+        away,
+        this.profiles,
+        userId,
+      );
+      return { match: publicMatch, scorecard: publicMatch.scorecard! };
+    }
+
+    if (!match.venueCmsId && home.homeVenueCmsId) {
+      match.schedule({
+        venueCmsId: OptionalVenueCmsId.from(home.homeVenueCmsId.value),
+      });
+    }
+
+    match.assertCanStart();
+    const venueCmsId = match.venueCmsId ?? home.homeVenueCmsId?.value ?? null;
+    if (match.sport.value !== "darts") {
+      if (!venueCmsId) {
+        throw new TeamMatchNotReadyError("venueCmsId is required to start");
+      }
+      const venue = await this.venues.findByCmsId(CmsId.from(venueCmsId));
+      if (!venue) {
+        throw new DomainError("venueCmsId is not a registered venue");
+      }
+    } else if (venueCmsId) {
+      const venue = await this.venues.findByCmsId(CmsId.from(venueCmsId));
+      if (!venue) {
+        throw new DomainError("venueCmsId is not a registered venue");
+      }
+    }
+
+    const profiles = new Map<string, SeatedProfile>();
+    for (const id of [
+      ...match.homeLineup().userIds,
+      ...(match.awayLineup()?.userIds ?? []),
+    ]) {
+      profiles.set(id, await resolveProfile(this.profiles, id));
+    }
+
+    const startsAt =
+      match.startsAt?.toISOString() ?? new Date().toISOString();
+
+    let liveId: string;
+    if (match.sport.value === "padel") {
+      const created = await this.createMatch.execute({
+        venueCmsId: venueCmsId!,
+        startsAt,
+        ruleset: input.ruleset ?? "golden_point",
+        pairings: pairingsFromLineups(match, profiles),
+        servingTeam: input.servingTeam,
+      });
+      liveId = created.id;
+    } else if (match.sport.value === "golf") {
+      const holesPlayed = input.holesPlayed ?? 9;
+      const created = await this.createGolfRound.execute({
+        venueCmsId: venueCmsId!,
+        startsAt,
+        holesPlayed,
+        startingHole: input.startingHole,
+        teeName: input.teeName ?? "White",
+        course:
+          input.course ??
+          (holesPlayed === 9 ? defaultNineHoleCourse() : undefined),
+        players: golfPlayersFromLineups(match, profiles),
+      });
+      liveId = created.id;
+    } else {
+      const created = await this.createDartsMatch.execute({
+        venueCmsId,
+        startsAt,
+        players: dartsPlayersFromLineups(match, profiles),
+      });
+      liveId = created.id;
+    }
+
+    match.start(TeamMatchScorecard.from({ sport: match.sport, id: liveId }));
+    const saved = await this.matches.persist(match);
+    const publicMatch = await toPublicMatch(
+      saved,
+      home,
+      away,
+      this.profiles,
+      userId,
+    );
+    return { match: publicMatch, scorecard: publicMatch.scorecard! };
+  }
+}
+
+export class CompleteTeamMatch {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+    private readonly getPadel?: GetMatchById,
+    private readonly getGolf?: GetGolfRoundById,
+    private readonly getDarts?: GetDartsMatchById,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    matchId: string;
+    winnerTeamId?: unknown;
+  }): Promise<{ match: PublicTeamMatch }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const match = await loadMatch(this.matches, input.matchId);
+    const home = await loadTeam(this.teams, match.homeTeamId);
+    const away = match.awayTeamId
+      ? await loadTeam(this.teams, match.awayTeamId)
+      : null;
+
+    const allowed =
+      isStaff(home, userId) ||
+      (away && isStaff(away, userId)) ||
+      match.isLineupMember(userId);
+    if (!allowed) {
+      throw new TeamMatchForbiddenError(
+        "Only a lineup player or team staff can complete",
+      );
+    }
+
+    let winnerTeamId =
+      input.winnerTeamId == null || input.winnerTeamId === ""
+        ? null
+        : requiredTrimmed(input.winnerTeamId, "winnerTeamId");
+
+    if (winnerTeamId === null && match.scorecard) {
+      winnerTeamId = await this.inferWinner(match);
+    }
+
+    match.complete(winnerTeamId);
+    const saved = await this.matches.persist(match);
+    return {
+      match: await toPublicMatch(saved, home, away, this.profiles, userId),
+    };
+  }
+
+  private async inferWinner(match: TeamMatch): Promise<string | null> {
+    const card = match.scorecard;
+    if (!card) return null;
+    if (card.sport.value === "padel" && this.getPadel) {
+      const padel = await this.getPadel.execute(card.id);
+      if (!padel?.isLocked || !padel.winner) return null;
+      return padel.winner.value === "A" ? match.homeTeamId : match.awayTeamId;
+    }
+    if (card.sport.value === "darts" && this.getDarts) {
+      const darts = await this.getDarts.execute(card.id);
+      if (!darts?.isLocked) return null;
+      const winnerUserId = darts.toSnapshot().winnerUserId;
+      if (!winnerUserId) return null;
+      if (match.homeLineup().includes(winnerUserId)) return match.homeTeamId;
+      if (match.awayLineup()?.includes(winnerUserId)) return match.awayTeamId;
+      return null;
+    }
+    if (card.sport.value === "golf" && this.getGolf) {
+      const golf = await this.getGolf.execute(card.id);
+      if (!golf?.isLocked || !golf.score) return null;
+      return inferGolfWinner(match, {
+        players: golf.players.map((player) => ({
+          slot: player.slot,
+          userId: player.userId,
+        })),
+        holes: golf.score.toSnapshot().holes,
+      });
+    }
+    return null;
+  }
+}
+
+export class GetTeamMatch {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    matchId: string;
+  }): Promise<{ match: PublicTeamMatch }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const match = await loadMatch(this.matches, input.matchId);
+    const home = await loadTeam(this.teams, match.homeTeamId);
+    const away = match.awayTeamId
+      ? await loadTeam(this.teams, match.awayTeamId)
+      : null;
+    assertCanView(userId, home, away);
+    return {
+      match: await toPublicMatch(match, home, away, this.profiles, userId),
+    };
+  }
+}
+
+export class ListTeamMatches {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    teamId: string;
+  }): Promise<{ matches: PublicTeamMatch[] }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const team = await loadTeam(this.teams, input.teamId);
+    if (!team.isMember(userId)) {
+      throw new TeamForbiddenError("Only a team member can view this team");
+    }
+    const rows = await this.matches.listForTeams([team.id]);
+    const matches: PublicTeamMatch[] = [];
+    for (const row of rows) {
+      const home = await loadTeam(this.teams, row.homeTeamId);
+      const away = row.awayTeamId
+        ? await loadTeam(this.teams, row.awayTeamId)
+        : null;
+      matches.push(await toPublicMatch(row, home, away, this.profiles, userId));
+    }
+    return { matches };
+  }
+}
+
+export class ListMyTeamMatches {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly matches: TeamMatchRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string }): Promise<{
+    upcoming: PublicTeamMatch[];
+    recent: PublicTeamMatch[];
+  }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const myTeams = (await this.teams.listForUser(userId)).filter((team) =>
+      team.isActiveMember(userId),
+    );
+    const rows = await this.matches.listForTeams(myTeams.map((team) => team.id));
+    const upcoming: PublicTeamMatch[] = [];
+    const recent: PublicTeamMatch[] = [];
+    for (const row of rows) {
+      const home = await loadTeam(this.teams, row.homeTeamId);
+      const away = row.awayTeamId
+        ? await loadTeam(this.teams, row.awayTeamId)
+        : null;
+      const publicMatch = await toPublicMatch(
+        row,
+        home,
+        away,
+        this.profiles,
+        userId,
+      );
+      if (
+        row.status.isPending ||
+        row.status.isScheduled ||
+        row.status.isLive
+      ) {
+        upcoming.push(publicMatch);
+      } else {
+        recent.push(publicMatch);
+      }
+    }
+    upcoming.sort(compareUpcoming);
+    recent.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    return { upcoming, recent: recent.slice(0, 20) };
+  }
+}
+
+function compareUpcoming(a: PublicTeamMatch, b: PublicTeamMatch): number {
+  if (a.startsAt && b.startsAt) return a.startsAt.localeCompare(b.startsAt);
+  if (a.startsAt) return -1;
+  if (b.startsAt) return 1;
+  return b.createdAt.localeCompare(a.createdAt);
+}
+
+export function inferGolfWinner(
+  match: TeamMatch,
+  golf: {
+    players: Array<{ slot: number; userId: string | null }>;
+    holes: Array<{ strokes: Record<string, number> }>;
+  },
+): string | null {
+  const totals = new Map<string, number>();
+  for (const player of golf.players) {
+    if (!player.userId) continue;
+    let total = 0;
+    for (const hole of golf.holes) {
+      const strokes = hole.strokes[String(player.slot)];
+      if (typeof strokes !== "number") return null;
+      total += strokes;
+    }
+    totals.set(player.userId, total);
+  }
+  let home = 0;
+  let away = 0;
+  for (const userId of match.homeLineup().userIds) {
+    const total = totals.get(userId);
+    if (total == null) return null;
+    home += total;
+  }
+  for (const userId of match.awayLineup()?.userIds ?? []) {
+    const total = totals.get(userId);
+    if (total == null) return null;
+    away += total;
+  }
+  if (home === away) return null;
+  return home < away ? match.homeTeamId : match.awayTeamId;
+}
+
+export {
+  TeamMatchAlreadyAcceptedError,
+  TeamMatchForbiddenError,
+  TeamMatchNotFoundError,
+  TeamMatchNotReadyError,
+  TeamMatchSportMismatchError,
+};

--- a/src/modules/teams/controllers/teams.controller.ts
+++ b/src/modules/teams/controllers/teams.controller.ts
@@ -19,6 +19,7 @@ import {
   LeaveTeam,
   ListMyTeams,
   RemoveMember,
+  SearchTeams,
   TransferOwnership,
   UpdateMemberRole,
   UpdateTeam,
@@ -69,6 +70,11 @@ const transferBodySchema = z.object({
   userId: z.string(),
 });
 
+const searchQuerySchema = z.object({
+  sport: z.string(),
+  q: z.string().optional(),
+});
+
 export function createTeamsController(deps: {
   createTeam: CreateTeam;
   getTeam: GetTeam;
@@ -82,6 +88,7 @@ export function createTeamsController(deps: {
   removeMember: RemoveMember;
   leaveTeam: LeaveTeam;
   transferOwnership: TransferOwnership;
+  searchTeams: SearchTeams;
   tryGetSessionUserId: (req: Request) => string | null;
 }) {
   return {
@@ -286,6 +293,25 @@ export function createTeamsController(deps: {
 
         const { id } = z.parse(teamIdParamSchema, req.params);
         const result = await deps.leaveTeam.execute({ userId, teamId: id });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTeamsError(res, error);
+      }
+    },
+
+    async search(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const query = z.parse(searchQuerySchema, req.query);
+        const result = await deps.searchTeams.execute({
+          userId,
+          sport: query.sport,
+          query: query.q,
+        });
         return res.status(200).json(result);
       } catch (error) {
         return sendTeamsError(res, error);

--- a/src/modules/teams/index.ts
+++ b/src/modules/teams/index.ts
@@ -24,6 +24,7 @@ import {
   LeaveTeam,
   ListMyTeams,
   RemoveMember,
+  SearchTeams,
   TransferOwnership,
   UpdateMemberRole,
   UpdateTeam,
@@ -74,6 +75,7 @@ export function createTeamsModule({
       teamRepository,
       friendProfileLookup,
     ),
+    searchTeams: new SearchTeams(teamRepository, friendshipRepository),
     tryGetSessionUserId,
   });
 
@@ -113,6 +115,7 @@ export {
   LeaveTeam,
   ListMyTeams,
   RemoveMember,
+  SearchTeams,
   TransferOwnership,
   UpdateMemberRole,
   UpdateTeam,
@@ -121,5 +124,6 @@ export type {
   PublicInviteLink,
   PublicTeam,
   PublicTeamMember,
+  PublicTeamSearchHit,
   PublicTeamSummary,
 } from "./services/teams.service";

--- a/src/modules/teams/repositories/in-memory-team.repository.ts
+++ b/src/modules/teams/repositories/in-memory-team.repository.ts
@@ -1,6 +1,7 @@
 import { Team } from "../entities/team";
 import { TeamPersistenceError } from "../entities/team-persistence-error";
-import { TeamRepository } from "./team.repository";
+import { TeamSportValue } from "../entities/team-sport";
+import { TeamRepository, TeamSearchParams } from "./team.repository";
 
 export class InMemoryTeamRepository implements TeamRepository {
   private readonly byId = new Map<string, Team>();
@@ -47,6 +48,41 @@ export class InMemoryTeamRepository implements TeamRepository {
         const bJoined = b.membershipOf(userId)?.joinedAt.getTime() ?? 0;
         return bJoined - aJoined;
       })
+      .map((team) => clone(team)!);
+  }
+
+  async listActiveForUsers(
+    userIds: string[],
+    sport: TeamSportValue,
+  ): Promise<Team[]> {
+    const ids = new Set(userIds);
+    return [...this.byId.values()]
+      .filter(
+        (team) =>
+          team.sport.value === sport &&
+          team.members.some(
+            (member) => member.status.isActive && ids.has(member.userId),
+          ),
+      )
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+      .map((team) => clone(team)!);
+  }
+
+  async search(params: TeamSearchParams): Promise<Team[]> {
+    const query = params.query?.trim().toLowerCase() ?? "";
+    const exclude = new Set(params.excludeTeamIds ?? []);
+    const limit = Math.min(Math.max(params.limit ?? 20, 1), 50);
+    return [...this.byId.values()]
+      .filter((team) => {
+        if (team.sport.value !== params.sport) return false;
+        if (exclude.has(team.id)) return false;
+        if (query && !team.name.value.toLowerCase().includes(query)) {
+          return false;
+        }
+        return true;
+      })
+      .sort((a, b) => a.name.value.localeCompare(b.name.value))
+      .slice(0, limit)
       .map((team) => clone(team)!);
   }
 }

--- a/src/modules/teams/repositories/prisma-team.repository.ts
+++ b/src/modules/teams/repositories/prisma-team.repository.ts
@@ -9,7 +9,8 @@ import { TeamMembership } from "../entities/team-membership";
 import { TeamName } from "../entities/team-name";
 import { TeamPersistenceError } from "../entities/team-persistence-error";
 import { TeamSport } from "../entities/team-sport";
-import { TeamRepository } from "./team.repository";
+import { TeamSportValue } from "../entities/team-sport";
+import { TeamRepository, TeamSearchParams } from "./team.repository";
 
 type MemberRow = {
   id: string;
@@ -257,6 +258,56 @@ export class PrismaTeamRepository implements TeamRepository {
         });
     } catch (error) {
       throw new TeamPersistenceError("Failed to list user teams", {
+        cause: error,
+      });
+    }
+  }
+
+  async listActiveForUsers(
+    userIds: string[],
+    sport: TeamSportValue,
+  ): Promise<Team[]> {
+    if (userIds.length === 0) return [];
+    try {
+      const rows = await this.prisma.team.findMany({
+        where: {
+          sport,
+          members: {
+            some: { userId: { in: userIds }, status: "active" },
+          },
+        },
+        include: includeRelations,
+        orderBy: { updatedAt: "desc" },
+      });
+      return rows.map(toDomain);
+    } catch (error) {
+      throw new TeamPersistenceError("Failed to list teams for users", {
+        cause: error,
+      });
+    }
+  }
+
+  async search(params: TeamSearchParams): Promise<Team[]> {
+    const query = params.query?.trim() ?? "";
+    const limit = Math.min(Math.max(params.limit ?? 20, 1), 50);
+    try {
+      const rows = await this.prisma.team.findMany({
+        where: {
+          sport: params.sport,
+          ...(params.excludeTeamIds && params.excludeTeamIds.length > 0
+            ? { id: { notIn: params.excludeTeamIds } }
+            : {}),
+          ...(query
+            ? { name: { contains: query, mode: "insensitive" } }
+            : {}),
+        },
+        include: includeRelations,
+        orderBy: { name: "asc" },
+        take: limit,
+      });
+      return rows.map(toDomain);
+    } catch (error) {
+      throw new TeamPersistenceError("Failed to search teams", {
         cause: error,
       });
     }

--- a/src/modules/teams/repositories/team.repository.ts
+++ b/src/modules/teams/repositories/team.repository.ts
@@ -1,4 +1,12 @@
+import { TeamSportValue } from "../entities/team-sport";
 import { Team } from "../entities/team";
+
+export type TeamSearchParams = {
+  sport: TeamSportValue;
+  query?: string;
+  excludeTeamIds?: string[];
+  limit?: number;
+};
 
 export interface TeamRepository {
   findById(id: string): Promise<Team | null>;
@@ -7,4 +15,6 @@ export interface TeamRepository {
   persist(team: Team): Promise<Team>;
   delete(id: string): Promise<void>;
   listForUser(userId: string): Promise<Team[]>;
+  listActiveForUsers(userIds: string[], sport: TeamSportValue): Promise<Team[]>;
+  search(params: TeamSearchParams): Promise<Team[]>;
 }

--- a/src/modules/teams/routes/teams.routes.ts
+++ b/src/modules/teams/routes/teams.routes.ts
@@ -22,6 +22,10 @@ export function createTeamsRoutes(
     void controller.list(req, res);
   });
 
+  router.get("/api/teams/search", options.requireAuth, (req, res) => {
+    void controller.search(req, res);
+  });
+
   router.post("/api/teams/join", options.requireAuth, (req, res) => {
     void controller.join(req, res);
   });

--- a/src/modules/teams/services/teams.service.ts
+++ b/src/modules/teams/services/teams.service.ts
@@ -48,6 +48,15 @@ export type PublicTeam = PublicTeamSummary & {
   inviteLink: PublicInviteLink | null;
 };
 
+export type PublicTeamSearchHit = {
+  id: string;
+  name: string;
+  sport: "padel" | "golf" | "darts";
+  homeVenueCmsId: string | null;
+  memberCount: number;
+  source: "friend" | "name";
+};
+
 async function requireAcceptedFriend(
   friendships: FriendshipRepository,
   actorId: string,
@@ -388,6 +397,78 @@ export class LeaveTeam {
     team.leave(userId);
     await this.teams.persist(team);
     return { ok: true as const };
+  }
+}
+
+export class SearchTeams {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly friendships: FriendshipRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    sport: unknown;
+    query?: unknown;
+  }): Promise<{ teams: PublicTeamSearchHit[] }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const sport = TeamSport.from(input.sport);
+    const query =
+      typeof input.query === "string" ? input.query.trim() : "";
+
+    const mine = (await this.teams.listForUser(userId)).filter((team) =>
+      team.isActiveMember(userId),
+    );
+    const excludeIds = mine.map((team) => team.id);
+
+    const friendships = await this.friendships.listForUser(userId);
+    const friendIds = friendships
+      .filter((row) => row.status === "accepted")
+      .map((row) =>
+        row.requesterId === userId ? row.addresseeId : row.requesterId,
+      );
+
+    const friendTeams = await this.teams.listActiveForUsers(
+      friendIds,
+      sport.value,
+    );
+    const named =
+      query.length > 0
+        ? await this.teams.search({
+            sport: sport.value,
+            query,
+            excludeTeamIds: excludeIds,
+            limit: 20,
+          })
+        : [];
+
+    const seen = new Set<string>();
+    const teams: PublicTeamSearchHit[] = [];
+    for (const team of friendTeams) {
+      if (excludeIds.includes(team.id) || seen.has(team.id)) continue;
+      seen.add(team.id);
+      teams.push({
+        id: team.id,
+        name: team.name.value,
+        sport: team.sport.value,
+        homeVenueCmsId: team.homeVenueCmsId?.value ?? null,
+        memberCount: team.memberCount,
+        source: "friend",
+      });
+    }
+    for (const team of named) {
+      if (seen.has(team.id)) continue;
+      seen.add(team.id);
+      teams.push({
+        id: team.id,
+        name: team.name.value,
+        sport: team.sport.value,
+        homeVenueCmsId: team.homeVenueCmsId?.value ?? null,
+        memberCount: team.memberCount,
+        source: "name",
+      });
+    }
+    return { teams };
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #44

Competitive fixture between two same-sport teams (padel | golf | darts). Reuses existing live scorecards; result lands on both teams’ histories. Not organised-friend games; not tournaments/leagues.

## What landed
- `TeamMatch` aggregate + Prisma migration `20260907210000_team_match`
- Challenge flow: target a team **or** generate a challenge link
- Accept / decline / join via token
- Per-team lineups (active members only)
- Schedule `startsAt` / `venueCmsId` before start
- Start creates a live padel / golf / darts scorecard via existing create services
- Scorecard lock hook marks the team match completed + winner (padel A→home / B→away; darts winner userId; golf lower combined strokes)
- `POST /complete` fallback if the hook cannot infer a winner
- List by team, mine upcoming/recent, same-sport team search

## Frontend contract (summary)
See the issue and PR walkthrough. Auth is the session cookie (`requireAuth`).

### Routes
- `POST /api/team-matches` — create challenge
- `POST /api/team-matches/join` — `{ token, teamId }`
- `POST /api/team-matches/:id/accept` | `/decline`
- `PATCH /api/team-matches/:id` — `{ startsAt?, venueCmsId? }`
- `PUT /api/team-matches/:id/lineup` — `{ userIds, teamId? }`
- `POST /api/team-matches/:id/start` — returns `{ match, scorecard: { sport, id, path } }`
- `POST /api/team-matches/:id/cancel`
- `POST /api/team-matches/:id/complete` — `{ winnerTeamId? }`
- `GET /api/team-matches/:id`
- `GET /api/team-matches?teamId=` and `GET /api/teams/:id/matches`
- `GET /api/team-matches/mine` — `{ upcoming, recent }`
- `GET /api/teams/search?sport=&q=` — friends’ teams + name search

### Statuses
`pending` → `scheduled` (accepted/joined) → `live` → `completed`  
Also `declined`, `cancelled` (before live/completed only).

### Lineup sizes
- padel: 2 vs 2
- golf: 1–2 per side, same size
- darts: 1 vs 1

### Scorecard paths
`/padel/:id`, `/golf/:id`, `/darts/:id`

Naming: **home** = challenging team, **away** = opponent.

## Out of scope
Tournaments, leagues, standings, multi-rubber, public ladder, payments.

Do not merge until reviewed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72d48926-2ef5-4bda-a917-89d4620cf5f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72d48926-2ef5-4bda-a917-89d4620cf5f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

