### PR TITLE
Tournaments v1 (single-elim 4/8/16)

### DIFF
--- a/prisma/migrations/20260908070000_tournament/migration.sql
+++ b/prisma/migrations/20260908070000_tournament/migration.sql
@@ -1,0 +1,105 @@
+-- CreateEnum
+CREATE TYPE "TournamentStatus" AS ENUM ('draft', 'registration', 'active', 'completed');
+
+-- CreateEnum
+CREATE TYPE "TournamentRegistrationStatus" AS ENUM ('pending', 'accepted', 'withdrawn');
+
+-- CreateEnum
+CREATE TYPE "TournamentSlotSide" AS ENUM ('home', 'away');
+
+-- CreateTable
+CREATE TABLE "Tournament" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "sport" "TeamSport" NOT NULL,
+    "size" INTEGER NOT NULL,
+    "status" "TournamentStatus" NOT NULL DEFAULT 'draft',
+    "venueCmsId" TEXT,
+    "startsAt" TIMESTAMP(3),
+    "organizerUserId" TEXT NOT NULL,
+    "winnerTeamId" TEXT,
+    "inviteToken" VARCHAR(32) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Tournament_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TournamentRegistration" (
+    "id" TEXT NOT NULL,
+    "tournamentId" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "status" "TournamentRegistrationStatus" NOT NULL DEFAULT 'pending',
+    "seed" INTEGER,
+    "registeredBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TournamentRegistration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TournamentSlot" (
+    "id" TEXT NOT NULL,
+    "tournamentId" TEXT NOT NULL,
+    "round" INTEGER NOT NULL,
+    "position" INTEGER NOT NULL,
+    "homeTeamId" TEXT,
+    "awayTeamId" TEXT,
+    "homeSeed" INTEGER,
+    "awaySeed" INTEGER,
+    "teamMatchId" TEXT,
+    "winnerTeamId" TEXT,
+    "nextSlotId" TEXT,
+    "nextSide" "TournamentSlotSide",
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TournamentSlot_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tournament_inviteToken_key" ON "Tournament"("inviteToken");
+
+-- CreateIndex
+CREATE INDEX "Tournament_organizerUserId_idx" ON "Tournament"("organizerUserId");
+
+-- CreateIndex
+CREATE INDEX "Tournament_status_startsAt_idx" ON "Tournament"("status", "startsAt");
+
+-- CreateIndex
+CREATE INDEX "Tournament_organizerUserId_status_idx" ON "Tournament"("organizerUserId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TournamentRegistration_tournamentId_teamId_key" ON "TournamentRegistration"("tournamentId", "teamId");
+
+-- CreateIndex
+CREATE INDEX "TournamentRegistration_teamId_idx" ON "TournamentRegistration"("teamId");
+
+-- CreateIndex
+CREATE INDEX "TournamentRegistration_tournamentId_idx" ON "TournamentRegistration"("tournamentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TournamentSlot_teamMatchId_key" ON "TournamentSlot"("teamMatchId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "TournamentSlot_tournamentId_round_position_key" ON "TournamentSlot"("tournamentId", "round", "position");
+
+-- CreateIndex
+CREATE INDEX "TournamentSlot_tournamentId_idx" ON "TournamentSlot"("tournamentId");
+
+-- CreateIndex
+CREATE INDEX "TournamentSlot_teamMatchId_idx" ON "TournamentSlot"("teamMatchId");
+
+-- AddForeignKey
+ALTER TABLE "TournamentRegistration" ADD CONSTRAINT "TournamentRegistration_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "Tournament"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TournamentRegistration" ADD CONSTRAINT "TournamentRegistration_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TournamentSlot" ADD CONSTRAINT "TournamentSlot_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "Tournament"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TournamentSlot" ADD CONSTRAINT "TournamentSlot_teamMatchId_fkey" FOREIGN KEY ("teamMatchId") REFERENCES "TeamMatch"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -400,6 +400,7 @@ model Team {
   inviteLinks    TeamInviteLink[]
   homeMatches    TeamMatch[]      @relation("TeamMatchHome")
   awayMatches    TeamMatch[]      @relation("TeamMatchAway")
+  tournamentRegistrations TournamentRegistration[]
 
   @@index([createdBy])
   @@index([createdAt])
@@ -466,6 +467,7 @@ model TeamMatch {
 
   homeTeam Team  @relation("TeamMatchHome", fields: [homeTeamId], references: [id])
   awayTeam Team? @relation("TeamMatchAway", fields: [awayTeamId], references: [id])
+  tournamentSlot TournamentSlot?
 
   @@index([homeTeamId])
   @@index([awayTeamId])
@@ -495,6 +497,90 @@ enum NotificationType {
 
 // In-app inbox. No User FK — same as Friendship / OrganisedGameInvite.
 // Unique (recipientId, type, resourceId) keeps invite notices idempotent.
+enum TournamentStatus {
+  draft
+  registration
+  active
+  completed
+}
+
+enum TournamentRegistrationStatus {
+  pending
+  accepted
+  withdrawn
+}
+
+enum TournamentSlotSide {
+  home
+  away
+}
+
+// One-off single-elim bracket (size 4/8/16, no byes). Organizer need not
+// be on a team. No User FK — same as Team / TeamMatch. winnerTeamId is a
+// plain id like TeamMatch.winnerTeamId. Invite token is the share surface.
+model Tournament {
+  id              String           @id @default(uuid())
+  name            String
+  sport           TeamSport
+  size            Int
+  status          TournamentStatus @default(draft)
+  venueCmsId      String?
+  startsAt        DateTime?
+  organizerUserId String
+  winnerTeamId    String?
+  inviteToken     String           @unique @db.VarChar(32)
+  createdAt       DateTime         @default(now())
+  updatedAt       DateTime         @updatedAt
+  registrations   TournamentRegistration[]
+  slots           TournamentSlot[]
+
+  @@index([organizerUserId])
+  @@index([status, startsAt])
+  @@index([organizerUserId, status])
+}
+
+model TournamentRegistration {
+  id           String                       @id @default(uuid())
+  tournamentId String
+  teamId       String
+  status       TournamentRegistrationStatus @default(pending)
+  seed         Int?
+  registeredBy String
+  createdAt    DateTime                     @default(now())
+  updatedAt    DateTime                     @updatedAt
+
+  tournament Tournament @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
+  team       Team       @relation(fields: [teamId], references: [id])
+
+  @@unique([tournamentId, teamId])
+  @@index([teamId])
+  @@index([tournamentId])
+}
+
+model TournamentSlot {
+  id           String              @id @default(uuid())
+  tournamentId String
+  round        Int
+  position     Int
+  homeTeamId   String?
+  awayTeamId   String?
+  homeSeed     Int?
+  awaySeed     Int?
+  teamMatchId  String?             @unique
+  winnerTeamId String?
+  nextSlotId   String?
+  nextSide     TournamentSlotSide?
+  createdAt    DateTime            @default(now())
+  updatedAt    DateTime            @updatedAt
+
+  tournament Tournament @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
+  teamMatch  TeamMatch? @relation(fields: [teamMatchId], references: [id])
+
+  @@unique([tournamentId, round, position])
+  @@index([tournamentId])
+  @@index([teamMatchId])
+}
+
 model Notification {
   id          String           @id @default(uuid())
   recipientId String

--- a/src/app.ts
+++ b/src/app.ts
@@ -69,6 +69,12 @@ import {
 import { PrismaTeamMatchRepository } from "./modules/team-matches/repositories/prisma-team-match.repository";
 import { CompleteTeamMatchOnScorecardLock } from "./modules/team-matches/services/complete-on-scorecard-lock";
 import { ScorecardLockedEvent } from "./modules/scorecards/on-scorecard-locked";
+import {
+  createTournamentsModule,
+  TournamentRepository,
+} from "./modules/tournaments";
+import { PrismaTournamentRepository } from "./modules/tournaments/repositories/prisma-tournament.repository";
+import { AdvanceTournamentOnTeamMatchComplete } from "./modules/tournaments/services/advance-on-team-match-complete";
 
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
@@ -88,6 +94,7 @@ export type CreateAppDependencies = {
   notificationRepository?: NotificationRepository;
   teamRepository?: TeamRepository;
   teamMatchRepository?: TeamMatchRepository;
+  tournamentRepository?: TournamentRepository;
 };
 
 export async function createApp(
@@ -125,8 +132,17 @@ export async function createApp(
   const teamMatchRepository =
     dependencies.teamMatchRepository ??
     new PrismaTeamMatchRepository(prisma);
+  const tournamentRepository =
+    dependencies.tournamentRepository ??
+    new PrismaTournamentRepository(prisma);
+  const advanceTournament = new AdvanceTournamentOnTeamMatchComplete(
+    tournamentRepository,
+  );
+  const onTeamMatchCompleted = (match: import("./modules/team-matches/entities/team-match").TeamMatch) =>
+    advanceTournament.execute(match);
   const completeOnLock = new CompleteTeamMatchOnScorecardLock(
     teamMatchRepository,
+    onTeamMatchCompleted,
   );
   const onScorecardLocked = (event: ScorecardLockedEvent) =>
     completeOnLock.execute(event);
@@ -238,6 +254,15 @@ export async function createApp(
     dartsMatchRepository: darts.dartsMatchRepository,
     friendProfileLookup: friends.friendProfileLookup,
     teamMatchRepository,
+    onTeamMatchCompleted,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
+  const tournaments = createTournamentsModule({
+    prisma,
+    teamRepository: teams.teamRepository,
+    teamMatchRepository,
+    tournamentRepository,
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
@@ -258,6 +283,7 @@ export async function createApp(
   app.use(organisedGames.router);
   app.use(teams.router);
   app.use(teamMatches.router);
+  app.use(tournaments.router);
 
   app.use(
     (

--- a/src/modules/team-matches/index.ts
+++ b/src/modules/team-matches/index.ts
@@ -48,6 +48,7 @@ export type CreateTeamMatchesModuleParams = {
   dartsMatchRepository: DartsMatchRepository;
   friendProfileLookup: FriendProfileLookup;
   teamMatchRepository?: TeamMatchRepository;
+  onTeamMatchCompleted?: (match: import("./entities/team-match").TeamMatch) => Promise<void>;
   tryGetSessionUserId: (req: Request) => string | null;
   requireAuth: (req: Request, res: Response, next: NextFunction) => void;
 };
@@ -67,6 +68,7 @@ export function createTeamMatchesModule({
   dartsMatchRepository,
   friendProfileLookup,
   teamMatchRepository: teamMatchRepositoryOverride,
+  onTeamMatchCompleted,
   tryGetSessionUserId,
   requireAuth,
 }: CreateTeamMatchesModuleParams): TeamMatchesModule {
@@ -78,6 +80,7 @@ export function createTeamMatchesModule({
   const getDartsMatchById = new GetDartsMatchById(dartsMatchRepository);
   const completeOnLock = new CompleteTeamMatchOnScorecardLock(
     teamMatchRepository,
+    onTeamMatchCompleted,
   );
 
   const controller = createTeamMatchesController({
@@ -132,6 +135,7 @@ export function createTeamMatchesModule({
       getMatchById,
       getGolfRoundById,
       getDartsMatchById,
+      onTeamMatchCompleted,
     ),
     getTeamMatch: new GetTeamMatch(
       teamRepository,

--- a/src/modules/team-matches/services/complete-on-scorecard-lock.ts
+++ b/src/modules/team-matches/services/complete-on-scorecard-lock.ts
@@ -4,8 +4,13 @@ import { TeamMatchPersistenceError } from "../entities/team-match-persistence-er
 import { TeamMatchRepository } from "../repositories/team-match.repository";
 import { inferGolfWinner } from "./team-matches.service";
 
+export type TeamMatchCompletedHandler = (match: TeamMatch) => Promise<void>;
+
 export class CompleteTeamMatchOnScorecardLock {
-  constructor(private readonly matches: TeamMatchRepository) {}
+  constructor(
+    private readonly matches: TeamMatchRepository,
+    private readonly onCompleted?: TeamMatchCompletedHandler,
+  ) {}
 
   async execute(event: ScorecardLockedEvent): Promise<void> {
     try {
@@ -14,7 +19,10 @@ export class CompleteTeamMatchOnScorecardLock {
 
       const winnerTeamId = inferWinnerFromEvent(match, event);
       match.complete(winnerTeamId);
-      await this.matches.persist(match);
+      const saved = await this.matches.persist(match);
+      if (this.onCompleted) {
+        await this.onCompleted(saved);
+      }
     } catch (error) {
       if (error instanceof TeamMatchPersistenceError) return;
       console.error("Failed to complete team match from scorecard lock", error);

--- a/src/modules/team-matches/services/team-matches.service.ts
+++ b/src/modules/team-matches/services/team-matches.service.ts
@@ -617,6 +617,10 @@ export class StartTeamMatch {
   }
 }
 
+export type TeamMatchCompletedHandler = (
+  match: TeamMatch,
+) => Promise<void>;
+
 export class CompleteTeamMatch {
   constructor(
     private readonly teams: TeamRepository,
@@ -625,6 +629,7 @@ export class CompleteTeamMatch {
     private readonly getPadel?: GetMatchById,
     private readonly getGolf?: GetGolfRoundById,
     private readonly getDarts?: GetDartsMatchById,
+    private readonly onCompleted?: TeamMatchCompletedHandler,
   ) {}
 
   async execute(input: {
@@ -660,6 +665,9 @@ export class CompleteTeamMatch {
 
     match.complete(winnerTeamId);
     const saved = await this.matches.persist(match);
+    if (this.onCompleted) {
+      await this.onCompleted(saved);
+    }
     return {
       match: await toPublicMatch(saved, home, away, this.profiles, userId),
     };

--- a/src/modules/tournaments/controllers/tournaments.controller.ts
+++ b/src/modules/tournaments/controllers/tournaments.controller.ts
@@ -1,0 +1,388 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { TeamForbiddenError } from "../../teams/entities/team-forbidden-error";
+import { TeamNotFoundError } from "../../teams/entities/team-not-found-error";
+import { TeamPersistenceError } from "../../teams/entities/team-persistence-error";
+import { TeamMatchPersistenceError } from "../../team-matches/entities/team-match-persistence-error";
+import { TournamentAlreadyActiveError } from "../entities/tournament-already-active-error";
+import { TournamentForbiddenError } from "../entities/tournament-forbidden-error";
+import { TournamentFullError } from "../entities/tournament-full-error";
+import { TournamentNotFoundError } from "../entities/tournament-not-found-error";
+import { TournamentNotReadyError } from "../entities/tournament-not-ready-error";
+import { TournamentPersistenceError } from "../entities/tournament-persistence-error";
+import { TournamentRegistrationNotFoundError } from "../entities/tournament-registration-not-found-error";
+import { TournamentSlotNotFoundError } from "../entities/tournament-slot-not-found-error";
+import { TournamentSportMismatchError } from "../entities/tournament-sport-mismatch-error";
+import {
+  AcceptRegistration,
+  CreateTournament,
+  DeleteTournament,
+  GenerateDraw,
+  GetTournament,
+  InviteTeam,
+  JoinTournament,
+  ListMyTournaments,
+  ListTeamTournaments,
+  OpenRegistration,
+  RegisterTeam,
+  StartFixture,
+  StartTournament,
+  UpdateTournament,
+  WithdrawRegistration,
+} from "../services/tournaments.service";
+
+const createBodySchema = z.object({
+  name: z.string(),
+  sport: z.string(),
+  size: z.union([z.literal(4), z.literal(8), z.literal(16), z.number()]),
+  venueCmsId: z.string().nullable().optional(),
+  startsAt: z.string().nullable().optional(),
+});
+
+const updateBodySchema = z
+  .object({
+    name: z.string().optional(),
+    sport: z.string().optional(),
+    size: z.union([z.literal(4), z.literal(8), z.literal(16), z.number()]).optional(),
+    venueCmsId: z.string().nullable().optional(),
+    startsAt: z.string().nullable().optional(),
+  })
+  .refine(
+    (body) =>
+      body.name !== undefined ||
+      body.sport !== undefined ||
+      body.size !== undefined ||
+      Object.prototype.hasOwnProperty.call(body, "venueCmsId") ||
+      Object.prototype.hasOwnProperty.call(body, "startsAt"),
+    { message: "At least one field is required" },
+  );
+
+const idParamSchema = z.object({
+  id: z.string(),
+});
+
+const registrationParamSchema = z.object({
+  id: z.string(),
+  teamId: z.string(),
+});
+
+const fixtureParamSchema = z.object({
+  id: z.string(),
+  slotId: z.string(),
+});
+
+const registerBodySchema = z.object({
+  teamId: z.string(),
+});
+
+const joinBodySchema = z.object({
+  token: z.string(),
+  teamId: z.string(),
+});
+
+export function createTournamentsController(deps: {
+  createTournament: CreateTournament;
+  getTournament: GetTournament;
+  updateTournament: UpdateTournament;
+  deleteTournament: DeleteTournament;
+  openRegistration: OpenRegistration;
+  registerTeam: RegisterTeam;
+  joinTournament: JoinTournament;
+  inviteTeam: InviteTeam;
+  acceptRegistration: AcceptRegistration;
+  withdrawRegistration: WithdrawRegistration;
+  generateDraw: GenerateDraw;
+  startTournament: StartTournament;
+  startFixture: StartFixture;
+  listMyTournaments: ListMyTournaments;
+  listTeamTournaments: ListTeamTournaments;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async create(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const body = z.parse(createBodySchema, req.body ?? {});
+        const result = await deps.createTournament.execute({
+          userId,
+          name: body.name,
+          sport: body.sport,
+          size: body.size,
+          venueCmsId: body.venueCmsId,
+          startsAt: body.startsAt,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async get(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const result = await deps.getTournament.execute({
+          userId,
+          tournamentId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async update(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const body = z.parse(updateBodySchema, req.body ?? {});
+        const raw = (req.body ?? {}) as Record<string, unknown>;
+        const result = await deps.updateTournament.execute({
+          userId,
+          tournamentId: id,
+          name: body.name,
+          sport: body.sport,
+          size: body.size,
+          venueCmsId: body.venueCmsId,
+          startsAt: body.startsAt,
+          hasVenueCmsId: Object.prototype.hasOwnProperty.call(raw, "venueCmsId"),
+          hasStartsAt: Object.prototype.hasOwnProperty.call(raw, "startsAt"),
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async remove(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        await deps.deleteTournament.execute({
+          userId,
+          tournamentId: id,
+        });
+        return res.status(204).send();
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async openRegistration(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const result = await deps.openRegistration.execute({
+          userId,
+          tournamentId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async register(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const body = z.parse(registerBodySchema, req.body ?? {});
+        const result = await deps.registerTeam.execute({
+          userId,
+          tournamentId: id,
+          teamId: body.teamId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async join(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const body = z.parse(joinBodySchema, req.body ?? {});
+        const result = await deps.joinTournament.execute({
+          userId,
+          token: body.token,
+          teamId: body.teamId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async invite(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const body = z.parse(registerBodySchema, req.body ?? {});
+        const result = await deps.inviteTeam.execute({
+          userId,
+          tournamentId: id,
+          teamId: body.teamId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async accept(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, teamId } = z.parse(registrationParamSchema, req.params);
+        const result = await deps.acceptRegistration.execute({
+          userId,
+          tournamentId: id,
+          teamId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async withdraw(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, teamId } = z.parse(registrationParamSchema, req.params);
+        const result = await deps.withdrawRegistration.execute({
+          userId,
+          tournamentId: id,
+          teamId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async generateDraw(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const result = await deps.generateDraw.execute({
+          userId,
+          tournamentId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async start(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const result = await deps.startTournament.execute({
+          userId,
+          tournamentId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async startFixture(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, slotId } = z.parse(fixtureParamSchema, req.params);
+        const result = await deps.startFixture.execute({
+          userId,
+          tournamentId: id,
+          slotId,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async listMine(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const result = await deps.listMyTournaments.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+
+    async listForTeam(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const result = await deps.listTeamTournaments.execute({
+          userId,
+          teamId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendTournamentError(res, error);
+      }
+    },
+  };
+}
+
+function sendTournamentError(res: Response, error: unknown) {
+  if (
+    error instanceof TournamentNotFoundError ||
+    error instanceof TournamentRegistrationNotFoundError ||
+    error instanceof TournamentSlotNotFoundError ||
+    error instanceof TeamNotFoundError
+  ) {
+    return res.status(404).json({ error: error.message });
+  }
+  if (
+    error instanceof TournamentForbiddenError ||
+    error instanceof TeamForbiddenError
+  ) {
+    return res.status(403).json({ error: error.message });
+  }
+  if (error instanceof TournamentAlreadyActiveError) {
+    return res.status(409).json({ error: error.message });
+  }
+  if (
+    error instanceof TournamentSportMismatchError ||
+    error instanceof TournamentNotReadyError ||
+    error instanceof TournamentFullError
+  ) {
+    return res.status(400).json({ error: error.message });
+  }
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid tournament payload" });
+  }
+  if (
+    error instanceof TournamentPersistenceError ||
+    error instanceof TeamPersistenceError ||
+    error instanceof TeamMatchPersistenceError
+  ) {
+    return res.status(503).json({ error: error.message });
+  }
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/tournaments/controllers/tournaments.http.test.ts
+++ b/src/modules/tournaments/controllers/tournaments.http.test.ts
@@ -1,0 +1,624 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryDartsMatchRepository } from "../../darts/repositories/in-memory-darts-match.repository";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { InMemoryGolfRoundRepository } from "../../golf-round/repositories/in-memory-golf-round.repository";
+import { signAuthenticationToken } from "../../identity/utils/jwt";
+import { InMemoryMatchRepository } from "../../match/repositories/in-memory-match.repository";
+import { Team } from "../../teams/entities/team";
+import { TeamName } from "../../teams/entities/team-name";
+import { TeamSport } from "../../teams/entities/team-sport";
+import { InMemoryTeamRepository } from "../../teams/repositories/in-memory-team.repository";
+import { InMemoryTeamMatchRepository } from "../../team-matches/repositories/in-memory-team-match.repository";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { InMemoryTournamentRepository } from "../repositories/in-memory-tournament.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+async function becomeFriends(
+  friendships: InMemoryFriendshipRepository,
+  a: string,
+  b: string,
+) {
+  const pending = await friendships.createPending(a, b);
+  await friendships.accept(pending.id);
+}
+
+type PublicTournament = {
+  id: string;
+  name: string;
+  sport: string;
+  size: number;
+  status: string;
+  inviteToken: string | null;
+  acceptedCount: number;
+  winnerTeamId: string | null;
+  viewer: { role: string; teamId: string | null };
+  registrations: Array<{
+    team: { id: string; name: string; sport: string };
+    status: string;
+    seed: number | null;
+  }>;
+  bracket: {
+    rounds: number;
+    slots: Array<{
+      id: string;
+      round: number;
+      position: number;
+      homeTeam: { id: string } | null;
+      awayTeam: { id: string } | null;
+      teamMatchId: string | null;
+      teamMatchPath: string | null;
+      winnerTeamId: string | null;
+      nextSlotId: string | null;
+    }>;
+  };
+};
+
+describe("tournaments HTTP", () => {
+  const config = makeConfig();
+  let teams: InMemoryTeamRepository;
+  let matches: InMemoryTeamMatchRepository;
+  let tournaments: InMemoryTournamentRepository;
+  let friendships: InMemoryFriendshipRepository;
+  let profiles: InMemoryFriendProfileLookup;
+  let venues: InMemoryVenueRepository;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+  let teamA: string;
+  let teamB: string;
+  let teamC: string;
+  let teamD: string;
+  let golfTeam: string;
+
+  function cookie(userId: string) {
+    return `token=${signAuthenticationToken(config, { userId })}`;
+  }
+
+  async function json(
+    path: string,
+    init: RequestInit & { userId?: string } = {},
+  ) {
+    const headers = new Headers(init.headers);
+    if (init.body && !headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+    if (init.userId) headers.set("Cookie", cookie(init.userId));
+    return fetch(`${server.url}${path}`, { ...init, headers });
+  }
+
+  async function seedSquad(
+    ownerId: string,
+    name: string,
+    sport: string,
+    extraIds: string[],
+  ) {
+    const team = Team.create({
+      name: TeamName.from(name),
+      sport: TeamSport.from(sport),
+      createdBy: ownerId,
+    });
+    for (const extraId of extraIds) {
+      await becomeFriends(friendships, ownerId, extraId);
+      team.inviteFriend(ownerId, extraId);
+    }
+    return teams.create(team);
+  }
+
+  beforeEach(async () => {
+    teams = new InMemoryTeamRepository();
+    matches = new InMemoryTeamMatchRepository();
+    tournaments = new InMemoryTournamentRepository();
+    friendships = new InMemoryFriendshipRepository();
+    profiles = new InMemoryFriendProfileLookup();
+    venues = new InMemoryVenueRepository();
+
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-court-1"),
+        VenueName.from("Padel Club"),
+        Slug.from("padel-club"),
+      ),
+      { refreshDetails: false },
+    );
+
+    for (const [userId, displayName, handle] of [
+      ["user-org", "Organizer", "org"],
+      ["user-a", "Alex", "alex"],
+      ["user-a2", "Avery", "avery"],
+      ["user-b", "Blake", "blake"],
+      ["user-b2", "Blair", "blair"],
+      ["user-c", "Casey", "casey"],
+      ["user-c2", "Carmen", "carmen"],
+      ["user-d", "Drew", "drew"],
+      ["user-d2", "Dana", "dana"],
+      ["user-g", "Gale", "gale"],
+      ["user-z", "Zoe", "zoe"],
+    ] as const) {
+      profiles.seed({ userId, displayName, handle, avatarUrl: null });
+    }
+
+    teamA = (await seedSquad("user-a", "Aces", "padel", ["user-a2"])).id;
+    teamB = (await seedSquad("user-b", "Bats", "padel", ["user-b2"])).id;
+    teamC = (await seedSquad("user-c", "Cats", "padel", ["user-c2"])).id;
+    teamD = (await seedSquad("user-d", "Dogs", "padel", ["user-d2"])).id;
+    golfTeam = (await seedSquad("user-g", "Fairway", "golf", [])).id;
+
+    app = await createApp(config, {
+      venueRepository: venues,
+      friendshipRepository: friendships,
+      friendProfileLookup: profiles,
+      teamRepository: teams,
+      teamMatchRepository: matches,
+      tournamentRepository: tournaments,
+      matchRepository: new InMemoryMatchRepository(),
+      golfRoundRepository: new InMemoryGolfRoundRepository(),
+      dartsMatchRepository: new InMemoryDartsMatchRepository(),
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("create requires auth and opens as a draft", async () => {
+    const unauth = await json("/api/tournaments", {
+      method: "POST",
+      body: JSON.stringify({ name: "Sunday Cup", sport: "padel", size: 4 }),
+    });
+    expect(unauth.status).toBe(401);
+
+    const created = await json("/api/tournaments", {
+      method: "POST",
+      userId: "user-org",
+      body: JSON.stringify({
+        name: "Sunday Cup",
+        sport: "padel",
+        size: 4,
+        venueCmsId: "sanity-court-1",
+      }),
+    });
+    expect(created.status).toBe(201);
+    const body = (await created.json()) as { tournament: PublicTournament };
+    expect(body.tournament).toMatchObject({
+      name: "Sunday Cup",
+      sport: "padel",
+      size: 4,
+      status: "draft",
+      organizerUserId: "user-org",
+      viewer: { role: "organizer" },
+    });
+    expect(body.tournament.inviteToken).toHaveLength(32);
+  });
+
+  test("permission denials, wrong sport, draw only when full, start fixture, advance, winner, list mine", async () => {
+    const created = await json("/api/tournaments", {
+      method: "POST",
+      userId: "user-org",
+      body: JSON.stringify({
+        name: "Sunday Cup",
+        sport: "padel",
+        size: 4,
+        venueCmsId: "sanity-court-1",
+      }),
+    });
+    const { tournament: draft } = (await created.json()) as {
+      tournament: PublicTournament;
+    };
+
+    const strangerEdit = await json(`/api/tournaments/${draft.id}`, {
+      method: "PATCH",
+      userId: "user-z",
+      body: JSON.stringify({ name: "Hijack" }),
+    });
+    expect(strangerEdit.status).toBe(403);
+
+    const memberOpen = await json(
+      `/api/tournaments/${draft.id}/open-registration`,
+      { method: "POST", userId: "user-a" },
+    );
+    expect(memberOpen.status).toBe(403);
+
+    const opened = await json(`/api/tournaments/${draft.id}/open-registration`, {
+      method: "POST",
+      userId: "user-org",
+    });
+    expect(opened.status).toBe(200);
+    const openedBody = (await opened.json()) as { tournament: PublicTournament };
+    expect(openedBody.tournament.status).toBe("registration");
+    const token = openedBody.tournament.inviteToken;
+    expect(token).toHaveLength(32);
+
+    const wrongSport = await json("/api/tournaments/join", {
+      method: "POST",
+      userId: "user-g",
+      body: JSON.stringify({ token, teamId: golfTeam }),
+    });
+    expect(wrongSport.status).toBe(400);
+    expect(await wrongSport.json()).toEqual({
+      error: "Team sport must match the tournament",
+    });
+
+    const memberJoin = await json("/api/tournaments/join", {
+      method: "POST",
+      userId: "user-a2",
+      body: JSON.stringify({ token, teamId: teamA }),
+    });
+    expect(memberJoin.status).toBe(403);
+
+    const joinedA = await json("/api/tournaments/join", {
+      method: "POST",
+      userId: "user-a",
+      body: JSON.stringify({ token, teamId: teamA }),
+    });
+    expect(joinedA.status).toBe(200);
+    expect(
+      ((await joinedA.json()) as { tournament: PublicTournament }).tournament
+        .acceptedCount,
+    ).toBe(1);
+
+    await json(`/api/tournaments/${draft.id}/register`, {
+      method: "POST",
+      userId: "user-b",
+      body: JSON.stringify({ teamId: teamB }),
+    });
+    await json(`/api/tournaments/${draft.id}/register`, {
+      method: "POST",
+      userId: "user-c",
+      body: JSON.stringify({ teamId: teamC }),
+    });
+
+    const earlyDraw = await json(`/api/tournaments/${draft.id}/generate-draw`, {
+      method: "POST",
+      userId: "user-org",
+    });
+    expect(earlyDraw.status).toBe(400);
+
+    await json("/api/tournaments/join", {
+      method: "POST",
+      userId: "user-d",
+      body: JSON.stringify({ token, teamId: teamD }),
+    });
+
+    const strangerDraw = await json(`/api/tournaments/${draft.id}/generate-draw`, {
+      method: "POST",
+      userId: "user-a",
+    });
+    expect(strangerDraw.status).toBe(403);
+
+    const drawn = await json(`/api/tournaments/${draft.id}/generate-draw`, {
+      method: "POST",
+      userId: "user-org",
+    });
+    expect(drawn.status).toBe(200);
+    const drawnBody = (await drawn.json()) as { tournament: PublicTournament };
+    expect(drawnBody.tournament.status).toBe("active");
+    expect(drawnBody.tournament.bracket.slots).toHaveLength(3);
+    const firstRound = drawnBody.tournament.bracket.slots.filter(
+      (slot) => slot.round === 1,
+    );
+    expect(firstRound).toHaveLength(2);
+    for (const slot of firstRound) {
+      expect(slot.homeTeam).not.toBeNull();
+      expect(slot.awayTeam).not.toBeNull();
+    }
+
+    const lateJoin = await json("/api/tournaments/join", {
+      method: "POST",
+      userId: "user-g",
+      body: JSON.stringify({ token, teamId: golfTeam }),
+    });
+    expect(lateJoin.status).toBe(400);
+
+    const strangerFixture = await json(
+      `/api/tournaments/${draft.id}/fixtures/${firstRound[0].id}/start`,
+      { method: "POST", userId: "user-z" },
+    );
+    expect(strangerFixture.status).toBe(403);
+
+    const started = await json(
+      `/api/tournaments/${draft.id}/fixtures/${firstRound[0].id}/start`,
+      { method: "POST", userId: "user-org" },
+    );
+    expect(started.status).toBe(201);
+    const startedBody = (await started.json()) as {
+      tournament: PublicTournament;
+      fixture: { slotId: string; teamMatchId: string; path: string };
+    };
+    expect(startedBody.fixture.teamMatchId).toBeTruthy();
+    expect(startedBody.fixture.path).toBe(
+      `/api/team-matches/${startedBody.fixture.teamMatchId}`,
+    );
+
+    const storedMatch = await matches.findById(startedBody.fixture.teamMatchId);
+    expect(storedMatch?.status.isScheduled).toBe(true);
+    expect(storedMatch?.homeTeamId).toBe(firstRound[0].homeTeam!.id);
+    expect(storedMatch?.awayTeamId).toBe(firstRound[0].awayTeam!.id);
+
+    const homeOwner =
+      firstRound[0].homeTeam!.id === teamA
+        ? "user-a"
+        : firstRound[0].homeTeam!.id === teamB
+          ? "user-b"
+          : firstRound[0].homeTeam!.id === teamC
+            ? "user-c"
+            : "user-d";
+    const awayOwner =
+      firstRound[0].awayTeam!.id === teamA
+        ? "user-a"
+        : firstRound[0].awayTeam!.id === teamB
+          ? "user-b"
+          : firstRound[0].awayTeam!.id === teamC
+            ? "user-c"
+            : "user-d";
+    const homeMate = `${homeOwner}2`;
+    const awayMate = `${awayOwner}2`;
+
+    await json(`/api/team-matches/${startedBody.fixture.teamMatchId}/lineup`, {
+      method: "PUT",
+      userId: homeOwner,
+      body: JSON.stringify({ userIds: [homeOwner, homeMate] }),
+    });
+    await json(`/api/team-matches/${startedBody.fixture.teamMatchId}/lineup`, {
+      method: "PUT",
+      userId: awayOwner,
+      body: JSON.stringify({ userIds: [awayOwner, awayMate] }),
+    });
+    const live = await json(
+      `/api/team-matches/${startedBody.fixture.teamMatchId}/start`,
+      { method: "POST", userId: homeOwner },
+    );
+    expect(live.status).toBe(200);
+
+    const completed = await json(
+      `/api/team-matches/${startedBody.fixture.teamMatchId}/complete`,
+      {
+        method: "POST",
+        userId: homeOwner,
+        body: JSON.stringify({ winnerTeamId: firstRound[0].homeTeam!.id }),
+      },
+    );
+    expect(completed.status).toBe(200);
+
+    const afterAdvance = await json(`/api/tournaments/${draft.id}`, {
+      userId: "user-org",
+    });
+    expect(afterAdvance.status).toBe(200);
+    const advanced = (await afterAdvance.json()) as {
+      tournament: PublicTournament;
+    };
+    const next = advanced.tournament.bracket.slots.find(
+      (slot) => slot.id === firstRound[0].nextSlotId,
+    );
+    expect(next?.homeTeam?.id ?? next?.awayTeam?.id).toBe(
+      firstRound[0].homeTeam!.id,
+    );
+
+    const otherRound = firstRound[1];
+    const otherStart = await json(
+      `/api/tournaments/${draft.id}/fixtures/${otherRound.id}/start`,
+      { method: "POST", userId: "user-org" },
+    );
+    const otherFixture = (await otherStart.json()) as {
+      fixture: { teamMatchId: string };
+    };
+    const otherHomeOwner =
+      otherRound.homeTeam!.id === teamA
+        ? "user-a"
+        : otherRound.homeTeam!.id === teamB
+          ? "user-b"
+          : otherRound.homeTeam!.id === teamC
+            ? "user-c"
+            : "user-d";
+    const otherAwayOwner =
+      otherRound.awayTeam!.id === teamA
+        ? "user-a"
+        : otherRound.awayTeam!.id === teamB
+          ? "user-b"
+          : otherRound.awayTeam!.id === teamC
+            ? "user-c"
+            : "user-d";
+    await json(`/api/team-matches/${otherFixture.fixture.teamMatchId}/lineup`, {
+      method: "PUT",
+      userId: otherHomeOwner,
+      body: JSON.stringify({
+        userIds: [otherHomeOwner, `${otherHomeOwner}2`],
+      }),
+    });
+    await json(`/api/team-matches/${otherFixture.fixture.teamMatchId}/lineup`, {
+      method: "PUT",
+      userId: otherAwayOwner,
+      body: JSON.stringify({
+        userIds: [otherAwayOwner, `${otherAwayOwner}2`],
+      }),
+    });
+    await json(`/api/team-matches/${otherFixture.fixture.teamMatchId}/start`, {
+      method: "POST",
+      userId: otherHomeOwner,
+    });
+    await json(`/api/team-matches/${otherFixture.fixture.teamMatchId}/complete`, {
+      method: "POST",
+      userId: otherHomeOwner,
+      body: JSON.stringify({ winnerTeamId: otherRound.homeTeam!.id }),
+    });
+
+    const readyFinal = await json(`/api/tournaments/${draft.id}`, {
+      userId: "user-org",
+    });
+    const readyBody = (await readyFinal.json()) as {
+      tournament: PublicTournament;
+    };
+    const finalSlot = readyBody.tournament.bracket.slots.find(
+      (slot) => slot.round === 2,
+    );
+    expect(finalSlot?.homeTeam).not.toBeNull();
+    expect(finalSlot?.awayTeam).not.toBeNull();
+
+    const finalStart = await json(
+      `/api/tournaments/${draft.id}/fixtures/${finalSlot!.id}/start`,
+      { method: "POST", userId: "user-org" },
+    );
+    const finalFixture = (await finalStart.json()) as {
+      fixture: { teamMatchId: string };
+    };
+    const finalHomeOwner =
+      finalSlot!.homeTeam!.id === teamA
+        ? "user-a"
+        : finalSlot!.homeTeam!.id === teamB
+          ? "user-b"
+          : finalSlot!.homeTeam!.id === teamC
+            ? "user-c"
+            : "user-d";
+    const finalAwayOwner =
+      finalSlot!.awayTeam!.id === teamA
+        ? "user-a"
+        : finalSlot!.awayTeam!.id === teamB
+          ? "user-b"
+          : finalSlot!.awayTeam!.id === teamC
+            ? "user-c"
+            : "user-d";
+    await json(`/api/team-matches/${finalFixture.fixture.teamMatchId}/lineup`, {
+      method: "PUT",
+      userId: finalHomeOwner,
+      body: JSON.stringify({
+        userIds: [finalHomeOwner, `${finalHomeOwner}2`],
+      }),
+    });
+    await json(`/api/team-matches/${finalFixture.fixture.teamMatchId}/lineup`, {
+      method: "PUT",
+      userId: finalAwayOwner,
+      body: JSON.stringify({
+        userIds: [finalAwayOwner, `${finalAwayOwner}2`],
+      }),
+    });
+    await json(`/api/team-matches/${finalFixture.fixture.teamMatchId}/start`, {
+      method: "POST",
+      userId: finalHomeOwner,
+    });
+    await json(`/api/team-matches/${finalFixture.fixture.teamMatchId}/complete`, {
+      method: "POST",
+      userId: finalHomeOwner,
+      body: JSON.stringify({ winnerTeamId: finalSlot!.homeTeam!.id }),
+    });
+
+    const finished = await json(`/api/tournaments/${draft.id}`, {
+      userId: "user-org",
+    });
+    expect(finished.status).toBe(200);
+    expect(await finished.json()).toMatchObject({
+      tournament: {
+        status: "completed",
+        winnerTeamId: finalSlot!.homeTeam!.id,
+      },
+    });
+
+    const mineOrg = await json("/api/tournaments/mine", { userId: "user-org" });
+    expect(mineOrg.status).toBe(200);
+    expect(await mineOrg.json()).toMatchObject({
+      organizing: [expect.objectContaining({ id: draft.id, name: "Sunday Cup" })],
+      entered: [],
+    });
+
+    const mineA = await json("/api/tournaments/mine", { userId: "user-a" });
+    expect(mineA.status).toBe(200);
+    expect(await mineA.json()).toMatchObject({
+      organizing: [],
+      entered: [expect.objectContaining({ id: draft.id })],
+    });
+
+    const teamList = await json(`/api/teams/${teamA}/tournaments`, {
+      userId: "user-a",
+    });
+    expect(teamList.status).toBe(200);
+    expect(await teamList.json()).toMatchObject({
+      tournaments: [expect.objectContaining({ id: draft.id })],
+    });
+
+    const strangerTeam = await json(`/api/teams/${teamA}/tournaments`, {
+      userId: "user-z",
+    });
+    expect(strangerTeam.status).toBe(403);
+  });
+
+  test("draft delete is organizer-only and blocked after registration", async () => {
+    const created = await json("/api/tournaments", {
+      method: "POST",
+      userId: "user-org",
+      body: JSON.stringify({ name: "Scratch Cup", sport: "darts", size: 8 }),
+    });
+    const { tournament } = (await created.json()) as {
+      tournament: PublicTournament;
+    };
+
+    const denied = await json(`/api/tournaments/${tournament.id}`, {
+      method: "DELETE",
+      userId: "user-a",
+    });
+    expect(denied.status).toBe(403);
+
+    const opened = await json(
+      `/api/tournaments/${tournament.id}/open-registration`,
+      { method: "POST", userId: "user-org" },
+    );
+    expect(opened.status).toBe(200);
+
+    const blocked = await json(`/api/tournaments/${tournament.id}`, {
+      method: "DELETE",
+      userId: "user-org",
+    });
+    expect(blocked.status).toBe(400);
+
+    const other = await json("/api/tournaments", {
+      method: "POST",
+      userId: "user-org",
+      body: JSON.stringify({ name: "Gone", sport: "golf", size: 4 }),
+    });
+    const { tournament: gone } = (await other.json()) as {
+      tournament: PublicTournament;
+    };
+    const removed = await json(`/api/tournaments/${gone.id}`, {
+      method: "DELETE",
+      userId: "user-org",
+    });
+    expect(removed.status).toBe(204);
+  });
+});

--- a/src/modules/tournaments/entities/bracket.ts
+++ b/src/modules/tournaments/entities/bracket.ts
@@ -1,0 +1,79 @@
+import { TournamentSize } from "./tournament-size";
+import { TournamentSlot } from "./tournament-slot";
+
+export type SeededTeam = {
+  teamId: string;
+  seed: number;
+};
+
+/**
+ * Standard single-elim seed order so #1 and #2 meet in the final.
+ * 4:  [1, 4, 2, 3]
+ * 8:  [1, 8, 4, 5, 2, 7, 3, 6]
+ * 16: [1, 16, 8, 9, 4, 13, 5, 12, 2, 15, 7, 10, 3, 14, 6, 11]
+ */
+export function seedPositions(size: TournamentSize): number[] {
+  let positions = [1, 2];
+  while (positions.length < size.value) {
+    const next: number[] = [];
+    const n = positions.length * 2;
+    for (const seed of positions) {
+      next.push(seed, n + 1 - seed);
+    }
+    positions = next;
+  }
+  return positions;
+}
+
+export function fisherYatesShuffle<T>(items: T[]): T[] {
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+export function buildSingleElimSlots(
+  size: TournamentSize,
+  seeded: SeededTeam[],
+): TournamentSlot[] {
+  if (seeded.length !== size.value) {
+    throw new Error("Seeded field must equal tournament size");
+  }
+
+  const bySeed = new Map(seeded.map((entry) => [entry.seed, entry.teamId]));
+  const rounds = size.rounds;
+  const byRound: TournamentSlot[][] = [];
+
+  for (let round = 1; round <= rounds; round++) {
+    const count = size.value / 2 ** round;
+    const slots: TournamentSlot[] = [];
+    for (let position = 0; position < count; position++) {
+      slots.push(TournamentSlot.create({ round, position }));
+    }
+    byRound.push(slots);
+  }
+
+  for (let r = 0; r < byRound.length - 1; r++) {
+    for (let i = 0; i < byRound[r].length; i++) {
+      const next = byRound[r + 1][Math.floor(i / 2)];
+      byRound[r][i].setNext(next.id, i % 2 === 0 ? "home" : "away");
+    }
+  }
+
+  const order = seedPositions(size);
+  const first = byRound[0];
+  for (let i = 0; i < first.length; i++) {
+    const homeSeed = order[i * 2];
+    const awaySeed = order[i * 2 + 1];
+    const homeTeamId = bySeed.get(homeSeed);
+    const awayTeamId = bySeed.get(awaySeed);
+    if (!homeTeamId || !awayTeamId) {
+      throw new Error("Missing seeded team for first-round pair");
+    }
+    first[i].placeTeams(homeTeamId, awayTeamId, homeSeed, awaySeed);
+  }
+
+  return byRound.flat();
+}

--- a/src/modules/tournaments/entities/tournament-already-active-error.ts
+++ b/src/modules/tournaments/entities/tournament-already-active-error.ts
@@ -1,0 +1,6 @@
+export class TournamentAlreadyActiveError extends Error {
+  constructor(message = "Tournament draw has already been generated") {
+    super(message);
+    this.name = "TournamentAlreadyActiveError";
+  }
+}

--- a/src/modules/tournaments/entities/tournament-forbidden-error.ts
+++ b/src/modules/tournaments/entities/tournament-forbidden-error.ts
@@ -1,0 +1,6 @@
+export class TournamentForbiddenError extends Error {
+  constructor(message = "Not allowed for this tournament") {
+    super(message);
+    this.name = "TournamentForbiddenError";
+  }
+}

--- a/src/modules/tournaments/entities/tournament-full-error.ts
+++ b/src/modules/tournaments/entities/tournament-full-error.ts
@@ -1,0 +1,6 @@
+export class TournamentFullError extends Error {
+  constructor(message = "Tournament is full") {
+    super(message);
+    this.name = "TournamentFullError";
+  }
+}

--- a/src/modules/tournaments/entities/tournament-invite-token.ts
+++ b/src/modules/tournaments/entities/tournament-invite-token.ts
@@ -1,0 +1,31 @@
+import { randomBytes } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+export const TOURNAMENT_INVITE_TOKEN_LENGTH = 32;
+const TOURNAMENT_INVITE_TOKEN_PATTERN = /^[a-f0-9]+$/;
+
+export class TournamentInviteToken {
+  private constructor(readonly value: string) {}
+
+  static generate(): TournamentInviteToken {
+    return new TournamentInviteToken(randomBytes(16).toString("hex"));
+  }
+
+  static from(raw: unknown): TournamentInviteToken {
+    const value = requiredTrimmed(raw, "token").toLowerCase();
+    if (value.length !== TOURNAMENT_INVITE_TOKEN_LENGTH) {
+      throw new DomainError(
+        `token must be ${TOURNAMENT_INVITE_TOKEN_LENGTH} characters`,
+      );
+    }
+    if (!TOURNAMENT_INVITE_TOKEN_PATTERN.test(value)) {
+      throw new DomainError("token is invalid");
+    }
+    return new TournamentInviteToken(value);
+  }
+
+  equals(other: TournamentInviteToken): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/tournaments/entities/tournament-name.ts
+++ b/src/modules/tournaments/entities/tournament-name.ts
@@ -1,0 +1,19 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const MAX_LENGTH = 80;
+
+export class TournamentName {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): TournamentName {
+    const name = requiredTrimmed(raw, "name");
+    if (name.length > MAX_LENGTH) {
+      throw new DomainError(`name must be at most ${MAX_LENGTH} characters`);
+    }
+    return new TournamentName(name);
+  }
+
+  equals(other: TournamentName): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/tournaments/entities/tournament-not-found-error.ts
+++ b/src/modules/tournaments/entities/tournament-not-found-error.ts
@@ -1,0 +1,6 @@
+export class TournamentNotFoundError extends Error {
+  constructor(message = "Tournament not found") {
+    super(message);
+    this.name = "TournamentNotFoundError";
+  }
+}

--- a/src/modules/tournaments/entities/tournament-not-ready-error.ts
+++ b/src/modules/tournaments/entities/tournament-not-ready-error.ts
@@ -1,0 +1,6 @@
+export class TournamentNotReadyError extends Error {
+  constructor(message = "Tournament is not ready") {
+    super(message);
+    this.name = "TournamentNotReadyError";
+  }
+}

--- a/src/modules/tournaments/entities/tournament-persistence-error.ts
+++ b/src/modules/tournaments/entities/tournament-persistence-error.ts
@@ -1,0 +1,6 @@
+export class TournamentPersistenceError extends Error {
+  constructor(message = "Unable to save tournament", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "TournamentPersistenceError";
+  }
+}

--- a/src/modules/tournaments/entities/tournament-registration-not-found-error.ts
+++ b/src/modules/tournaments/entities/tournament-registration-not-found-error.ts
@@ -1,0 +1,6 @@
+export class TournamentRegistrationNotFoundError extends Error {
+  constructor(message = "Tournament registration not found") {
+    super(message);
+    this.name = "TournamentRegistrationNotFoundError";
+  }
+}

--- a/src/modules/tournaments/entities/tournament-registration-status.ts
+++ b/src/modules/tournaments/entities/tournament-registration-status.ts
@@ -1,0 +1,41 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const TOURNAMENT_REGISTRATION_STATUSES = [
+  "pending",
+  "accepted",
+  "withdrawn",
+] as const;
+
+export type TournamentRegistrationStatusValue =
+  (typeof TOURNAMENT_REGISTRATION_STATUSES)[number];
+
+export class TournamentRegistrationStatus {
+  static readonly PENDING = new TournamentRegistrationStatus("pending");
+  static readonly ACCEPTED = new TournamentRegistrationStatus("accepted");
+  static readonly WITHDRAWN = new TournamentRegistrationStatus("withdrawn");
+
+  private constructor(readonly value: TournamentRegistrationStatusValue) {}
+
+  static from(raw: unknown): TournamentRegistrationStatus {
+    if (raw === "pending") return TournamentRegistrationStatus.PENDING;
+    if (raw === "accepted") return TournamentRegistrationStatus.ACCEPTED;
+    if (raw === "withdrawn") return TournamentRegistrationStatus.WITHDRAWN;
+    throw new DomainError("status must be pending, accepted, or withdrawn");
+  }
+
+  get isPending(): boolean {
+    return this.value === "pending";
+  }
+
+  get isAccepted(): boolean {
+    return this.value === "accepted";
+  }
+
+  get isWithdrawn(): boolean {
+    return this.value === "withdrawn";
+  }
+
+  equals(other: TournamentRegistrationStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/tournaments/entities/tournament-registration.ts
+++ b/src/modules/tournaments/entities/tournament-registration.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from "node:crypto";
+
+import { requiredTrimmed } from "../../../lib/domain-error";
+import { TournamentRegistrationStatus } from "./tournament-registration-status";
+
+export type TournamentRegistrationSnapshot = {
+  id: string;
+  teamId: string;
+  status: "pending" | "accepted" | "withdrawn";
+  seed: number | null;
+  registeredBy: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export class TournamentRegistration {
+  private constructor(
+    readonly id: string,
+    readonly teamId: string,
+    private statusValue: TournamentRegistrationStatus,
+    private seedValue: number | null,
+    readonly registeredBy: string,
+    readonly createdAt: Date,
+    private updatedAtValue: Date,
+  ) {}
+
+  static create(
+    teamId: string,
+    registeredBy: string,
+    status: TournamentRegistrationStatus,
+    now = new Date(),
+  ): TournamentRegistration {
+    return new TournamentRegistration(
+      randomUUID(),
+      requiredTrimmed(teamId, "teamId"),
+      status,
+      null,
+      requiredTrimmed(registeredBy, "userId"),
+      now,
+      now,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    teamId: string;
+    status: TournamentRegistrationStatus;
+    seed: number | null;
+    registeredBy: string;
+    createdAt: Date;
+    updatedAt: Date;
+  }): TournamentRegistration {
+    return new TournamentRegistration(
+      props.id,
+      props.teamId,
+      props.status,
+      props.seed,
+      props.registeredBy,
+      props.createdAt,
+      props.updatedAt,
+    );
+  }
+
+  static fromSnapshot(
+    snapshot: TournamentRegistrationSnapshot,
+  ): TournamentRegistration {
+    return TournamentRegistration.rehydrate({
+      id: snapshot.id,
+      teamId: snapshot.teamId,
+      status: TournamentRegistrationStatus.from(snapshot.status),
+      seed: snapshot.seed,
+      registeredBy: snapshot.registeredBy,
+      createdAt: new Date(snapshot.createdAt),
+      updatedAt: new Date(snapshot.updatedAt),
+    });
+  }
+
+  get status(): TournamentRegistrationStatus {
+    return this.statusValue;
+  }
+
+  get seed(): number | null {
+    return this.seedValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  accept(now = new Date()): void {
+    this.statusValue = TournamentRegistrationStatus.ACCEPTED;
+    this.touch(now);
+  }
+
+  withdraw(now = new Date()): void {
+    this.statusValue = TournamentRegistrationStatus.WITHDRAWN;
+    this.seedValue = null;
+    this.touch(now);
+  }
+
+  markPending(now = new Date()): void {
+    this.statusValue = TournamentRegistrationStatus.PENDING;
+    this.seedValue = null;
+    this.touch(now);
+  }
+
+  assignSeed(seed: number, now = new Date()): void {
+    this.seedValue = seed;
+    this.touch(now);
+  }
+
+  toSnapshot(): TournamentRegistrationSnapshot {
+    return {
+      id: this.id,
+      teamId: this.teamId,
+      status: this.statusValue.value,
+      seed: this.seedValue,
+      registeredBy: this.registeredBy,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+    };
+  }
+
+  private touch(now = new Date()): void {
+    this.updatedAtValue = now;
+  }
+}

--- a/src/modules/tournaments/entities/tournament-size.ts
+++ b/src/modules/tournaments/entities/tournament-size.ts
@@ -1,0 +1,37 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const TOURNAMENT_SIZES = [4, 8, 16] as const;
+export type TournamentSizeValue = (typeof TOURNAMENT_SIZES)[number];
+
+export class TournamentSize {
+  static readonly FOUR = new TournamentSize(4);
+  static readonly EIGHT = new TournamentSize(8);
+  static readonly SIXTEEN = new TournamentSize(16);
+
+  private constructor(readonly value: TournamentSizeValue) {}
+
+  static from(raw: unknown): TournamentSize {
+    const parsed =
+      typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : NaN;
+    if (parsed === 4) return TournamentSize.FOUR;
+    if (parsed === 8) return TournamentSize.EIGHT;
+    if (parsed === 16) return TournamentSize.SIXTEEN;
+    throw new DomainError("size must be 4, 8, or 16");
+  }
+
+  get rounds(): number {
+    return Math.log2(this.value);
+  }
+
+  get firstRoundSlots(): number {
+    return this.value / 2;
+  }
+
+  get totalSlots(): number {
+    return this.value - 1;
+  }
+
+  equals(other: TournamentSize): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/tournaments/entities/tournament-slot-not-found-error.ts
+++ b/src/modules/tournaments/entities/tournament-slot-not-found-error.ts
@@ -1,0 +1,6 @@
+export class TournamentSlotNotFoundError extends Error {
+  constructor(message = "Tournament fixture not found") {
+    super(message);
+    this.name = "TournamentSlotNotFoundError";
+  }
+}

--- a/src/modules/tournaments/entities/tournament-slot.ts
+++ b/src/modules/tournaments/entities/tournament-slot.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+export type TournamentSlotSide = "home" | "away";
+
+export type TournamentSlotSnapshot = {
+  id: string;
+  round: number;
+  position: number;
+  homeTeamId: string | null;
+  awayTeamId: string | null;
+  homeSeed: number | null;
+  awaySeed: number | null;
+  teamMatchId: string | null;
+  winnerTeamId: string | null;
+  nextSlotId: string | null;
+  nextSide: TournamentSlotSide | null;
+};
+
+export class TournamentSlot {
+  private constructor(
+    readonly id: string,
+    readonly round: number,
+    readonly position: number,
+    private homeTeamIdValue: string | null,
+    private awayTeamIdValue: string | null,
+    private homeSeedValue: number | null,
+    private awaySeedValue: number | null,
+    private teamMatchIdValue: string | null,
+    private winnerTeamIdValue: string | null,
+    private nextSlotIdValue: string | null,
+    private nextSideValue: TournamentSlotSide | null,
+  ) {}
+
+  static create(props: { round: number; position: number }): TournamentSlot {
+    return new TournamentSlot(
+      randomUUID(),
+      props.round,
+      props.position,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    );
+  }
+
+  static rehydrate(props: TournamentSlotSnapshot): TournamentSlot {
+    return new TournamentSlot(
+      props.id,
+      props.round,
+      props.position,
+      props.homeTeamId,
+      props.awayTeamId,
+      props.homeSeed,
+      props.awaySeed,
+      props.teamMatchId,
+      props.winnerTeamId,
+      props.nextSlotId,
+      props.nextSide,
+    );
+  }
+
+  static fromSnapshot(snapshot: TournamentSlotSnapshot): TournamentSlot {
+    return TournamentSlot.rehydrate(snapshot);
+  }
+
+  get homeTeamId(): string | null {
+    return this.homeTeamIdValue;
+  }
+
+  get awayTeamId(): string | null {
+    return this.awayTeamIdValue;
+  }
+
+  get homeSeed(): number | null {
+    return this.homeSeedValue;
+  }
+
+  get awaySeed(): number | null {
+    return this.awaySeedValue;
+  }
+
+  get teamMatchId(): string | null {
+    return this.teamMatchIdValue;
+  }
+
+  get winnerTeamId(): string | null {
+    return this.winnerTeamIdValue;
+  }
+
+  get nextSlotId(): string | null {
+    return this.nextSlotIdValue;
+  }
+
+  get nextSide(): TournamentSlotSide | null {
+    return this.nextSideValue;
+  }
+
+  get isReady(): boolean {
+    return this.homeTeamIdValue !== null && this.awayTeamIdValue !== null;
+  }
+
+  get isFinal(): boolean {
+    return this.nextSlotIdValue === null;
+  }
+
+  involvesTeam(teamId: string): boolean {
+    return (
+      this.homeTeamIdValue === teamId || this.awayTeamIdValue === teamId
+    );
+  }
+
+  setNext(nextSlotId: string, nextSide: TournamentSlotSide): void {
+    this.nextSlotIdValue = nextSlotId;
+    this.nextSideValue = nextSide;
+  }
+
+  placeTeams(
+    homeTeamId: string,
+    awayTeamId: string,
+    homeSeed: number,
+    awaySeed: number,
+  ): void {
+    this.homeTeamIdValue = homeTeamId;
+    this.awayTeamIdValue = awayTeamId;
+    this.homeSeedValue = homeSeed;
+    this.awaySeedValue = awaySeed;
+  }
+
+  placeSide(side: TournamentSlotSide, teamId: string): void {
+    const id = requiredTrimmed(teamId, "teamId");
+    if (side === "home") {
+      if (this.homeTeamIdValue && this.homeTeamIdValue !== id) {
+        throw new DomainError("Home side is already occupied");
+      }
+      this.homeTeamIdValue = id;
+      return;
+    }
+    if (this.awayTeamIdValue && this.awayTeamIdValue !== id) {
+      throw new DomainError("Away side is already occupied");
+    }
+    this.awayTeamIdValue = id;
+  }
+
+  attachMatch(teamMatchId: string): void {
+    const id = requiredTrimmed(teamMatchId, "teamMatchId");
+    if (this.teamMatchIdValue && this.teamMatchIdValue !== id) {
+      throw new DomainError("Fixture already has a team match");
+    }
+    if (!this.isReady) {
+      throw new DomainError("Both teams must be set before starting a fixture");
+    }
+    this.teamMatchIdValue = id;
+  }
+
+  setWinner(winnerTeamId: string): void {
+    const id = requiredTrimmed(winnerTeamId, "winnerTeamId");
+    if (!this.involvesTeam(id)) {
+      throw new DomainError("winnerTeamId must be home or away");
+    }
+    if (this.winnerTeamIdValue && this.winnerTeamIdValue !== id) {
+      throw new DomainError("Fixture already has a different winner");
+    }
+    this.winnerTeamIdValue = id;
+  }
+
+  toSnapshot(): TournamentSlotSnapshot {
+    return {
+      id: this.id,
+      round: this.round,
+      position: this.position,
+      homeTeamId: this.homeTeamIdValue,
+      awayTeamId: this.awayTeamIdValue,
+      homeSeed: this.homeSeedValue,
+      awaySeed: this.awaySeedValue,
+      teamMatchId: this.teamMatchIdValue,
+      winnerTeamId: this.winnerTeamIdValue,
+      nextSlotId: this.nextSlotIdValue,
+      nextSide: this.nextSideValue,
+    };
+  }
+}

--- a/src/modules/tournaments/entities/tournament-sport-mismatch-error.ts
+++ b/src/modules/tournaments/entities/tournament-sport-mismatch-error.ts
@@ -1,0 +1,6 @@
+export class TournamentSportMismatchError extends Error {
+  constructor(message = "Team sport must match the tournament") {
+    super(message);
+    this.name = "TournamentSportMismatchError";
+  }
+}

--- a/src/modules/tournaments/entities/tournament-status.ts
+++ b/src/modules/tournaments/entities/tournament-status.ts
@@ -1,0 +1,57 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const TOURNAMENT_STATUSES = [
+  "draft",
+  "registration",
+  "active",
+  "completed",
+] as const;
+
+export type TournamentStatusValue = (typeof TOURNAMENT_STATUSES)[number];
+
+export class TournamentStatus {
+  static readonly DRAFT = new TournamentStatus("draft");
+  static readonly REGISTRATION = new TournamentStatus("registration");
+  static readonly ACTIVE = new TournamentStatus("active");
+  static readonly COMPLETED = new TournamentStatus("completed");
+
+  private constructor(readonly value: TournamentStatusValue) {}
+
+  static from(raw: unknown): TournamentStatus {
+    if (raw === "draft") return TournamentStatus.DRAFT;
+    if (raw === "registration") return TournamentStatus.REGISTRATION;
+    if (raw === "active") return TournamentStatus.ACTIVE;
+    if (raw === "completed") return TournamentStatus.COMPLETED;
+    throw new DomainError(
+      "status must be draft, registration, active, or completed",
+    );
+  }
+
+  get isDraft(): boolean {
+    return this.value === "draft";
+  }
+
+  get isRegistration(): boolean {
+    return this.value === "registration";
+  }
+
+  get isActive(): boolean {
+    return this.value === "active";
+  }
+
+  get isCompleted(): boolean {
+    return this.value === "completed";
+  }
+
+  get hasDraw(): boolean {
+    return this.isActive || this.isCompleted;
+  }
+
+  get isOpenForRegistration(): boolean {
+    return this.isRegistration;
+  }
+
+  equals(other: TournamentStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/tournaments/entities/tournament.test.ts
+++ b/src/modules/tournaments/entities/tournament.test.ts
@@ -1,0 +1,174 @@
+import { DomainError } from "../../../lib/domain-error";
+import { TeamSport } from "../../teams/entities/team-sport";
+import { seedPositions } from "./bracket";
+import { Tournament } from "./tournament";
+import { TournamentForbiddenError } from "./tournament-forbidden-error";
+import { TournamentFullError } from "./tournament-full-error";
+import { TournamentInviteToken } from "./tournament-invite-token";
+import { TournamentName } from "./tournament-name";
+import { TournamentNotReadyError } from "./tournament-not-ready-error";
+import { TournamentSize } from "./tournament-size";
+import { TournamentStatus } from "./tournament-status";
+
+function draft(size: 4 | 8 | 16 = 4) {
+  return Tournament.create({
+    name: TournamentName.from("Sunday Cup"),
+    sport: TeamSport.PADEL,
+    size: TournamentSize.from(size),
+    organizerUserId: "user-org",
+  });
+}
+
+function fillAccepted(tournament: Tournament, count: number) {
+  for (let i = 1; i <= count; i++) {
+    tournament.registerAccepted(`team-${i}`, `captain-${i}`);
+  }
+}
+
+describe("tournament value objects", () => {
+  test("size is 4, 8, or 16", () => {
+    expect(TournamentSize.from(4).totalSlots).toBe(3);
+    expect(TournamentSize.from("8").firstRoundSlots).toBe(4);
+    expect(TournamentSize.from(16).rounds).toBe(4);
+    expect(() => TournamentSize.from(6)).toThrow(DomainError);
+  });
+
+  test("status is a closed enum", () => {
+    expect(TournamentStatus.from("draft").isDraft).toBe(true);
+    expect(() => TournamentStatus.from("open")).toThrow(DomainError);
+  });
+
+  test("invite token is 32 hex chars", () => {
+    const token = TournamentInviteToken.generate();
+    expect(token.value).toHaveLength(32);
+    expect(TournamentInviteToken.from(token.value).equals(token)).toBe(true);
+    expect(() => TournamentInviteToken.from("nope")).toThrow(DomainError);
+  });
+
+  test("standard seed order places 1 vs size in the first slot", () => {
+    expect(seedPositions(TournamentSize.FOUR)).toEqual([1, 4, 2, 3]);
+    expect(seedPositions(TournamentSize.EIGHT)).toEqual([1, 8, 4, 5, 2, 7, 3, 6]);
+  });
+});
+
+describe(Tournament, () => {
+  test("create is a draft owned by the organizer", () => {
+    const tournament = draft();
+    const snapshot = tournament.toSnapshot();
+    expect(snapshot).toMatchObject({
+      name: "Sunday Cup",
+      sport: "padel",
+      size: 4,
+      status: "draft",
+      organizerUserId: "user-org",
+      winnerTeamId: null,
+    });
+    expect(snapshot.inviteToken).toHaveLength(32);
+    expect(snapshot.registrations).toEqual([]);
+    expect(snapshot.slots).toEqual([]);
+  });
+
+  test("only the organizer can edit a draft or open registration", () => {
+    const tournament = draft();
+    expect(() =>
+      tournament.updateDetails("user-z", { name: TournamentName.from("Nope") }),
+    ).toThrow(TournamentForbiddenError);
+    expect(() => tournament.openRegistration("user-z")).toThrow(
+      TournamentForbiddenError,
+    );
+
+    tournament.updateDetails("user-org", { name: TournamentName.from("Renamed") });
+    tournament.openRegistration("user-org");
+    expect(tournament.status.isRegistration).toBe(true);
+    expect(() =>
+      tournament.updateDetails("user-org", { name: TournamentName.from("Later") }),
+    ).toThrow(DomainError);
+  });
+
+  test("cannot generate a draw until the field is full", () => {
+    const tournament = draft();
+    tournament.openRegistration("user-org");
+    fillAccepted(tournament, 3);
+    expect(() => tournament.generateDraw("user-org")).toThrow(
+      TournamentNotReadyError,
+    );
+
+    tournament.registerAccepted("team-4", "captain-4");
+    tournament.generateDraw("user-org", (items) => items);
+    expect(tournament.status.isActive).toBe(true);
+    expect(tournament.slots).toHaveLength(3);
+    expect(tournament.slots.filter((slot) => slot.round === 1)).toHaveLength(2);
+    for (const slot of tournament.slots.filter((slot) => slot.round === 1)) {
+      expect(slot.isReady).toBe(true);
+      expect(slot.homeTeamId).not.toBe(slot.awayTeamId);
+    }
+  });
+
+  test("cannot register after the draw and cannot overfill", () => {
+    const tournament = draft();
+    tournament.openRegistration("user-org");
+    fillAccepted(tournament, 4);
+    expect(() => tournament.registerAccepted("team-5", "captain-5")).toThrow(
+      TournamentFullError,
+    );
+    tournament.generateDraw("user-org", (items) => items);
+    expect(() => tournament.registerAccepted("team-5", "captain-5")).toThrow(
+      DomainError,
+    );
+    expect(() => tournament.withdrawRegistration("team-1")).toThrow(DomainError);
+  });
+
+  test("withdraw before the draw frees a spot", () => {
+    const tournament = draft();
+    tournament.openRegistration("user-org");
+    fillAccepted(tournament, 4);
+    tournament.withdrawRegistration("team-4");
+    expect(tournament.acceptedCount).toBe(3);
+    tournament.registerAccepted("team-5", "captain-5");
+    expect(tournament.acceptedCount).toBe(4);
+  });
+
+  test("starting a fixture creates a link; complete advances; final sets winner", () => {
+    const tournament = draft();
+    tournament.openRegistration("user-org");
+    fillAccepted(tournament, 4);
+    tournament.generateDraw("user-org", (items) => items);
+
+    const firstRound = tournament.slots.filter((slot) => slot.round === 1);
+    const final = tournament.slots.find((slot) => slot.round === 2);
+    expect(final).toBeDefined();
+
+    tournament.attachFixture(firstRound[0].id, "match-1");
+    tournament.attachFixture(firstRound[1].id, "match-2");
+    expect(() => tournament.attachFixture(firstRound[0].id, "match-other")).toThrow(
+      DomainError,
+    );
+
+    tournament.advanceFromMatch("match-1", firstRound[0].homeTeamId!);
+    tournament.advanceFromMatch("match-2", firstRound[1].homeTeamId!);
+    expect(final!.isReady).toBe(true);
+    expect(final!.homeTeamId).toBe(firstRound[0].homeTeamId);
+    expect(final!.awayTeamId).toBe(firstRound[1].homeTeamId);
+
+    tournament.attachFixture(final!.id, "match-final");
+    tournament.advanceFromMatch("match-final", final!.homeTeamId!);
+    expect(tournament.status.isCompleted).toBe(true);
+    expect(tournament.winnerTeamId).toBe(final!.homeTeamId);
+  });
+
+  test("cannot delete after registration opens", () => {
+    const tournament = draft();
+    tournament.assertCanDelete("user-org");
+    tournament.openRegistration("user-org");
+    expect(() => tournament.assertCanDelete("user-org")).toThrow(DomainError);
+  });
+
+  test("round-trips through a snapshot", () => {
+    const tournament = draft();
+    tournament.openRegistration("user-org");
+    fillAccepted(tournament, 4);
+    tournament.generateDraw("user-org", (items) => items);
+    const copy = Tournament.fromSnapshot(tournament.toSnapshot());
+    expect(copy.toSnapshot()).toEqual(tournament.toSnapshot());
+  });
+});

--- a/src/modules/tournaments/entities/tournament.ts
+++ b/src/modules/tournaments/entities/tournament.ts
@@ -1,0 +1,502 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { OptionalStartsAt } from "../../team-matches/entities/optional-starts-at";
+import { OptionalVenueCmsId } from "../../team-matches/entities/optional-venue-cms-id";
+import { TeamSport } from "../../teams/entities/team-sport";
+import {
+  buildSingleElimSlots,
+  fisherYatesShuffle,
+} from "./bracket";
+import { TournamentAlreadyActiveError } from "./tournament-already-active-error";
+import { TournamentForbiddenError } from "./tournament-forbidden-error";
+import { TournamentFullError } from "./tournament-full-error";
+import { TournamentInviteToken } from "./tournament-invite-token";
+import { TournamentName } from "./tournament-name";
+import { TournamentNotReadyError } from "./tournament-not-ready-error";
+import { TournamentRegistration } from "./tournament-registration";
+import { TournamentRegistrationNotFoundError } from "./tournament-registration-not-found-error";
+import { TournamentRegistrationStatus } from "./tournament-registration-status";
+import { TournamentSize } from "./tournament-size";
+import { TournamentSlot } from "./tournament-slot";
+import { TournamentSlotNotFoundError } from "./tournament-slot-not-found-error";
+import { TournamentStatus } from "./tournament-status";
+
+export type TournamentSnapshot = {
+  id: string;
+  name: string;
+  sport: "padel" | "golf" | "darts";
+  size: 4 | 8 | 16;
+  status: "draft" | "registration" | "active" | "completed";
+  venueCmsId: string | null;
+  startsAt: string | null;
+  organizerUserId: string;
+  winnerTeamId: string | null;
+  inviteToken: string;
+  createdAt: string;
+  updatedAt: string;
+  registrations: ReturnType<TournamentRegistration["toSnapshot"]>[];
+  slots: ReturnType<TournamentSlot["toSnapshot"]>[];
+};
+
+export type CreateTournamentProps = {
+  name: TournamentName;
+  sport: TeamSport;
+  size: TournamentSize;
+  organizerUserId: string;
+  venueCmsId?: OptionalVenueCmsId;
+  startsAt?: OptionalStartsAt;
+};
+
+export type UpdateTournamentDetailsProps = {
+  name?: TournamentName;
+  sport?: TeamSport;
+  size?: TournamentSize;
+  venueCmsId?: OptionalVenueCmsId;
+  startsAt?: OptionalStartsAt;
+};
+
+export class Tournament {
+  private constructor(
+    readonly id: string,
+    private nameValue: TournamentName,
+    private sportValue: TeamSport,
+    private sizeValue: TournamentSize,
+    private statusValue: TournamentStatus,
+    private venueCmsIdValue: OptionalVenueCmsId,
+    private startsAtValue: OptionalStartsAt,
+    readonly organizerUserId: string,
+    private winnerTeamIdValue: string | null,
+    readonly inviteToken: TournamentInviteToken,
+    readonly createdAt: Date,
+    private updatedAtValue: Date,
+    private registrationsValue: TournamentRegistration[],
+    private slotsValue: TournamentSlot[],
+  ) {}
+
+  static create(props: CreateTournamentProps): Tournament {
+    const organizerUserId = requiredTrimmed(props.organizerUserId, "userId");
+    const now = new Date();
+    return new Tournament(
+      randomUUID(),
+      props.name,
+      props.sport,
+      props.size,
+      TournamentStatus.DRAFT,
+      props.venueCmsId ?? OptionalVenueCmsId.from(null),
+      props.startsAt ?? OptionalStartsAt.from(null),
+      organizerUserId,
+      null,
+      TournamentInviteToken.generate(),
+      now,
+      now,
+      [],
+      [],
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    name: TournamentName;
+    sport: TeamSport;
+    size: TournamentSize;
+    status: TournamentStatus;
+    venueCmsId: OptionalVenueCmsId;
+    startsAt: OptionalStartsAt;
+    organizerUserId: string;
+    winnerTeamId: string | null;
+    inviteToken: TournamentInviteToken;
+    createdAt: Date;
+    updatedAt: Date;
+    registrations: TournamentRegistration[];
+    slots: TournamentSlot[];
+  }): Tournament {
+    return new Tournament(
+      props.id,
+      props.name,
+      props.sport,
+      props.size,
+      props.status,
+      props.venueCmsId,
+      props.startsAt,
+      props.organizerUserId,
+      props.winnerTeamId,
+      props.inviteToken,
+      props.createdAt,
+      props.updatedAt,
+      [...props.registrations],
+      [...props.slots],
+    );
+  }
+
+  static fromSnapshot(snapshot: TournamentSnapshot): Tournament {
+    return Tournament.rehydrate({
+      id: snapshot.id,
+      name: TournamentName.from(snapshot.name),
+      sport: TeamSport.from(snapshot.sport),
+      size: TournamentSize.from(snapshot.size),
+      status: TournamentStatus.from(snapshot.status),
+      venueCmsId: OptionalVenueCmsId.from(snapshot.venueCmsId),
+      startsAt: OptionalStartsAt.from(snapshot.startsAt),
+      organizerUserId: snapshot.organizerUserId,
+      winnerTeamId: snapshot.winnerTeamId,
+      inviteToken: TournamentInviteToken.from(snapshot.inviteToken),
+      createdAt: new Date(snapshot.createdAt),
+      updatedAt: new Date(snapshot.updatedAt),
+      registrations: snapshot.registrations.map((row) =>
+        TournamentRegistration.fromSnapshot(row),
+      ),
+      slots: snapshot.slots.map((row) => TournamentSlot.fromSnapshot(row)),
+    });
+  }
+
+  get name(): TournamentName {
+    return this.nameValue;
+  }
+
+  get sport(): TeamSport {
+    return this.sportValue;
+  }
+
+  get size(): TournamentSize {
+    return this.sizeValue;
+  }
+
+  get status(): TournamentStatus {
+    return this.statusValue;
+  }
+
+  get venueCmsId(): string | null {
+    return this.venueCmsIdValue.value;
+  }
+
+  get startsAt(): Date | null {
+    return this.startsAtValue.value;
+  }
+
+  get winnerTeamId(): string | null {
+    return this.winnerTeamIdValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  get registrations(): readonly TournamentRegistration[] {
+    return this.registrationsValue;
+  }
+
+  get slots(): readonly TournamentSlot[] {
+    return this.slotsValue;
+  }
+
+  get acceptedCount(): number {
+    return this.acceptedRegistrations().length;
+  }
+
+  get hasDraw(): boolean {
+    return this.slotsValue.length > 0;
+  }
+
+  isOrganizer(userId: string): boolean {
+    return this.organizerUserId === userId.trim();
+  }
+
+  registrationOf(teamId: string): TournamentRegistration | null {
+    const id = teamId.trim();
+    return (
+      this.registrationsValue.find((entry) => entry.teamId === id) ?? null
+    );
+  }
+
+  slotById(slotId: string): TournamentSlot | null {
+    return this.slotsValue.find((slot) => slot.id === slotId) ?? null;
+  }
+
+  slotByTeamMatchId(teamMatchId: string): TournamentSlot | null {
+    return (
+      this.slotsValue.find((slot) => slot.teamMatchId === teamMatchId) ?? null
+    );
+  }
+
+  enteredTeamIds(): string[] {
+    return this.registrationsValue
+      .filter((entry) => !entry.status.isWithdrawn)
+      .map((entry) => entry.teamId);
+  }
+
+  assertOrganizer(userId: string): void {
+    if (!this.isOrganizer(userId)) {
+      throw new TournamentForbiddenError(
+        "Only the tournament organizer can do that",
+      );
+    }
+  }
+
+  assertCanDelete(userId: string): void {
+    this.assertOrganizer(userId);
+    if (!this.statusValue.isDraft) {
+      throw new DomainError("Only a draft tournament can be deleted");
+    }
+  }
+
+  updateDetails(actorId: string, details: UpdateTournamentDetailsProps): void {
+    this.assertOrganizer(actorId);
+    if (!this.statusValue.isDraft) {
+      throw new DomainError("Only a draft tournament can be edited");
+    }
+    if (
+      details.name == null &&
+      details.sport == null &&
+      details.size == null &&
+      !("venueCmsId" in details) &&
+      !("startsAt" in details)
+    ) {
+      throw new DomainError("At least one field is required");
+    }
+
+    if (details.name) this.nameValue = details.name;
+    if (details.sport) this.sportValue = details.sport;
+    if (details.size) this.sizeValue = details.size;
+    if ("venueCmsId" in details) {
+      this.venueCmsIdValue = details.venueCmsId ?? OptionalVenueCmsId.from(null);
+    }
+    if ("startsAt" in details) {
+      this.startsAtValue = details.startsAt ?? OptionalStartsAt.from(null);
+    }
+    this.touch();
+  }
+
+  openRegistration(actorId: string): void {
+    this.assertOrganizer(actorId);
+    if (this.statusValue.isRegistration) return;
+    if (!this.statusValue.isDraft) {
+      throw new DomainError("Registration can only be opened from draft");
+    }
+    this.statusValue = TournamentStatus.REGISTRATION;
+    this.touch();
+  }
+
+  inviteTeam(actorId: string, teamId: string, now = new Date()): TournamentRegistration {
+    this.assertOrganizer(actorId);
+    this.assertOpenForRegistration();
+    const id = requiredTrimmed(teamId, "teamId");
+    const existing = this.registrationOf(id);
+    if (existing) {
+      if (existing.status.isAccepted || existing.status.isPending) {
+        return existing;
+      }
+      this.assertRoomForAccepted();
+      existing.markPending(now);
+      this.touch(now);
+      return existing;
+    }
+    this.assertRoomForAccepted();
+    const created = TournamentRegistration.create(
+      id,
+      actorId,
+      TournamentRegistrationStatus.PENDING,
+      now,
+    );
+    this.registrationsValue = [...this.registrationsValue, created];
+    this.touch(now);
+    return created;
+  }
+
+  registerAccepted(
+    teamId: string,
+    registeredBy: string,
+    now = new Date(),
+  ): TournamentRegistration {
+    this.assertOpenForRegistration();
+    const id = requiredTrimmed(teamId, "teamId");
+    const existing = this.registrationOf(id);
+    if (existing) {
+      if (existing.status.isAccepted) return existing;
+      this.assertRoomForAccepted();
+      existing.accept(now);
+      this.touch(now);
+      return existing;
+    }
+    this.assertRoomForAccepted();
+    const created = TournamentRegistration.create(
+      id,
+      registeredBy,
+      TournamentRegistrationStatus.ACCEPTED,
+      now,
+    );
+    this.registrationsValue = [...this.registrationsValue, created];
+    this.touch(now);
+    return created;
+  }
+
+  acceptRegistration(teamId: string, now = new Date()): TournamentRegistration {
+    this.assertOpenForRegistration();
+    const entry = this.requireRegistration(teamId);
+    if (entry.status.isAccepted) return entry;
+    if (!entry.status.isPending) {
+      throw new DomainError("Only a pending entry can be accepted");
+    }
+    this.assertRoomForAccepted();
+    entry.accept(now);
+    this.touch(now);
+    return entry;
+  }
+
+  withdrawRegistration(teamId: string, now = new Date()): TournamentRegistration {
+    this.assertOpenForRegistration();
+    const entry = this.requireRegistration(teamId);
+    if (entry.status.isWithdrawn) return entry;
+    entry.withdraw(now);
+    this.touch(now);
+    return entry;
+  }
+
+  generateDraw(
+    actorId: string,
+    shuffle: <T>(items: T[]) => T[] = fisherYatesShuffle,
+  ): void {
+    this.assertOrganizer(actorId);
+    if (this.hasDraw && this.statusValue.isActive) {
+      return;
+    }
+    if (this.hasDraw) {
+      throw new TournamentAlreadyActiveError();
+    }
+    if (!this.statusValue.isRegistration) {
+      throw new TournamentNotReadyError(
+        "Open registration and fill the field before generating a draw",
+      );
+    }
+    const accepted = this.acceptedRegistrations();
+    if (accepted.length !== this.sizeValue.value) {
+      throw new TournamentNotReadyError(
+        `Cannot generate draw until ${this.sizeValue.value} teams are accepted`,
+      );
+    }
+
+    const shuffled = shuffle(accepted);
+    const seeded = shuffled.map((entry, index) => {
+      const seed = index + 1;
+      entry.assignSeed(seed);
+      return { teamId: entry.teamId, seed };
+    });
+    this.slotsValue = buildSingleElimSlots(this.sizeValue, seeded);
+    this.statusValue = TournamentStatus.ACTIVE;
+    this.touch();
+  }
+
+  start(actorId: string): void {
+    this.assertOrganizer(actorId);
+    if (this.statusValue.isActive) return;
+    if (this.statusValue.isCompleted) {
+      throw new DomainError("Tournament is already completed");
+    }
+    if (!this.hasDraw) {
+      throw new TournamentNotReadyError(
+        "Generate the draw before starting the tournament",
+      );
+    }
+    this.statusValue = TournamentStatus.ACTIVE;
+    this.touch();
+  }
+
+  attachFixture(slotId: string, teamMatchId: string): TournamentSlot {
+    if (!this.statusValue.isActive) {
+      throw new TournamentNotReadyError(
+        "Fixtures can only be started after the tournament is active",
+      );
+    }
+    const slot = this.requireSlot(slotId);
+    if (!slot.isReady) {
+      throw new TournamentNotReadyError(
+        "Both teams must be set before starting this fixture",
+      );
+    }
+    slot.attachMatch(teamMatchId);
+    this.touch();
+    return slot;
+  }
+
+  advanceFromMatch(teamMatchId: string, winnerTeamId: string): void {
+    if (!this.statusValue.isActive && !this.statusValue.isCompleted) {
+      throw new DomainError("Tournament is not active");
+    }
+    const slot = this.slotByTeamMatchId(teamMatchId);
+    if (!slot) {
+      throw new TournamentSlotNotFoundError();
+    }
+    if (!winnerTeamId) {
+      throw new DomainError("Bracket advancement requires a match winner");
+    }
+    slot.setWinner(winnerTeamId);
+
+    if (slot.isFinal) {
+      this.winnerTeamIdValue = winnerTeamId;
+      this.statusValue = TournamentStatus.COMPLETED;
+      this.touch();
+      return;
+    }
+
+    if (!slot.nextSlotId || !slot.nextSide) {
+      throw new DomainError("Non-final fixture is missing its next slot");
+    }
+    const next = this.requireSlot(slot.nextSlotId);
+    next.placeSide(slot.nextSide, winnerTeamId);
+    this.touch();
+  }
+
+  toSnapshot(): TournamentSnapshot {
+    return {
+      id: this.id,
+      name: this.nameValue.value,
+      sport: this.sportValue.value,
+      size: this.sizeValue.value,
+      status: this.statusValue.value,
+      venueCmsId: this.venueCmsIdValue.value,
+      startsAt: this.startsAtValue.toIsoString(),
+      organizerUserId: this.organizerUserId,
+      winnerTeamId: this.winnerTeamIdValue,
+      inviteToken: this.inviteToken.value,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+      registrations: this.registrationsValue.map((entry) => entry.toSnapshot()),
+      slots: this.slotsValue.map((slot) => slot.toSnapshot()),
+    };
+  }
+
+  private acceptedRegistrations(): TournamentRegistration[] {
+    return this.registrationsValue.filter((entry) => entry.status.isAccepted);
+  }
+
+  private requireRegistration(teamId: string): TournamentRegistration {
+    const entry = this.registrationOf(teamId);
+    if (!entry) throw new TournamentRegistrationNotFoundError();
+    return entry;
+  }
+
+  private requireSlot(slotId: string): TournamentSlot {
+    const slot = this.slotById(slotId);
+    if (!slot) throw new TournamentSlotNotFoundError();
+    return slot;
+  }
+
+  private assertOpenForRegistration(): void {
+    if (!this.statusValue.isOpenForRegistration) {
+      throw new DomainError("Registration is not open");
+    }
+    if (this.hasDraw) {
+      throw new DomainError("Cannot change entries after the draw");
+    }
+  }
+
+  private assertRoomForAccepted(): void {
+    if (this.acceptedCount >= this.sizeValue.value) {
+      throw new TournamentFullError();
+    }
+  }
+
+  private touch(now = new Date()): void {
+    this.updatedAtValue = now;
+  }
+}

--- a/src/modules/tournaments/index.ts
+++ b/src/modules/tournaments/index.ts
@@ -1,0 +1,132 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { TeamMatchRepository } from "../team-matches/repositories/team-match.repository";
+import { TeamRepository } from "../teams/repositories/team.repository";
+import { createTournamentsController } from "./controllers/tournaments.controller";
+import { PrismaTournamentRepository } from "./repositories/prisma-tournament.repository";
+import { TournamentRepository } from "./repositories/tournament.repository";
+import { createTournamentsRoutes } from "./routes/tournaments.routes";
+import { AdvanceTournamentOnTeamMatchComplete } from "./services/advance-on-team-match-complete";
+import {
+  AcceptRegistration,
+  CreateTournament,
+  DeleteTournament,
+  GenerateDraw,
+  GetTournament,
+  InviteTeam,
+  JoinTournament,
+  ListMyTournaments,
+  ListTeamTournaments,
+  OpenRegistration,
+  RegisterTeam,
+  StartFixture,
+  StartTournament,
+  UpdateTournament,
+  WithdrawRegistration,
+} from "./services/tournaments.service";
+
+export type CreateTournamentsModuleParams = {
+  prisma: PrismaClient;
+  teamRepository: TeamRepository;
+  teamMatchRepository: TeamMatchRepository;
+  tournamentRepository?: TournamentRepository;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type TournamentsModule = {
+  router: Router;
+  tournamentRepository: TournamentRepository;
+  advanceOnTeamMatchComplete: AdvanceTournamentOnTeamMatchComplete;
+};
+
+export function createTournamentsModule({
+  prisma,
+  teamRepository,
+  teamMatchRepository,
+  tournamentRepository: tournamentRepositoryOverride,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreateTournamentsModuleParams): TournamentsModule {
+  const tournamentRepository =
+    tournamentRepositoryOverride ?? new PrismaTournamentRepository(prisma);
+
+  const controller = createTournamentsController({
+    createTournament: new CreateTournament(teamRepository, tournamentRepository),
+    getTournament: new GetTournament(teamRepository, tournamentRepository),
+    updateTournament: new UpdateTournament(teamRepository, tournamentRepository),
+    deleteTournament: new DeleteTournament(tournamentRepository),
+    openRegistration: new OpenRegistration(teamRepository, tournamentRepository),
+    registerTeam: new RegisterTeam(teamRepository, tournamentRepository),
+    joinTournament: new JoinTournament(teamRepository, tournamentRepository),
+    inviteTeam: new InviteTeam(teamRepository, tournamentRepository),
+    acceptRegistration: new AcceptRegistration(
+      teamRepository,
+      tournamentRepository,
+    ),
+    withdrawRegistration: new WithdrawRegistration(
+      teamRepository,
+      tournamentRepository,
+    ),
+    generateDraw: new GenerateDraw(teamRepository, tournamentRepository),
+    startTournament: new StartTournament(teamRepository, tournamentRepository),
+    startFixture: new StartFixture(
+      teamRepository,
+      tournamentRepository,
+      teamMatchRepository,
+    ),
+    listMyTournaments: new ListMyTournaments(
+      teamRepository,
+      tournamentRepository,
+    ),
+    listTeamTournaments: new ListTeamTournaments(
+      teamRepository,
+      tournamentRepository,
+    ),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createTournamentsRoutes(controller, { requireAuth }),
+    tournamentRepository,
+    advanceOnTeamMatchComplete: new AdvanceTournamentOnTeamMatchComplete(
+      tournamentRepository,
+    ),
+  };
+}
+
+export { createTournamentsController } from "./controllers/tournaments.controller";
+export { InMemoryTournamentRepository } from "./repositories/in-memory-tournament.repository";
+export { PrismaTournamentRepository } from "./repositories/prisma-tournament.repository";
+export type { TournamentRepository } from "./repositories/tournament.repository";
+export { Tournament } from "./entities/tournament";
+export { AdvanceTournamentOnTeamMatchComplete } from "./services/advance-on-team-match-complete";
+export {
+  AcceptRegistration,
+  CreateTournament,
+  DeleteTournament,
+  GenerateDraw,
+  GetTournament,
+  InviteTeam,
+  JoinTournament,
+  ListMyTournaments,
+  ListTeamTournaments,
+  OpenRegistration,
+  RegisterTeam,
+  StartFixture,
+  StartTournament,
+  UpdateTournament,
+  WithdrawRegistration,
+} from "./services/tournaments.service";
+export type {
+  PublicRegistration,
+  PublicSlot,
+  PublicTournament,
+  PublicTournamentSummary,
+} from "./services/tournaments.service";

--- a/src/modules/tournaments/repositories/in-memory-tournament.repository.ts
+++ b/src/modules/tournaments/repositories/in-memory-tournament.repository.ts
@@ -1,0 +1,73 @@
+import { Tournament } from "../entities/tournament";
+import { TournamentPersistenceError } from "../entities/tournament-persistence-error";
+import { TournamentRepository } from "./tournament.repository";
+
+export class InMemoryTournamentRepository implements TournamentRepository {
+  private readonly byId = new Map<string, Tournament>();
+
+  async findById(id: string): Promise<Tournament | null> {
+    return clone(this.byId.get(id) ?? null);
+  }
+
+  async findByInviteToken(token: string): Promise<Tournament | null> {
+    const value = token.trim().toLowerCase();
+    for (const tournament of this.byId.values()) {
+      if (tournament.inviteToken.value === value) {
+        return clone(tournament);
+      }
+    }
+    return null;
+  }
+
+  async findByTeamMatchId(teamMatchId: string): Promise<Tournament | null> {
+    const id = teamMatchId.trim();
+    for (const tournament of this.byId.values()) {
+      if (tournament.slotByTeamMatchId(id)) {
+        return clone(tournament);
+      }
+    }
+    return null;
+  }
+
+  async create(tournament: Tournament): Promise<Tournament> {
+    const stored = clone(tournament)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async persist(tournament: Tournament): Promise<Tournament> {
+    if (!this.byId.has(tournament.id)) {
+      throw new TournamentPersistenceError("Unable to save tournament");
+    }
+    const stored = clone(tournament)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async delete(id: string): Promise<void> {
+    this.byId.delete(id);
+  }
+
+  async listForOrganizer(userId: string): Promise<Tournament[]> {
+    return [...this.byId.values()]
+      .filter((tournament) => tournament.isOrganizer(userId))
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+      .map((tournament) => clone(tournament)!);
+  }
+
+  async listForTeamIds(teamIds: string[]): Promise<Tournament[]> {
+    if (teamIds.length === 0) return [];
+    const ids = new Set(teamIds);
+    return [...this.byId.values()]
+      .filter((tournament) =>
+        tournament.registrations.some((entry) => ids.has(entry.teamId)),
+      )
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+      .map((tournament) => clone(tournament)!);
+  }
+}
+
+function clone(tournament: Tournament | null): Tournament | null {
+  if (!tournament) return null;
+  return Tournament.fromSnapshot(tournament.toSnapshot());
+}

--- a/src/modules/tournaments/repositories/prisma-tournament.repository.ts
+++ b/src/modules/tournaments/repositories/prisma-tournament.repository.ts
@@ -1,0 +1,325 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { OptionalStartsAt } from "../../team-matches/entities/optional-starts-at";
+import { OptionalVenueCmsId } from "../../team-matches/entities/optional-venue-cms-id";
+import { TeamSport } from "../../teams/entities/team-sport";
+import { Tournament } from "../entities/tournament";
+import { TournamentInviteToken } from "../entities/tournament-invite-token";
+import { TournamentName } from "../entities/tournament-name";
+import { TournamentPersistenceError } from "../entities/tournament-persistence-error";
+import { TournamentRegistration } from "../entities/tournament-registration";
+import { TournamentRegistrationStatus } from "../entities/tournament-registration-status";
+import { TournamentSize } from "../entities/tournament-size";
+import { TournamentSlot } from "../entities/tournament-slot";
+import { TournamentStatus } from "../entities/tournament-status";
+import { TournamentRepository } from "./tournament.repository";
+
+type RegistrationRow = {
+  id: string;
+  teamId: string;
+  status: "pending" | "accepted" | "withdrawn";
+  seed: number | null;
+  registeredBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type SlotRow = {
+  id: string;
+  round: number;
+  position: number;
+  homeTeamId: string | null;
+  awayTeamId: string | null;
+  homeSeed: number | null;
+  awaySeed: number | null;
+  teamMatchId: string | null;
+  winnerTeamId: string | null;
+  nextSlotId: string | null;
+  nextSide: "home" | "away" | null;
+};
+
+type TournamentRow = {
+  id: string;
+  name: string;
+  sport: "padel" | "golf" | "darts";
+  size: number;
+  status: "draft" | "registration" | "active" | "completed";
+  venueCmsId: string | null;
+  startsAt: Date | null;
+  organizerUserId: string;
+  winnerTeamId: string | null;
+  inviteToken: string;
+  createdAt: Date;
+  updatedAt: Date;
+  registrations: RegistrationRow[];
+  slots: SlotRow[];
+};
+
+function prismaErrorCode(error: unknown): string {
+  if (error && typeof error === "object" && "code" in error) {
+    return String((error as { code?: unknown }).code);
+  }
+  return "";
+}
+
+function toDomain(row: TournamentRow): Tournament {
+  return Tournament.rehydrate({
+    id: row.id,
+    name: TournamentName.from(row.name),
+    sport: TeamSport.from(row.sport),
+    size: TournamentSize.from(row.size),
+    status: TournamentStatus.from(row.status),
+    venueCmsId: OptionalVenueCmsId.from(row.venueCmsId),
+    startsAt: OptionalStartsAt.from(row.startsAt),
+    organizerUserId: row.organizerUserId,
+    winnerTeamId: row.winnerTeamId,
+    inviteToken: TournamentInviteToken.from(row.inviteToken),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    registrations: row.registrations.map((entry) =>
+      TournamentRegistration.rehydrate({
+        id: entry.id,
+        teamId: entry.teamId,
+        status: TournamentRegistrationStatus.from(entry.status),
+        seed: entry.seed,
+        registeredBy: entry.registeredBy,
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+      }),
+    ),
+    slots: row.slots.map((slot) =>
+      TournamentSlot.rehydrate({
+        id: slot.id,
+        round: slot.round,
+        position: slot.position,
+        homeTeamId: slot.homeTeamId,
+        awayTeamId: slot.awayTeamId,
+        homeSeed: slot.homeSeed,
+        awaySeed: slot.awaySeed,
+        teamMatchId: slot.teamMatchId,
+        winnerTeamId: slot.winnerTeamId,
+        nextSlotId: slot.nextSlotId,
+        nextSide: slot.nextSide,
+      }),
+    ),
+  });
+}
+
+const includeRelations = {
+  registrations: { orderBy: { createdAt: "asc" as const } },
+  slots: { orderBy: [{ round: "asc" as const }, { position: "asc" as const }] },
+};
+
+export class PrismaTournamentRepository implements TournamentRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(id: string): Promise<Tournament | null> {
+    try {
+      const row = await this.prisma.tournament.findUnique({
+        where: { id },
+        include: includeRelations,
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new TournamentPersistenceError("Failed to load tournament", {
+        cause: error,
+      });
+    }
+  }
+
+  async findByInviteToken(token: string): Promise<Tournament | null> {
+    try {
+      const row = await this.prisma.tournament.findUnique({
+        where: { inviteToken: token.trim().toLowerCase() },
+        include: includeRelations,
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new TournamentPersistenceError("Failed to load tournament", {
+        cause: error,
+      });
+    }
+  }
+
+  async findByTeamMatchId(teamMatchId: string): Promise<Tournament | null> {
+    try {
+      const slot = await this.prisma.tournamentSlot.findUnique({
+        where: { teamMatchId: teamMatchId.trim() },
+        select: { tournamentId: true },
+      });
+      if (!slot) return null;
+      return this.findById(slot.tournamentId);
+    } catch (error) {
+      throw new TournamentPersistenceError("Failed to load tournament", {
+        cause: error,
+      });
+    }
+  }
+
+  async create(tournament: Tournament): Promise<Tournament> {
+    const snapshot = tournament.toSnapshot();
+    try {
+      const row = await this.prisma.tournament.create({
+        data: {
+          id: snapshot.id,
+          name: snapshot.name,
+          sport: snapshot.sport,
+          size: snapshot.size,
+          status: snapshot.status,
+          venueCmsId: snapshot.venueCmsId,
+          startsAt: tournament.startsAt,
+          organizerUserId: snapshot.organizerUserId,
+          winnerTeamId: snapshot.winnerTeamId,
+          inviteToken: snapshot.inviteToken,
+          createdAt: tournament.createdAt,
+          updatedAt: tournament.updatedAt,
+        },
+        include: includeRelations,
+      });
+      return toDomain(row);
+    } catch (error) {
+      throw new TournamentPersistenceError("Failed to create tournament", {
+        cause: error,
+      });
+    }
+  }
+
+  async persist(tournament: Tournament): Promise<Tournament> {
+    const snapshot = tournament.toSnapshot();
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.tournament.update({
+          where: { id: snapshot.id },
+          data: {
+            name: snapshot.name,
+            sport: snapshot.sport,
+            size: snapshot.size,
+            status: snapshot.status,
+            venueCmsId: snapshot.venueCmsId,
+            startsAt: tournament.startsAt,
+            winnerTeamId: snapshot.winnerTeamId,
+            inviteToken: snapshot.inviteToken,
+            updatedAt: tournament.updatedAt,
+          },
+        });
+
+        for (const entry of snapshot.registrations) {
+          await tx.tournamentRegistration.upsert({
+            where: {
+              tournamentId_teamId: {
+                tournamentId: snapshot.id,
+                teamId: entry.teamId,
+              },
+            },
+            create: {
+              id: entry.id,
+              tournamentId: snapshot.id,
+              teamId: entry.teamId,
+              status: entry.status,
+              seed: entry.seed,
+              registeredBy: entry.registeredBy,
+              createdAt: new Date(entry.createdAt),
+              updatedAt: new Date(entry.updatedAt),
+            },
+            update: {
+              status: entry.status,
+              seed: entry.seed,
+              updatedAt: new Date(entry.updatedAt),
+            },
+          });
+        }
+
+        await tx.tournamentSlot.deleteMany({
+          where: {
+            tournamentId: snapshot.id,
+            id: { notIn: snapshot.slots.map((slot) => slot.id) },
+          },
+        });
+
+        for (const slot of snapshot.slots) {
+          await tx.tournamentSlot.upsert({
+            where: { id: slot.id },
+            create: {
+              id: slot.id,
+              tournamentId: snapshot.id,
+              round: slot.round,
+              position: slot.position,
+              homeTeamId: slot.homeTeamId,
+              awayTeamId: slot.awayTeamId,
+              homeSeed: slot.homeSeed,
+              awaySeed: slot.awaySeed,
+              teamMatchId: slot.teamMatchId,
+              winnerTeamId: slot.winnerTeamId,
+              nextSlotId: slot.nextSlotId,
+              nextSide: slot.nextSide,
+            },
+            update: {
+              homeTeamId: slot.homeTeamId,
+              awayTeamId: slot.awayTeamId,
+              homeSeed: slot.homeSeed,
+              awaySeed: slot.awaySeed,
+              teamMatchId: slot.teamMatchId,
+              winnerTeamId: slot.winnerTeamId,
+              nextSlotId: slot.nextSlotId,
+              nextSide: slot.nextSide,
+            },
+          });
+        }
+      });
+
+      const reloaded = await this.findById(snapshot.id);
+      if (!reloaded) {
+        throw new TournamentPersistenceError("Failed to load tournament");
+      }
+      return reloaded;
+    } catch (error) {
+      if (error instanceof TournamentPersistenceError) throw error;
+      throw new TournamentPersistenceError("Failed to save tournament", {
+        cause: error,
+      });
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      await this.prisma.tournament.delete({ where: { id } });
+    } catch (error) {
+      if (prismaErrorCode(error) === "P2025") return;
+      throw new TournamentPersistenceError("Failed to delete tournament", {
+        cause: error,
+      });
+    }
+  }
+
+  async listForOrganizer(userId: string): Promise<Tournament[]> {
+    try {
+      const rows = await this.prisma.tournament.findMany({
+        where: { organizerUserId: userId },
+        include: includeRelations,
+        orderBy: { updatedAt: "desc" },
+      });
+      return rows.map(toDomain);
+    } catch (error) {
+      throw new TournamentPersistenceError("Failed to list tournaments", {
+        cause: error,
+      });
+    }
+  }
+
+  async listForTeamIds(teamIds: string[]): Promise<Tournament[]> {
+    if (teamIds.length === 0) return [];
+    try {
+      const rows = await this.prisma.tournament.findMany({
+        where: {
+          registrations: { some: { teamId: { in: teamIds } } },
+        },
+        include: includeRelations,
+        orderBy: { updatedAt: "desc" },
+      });
+      return rows.map(toDomain);
+    } catch (error) {
+      throw new TournamentPersistenceError("Failed to list tournaments", {
+        cause: error,
+      });
+    }
+  }
+}

--- a/src/modules/tournaments/repositories/tournament.repository.ts
+++ b/src/modules/tournaments/repositories/tournament.repository.ts
@@ -1,0 +1,12 @@
+import { Tournament } from "../entities/tournament";
+
+export interface TournamentRepository {
+  findById(id: string): Promise<Tournament | null>;
+  findByInviteToken(token: string): Promise<Tournament | null>;
+  findByTeamMatchId(teamMatchId: string): Promise<Tournament | null>;
+  create(tournament: Tournament): Promise<Tournament>;
+  persist(tournament: Tournament): Promise<Tournament>;
+  delete(id: string): Promise<void>;
+  listForOrganizer(userId: string): Promise<Tournament[]>;
+  listForTeamIds(teamIds: string[]): Promise<Tournament[]>;
+}

--- a/src/modules/tournaments/routes/tournaments.routes.ts
+++ b/src/modules/tournaments/routes/tournaments.routes.ts
@@ -1,0 +1,106 @@
+import { Router } from "express";
+
+import { createTournamentsController } from "../controllers/tournaments.controller";
+
+export function createTournamentsRoutes(
+  controller: ReturnType<typeof createTournamentsController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.post("/api/tournaments", options.requireAuth, (req, res) => {
+    void controller.create(req, res);
+  });
+
+  router.post("/api/tournaments/join", options.requireAuth, (req, res) => {
+    void controller.join(req, res);
+  });
+
+  router.get("/api/tournaments/mine", options.requireAuth, (req, res) => {
+    void controller.listMine(req, res);
+  });
+
+  router.get("/api/tournaments/:id", options.requireAuth, (req, res) => {
+    void controller.get(req, res);
+  });
+
+  router.patch("/api/tournaments/:id", options.requireAuth, (req, res) => {
+    void controller.update(req, res);
+  });
+
+  router.delete("/api/tournaments/:id", options.requireAuth, (req, res) => {
+    void controller.remove(req, res);
+  });
+
+  router.post(
+    "/api/tournaments/:id/open-registration",
+    options.requireAuth,
+    (req, res) => {
+      void controller.openRegistration(req, res);
+    },
+  );
+
+  router.post("/api/tournaments/:id/register", options.requireAuth, (req, res) => {
+    void controller.register(req, res);
+  });
+
+  router.post("/api/tournaments/:id/invite", options.requireAuth, (req, res) => {
+    void controller.invite(req, res);
+  });
+
+  router.post(
+    "/api/tournaments/:id/registrations/:teamId/accept",
+    options.requireAuth,
+    (req, res) => {
+      void controller.accept(req, res);
+    },
+  );
+
+  router.post(
+    "/api/tournaments/:id/registrations/:teamId/withdraw",
+    options.requireAuth,
+    (req, res) => {
+      void controller.withdraw(req, res);
+    },
+  );
+
+  router.post(
+    "/api/tournaments/:id/registrations/:teamId/decline",
+    options.requireAuth,
+    (req, res) => {
+      void controller.withdraw(req, res);
+    },
+  );
+
+  router.post(
+    "/api/tournaments/:id/generate-draw",
+    options.requireAuth,
+    (req, res) => {
+      void controller.generateDraw(req, res);
+    },
+  );
+
+  router.post("/api/tournaments/:id/start", options.requireAuth, (req, res) => {
+    void controller.start(req, res);
+  });
+
+  router.post(
+    "/api/tournaments/:id/fixtures/:slotId/start",
+    options.requireAuth,
+    (req, res) => {
+      void controller.startFixture(req, res);
+    },
+  );
+
+  router.get("/api/teams/:id/tournaments", options.requireAuth, (req, res) => {
+    void controller.listForTeam(req, res);
+  });
+
+  return router;
+}

--- a/src/modules/tournaments/services/advance-on-team-match-complete.ts
+++ b/src/modules/tournaments/services/advance-on-team-match-complete.ts
@@ -1,0 +1,20 @@
+import { TeamMatch } from "../../team-matches/entities/team-match";
+import { TournamentPersistenceError } from "../entities/tournament-persistence-error";
+import { TournamentRepository } from "../repositories/tournament.repository";
+
+export class AdvanceTournamentOnTeamMatchComplete {
+  constructor(private readonly tournaments: TournamentRepository) {}
+
+  async execute(match: TeamMatch): Promise<void> {
+    try {
+      if (!match.status.isCompleted || !match.winnerTeamId) return;
+      const tournament = await this.tournaments.findByTeamMatchId(match.id);
+      if (!tournament) return;
+      tournament.advanceFromMatch(match.id, match.winnerTeamId);
+      await this.tournaments.persist(tournament);
+    } catch (error) {
+      if (error instanceof TournamentPersistenceError) return;
+      console.error("Failed to advance tournament from team match", error);
+    }
+  }
+}

--- a/src/modules/tournaments/services/tournaments.service.ts
+++ b/src/modules/tournaments/services/tournaments.service.ts
@@ -1,0 +1,772 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { OptionalStartsAt } from "../../team-matches/entities/optional-starts-at";
+import { OptionalVenueCmsId } from "../../team-matches/entities/optional-venue-cms-id";
+import { TeamMatch } from "../../team-matches/entities/team-match";
+import { TeamMatchRepository } from "../../team-matches/repositories/team-match.repository";
+import { Team } from "../../teams/entities/team";
+import { TeamForbiddenError } from "../../teams/entities/team-forbidden-error";
+import { TeamNotFoundError } from "../../teams/entities/team-not-found-error";
+import { TeamSport } from "../../teams/entities/team-sport";
+import { TeamRepository } from "../../teams/repositories/team.repository";
+import { Tournament } from "../entities/tournament";
+import { TournamentForbiddenError } from "../entities/tournament-forbidden-error";
+import { TournamentInviteToken } from "../entities/tournament-invite-token";
+import { TournamentName } from "../entities/tournament-name";
+import { TournamentNotFoundError } from "../entities/tournament-not-found-error";
+import { TournamentSize } from "../entities/tournament-size";
+import { TournamentSlotNotFoundError } from "../entities/tournament-slot-not-found-error";
+import { TournamentSportMismatchError } from "../entities/tournament-sport-mismatch-error";
+import { TournamentRepository } from "../repositories/tournament.repository";
+
+export type PublicTeamRef = {
+  id: string;
+  name: string;
+  sport: "padel" | "golf" | "darts";
+};
+
+export type PublicRegistration = {
+  team: PublicTeamRef;
+  status: "pending" | "accepted" | "withdrawn";
+  seed: number | null;
+  registeredBy: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PublicSlot = {
+  id: string;
+  round: number;
+  position: number;
+  homeTeam: PublicTeamRef | null;
+  awayTeam: PublicTeamRef | null;
+  homeSeed: number | null;
+  awaySeed: number | null;
+  teamMatchId: string | null;
+  teamMatchPath: string | null;
+  winnerTeamId: string | null;
+  nextSlotId: string | null;
+  nextSide: "home" | "away" | null;
+};
+
+export type PublicTournamentViewer = {
+  role: "organizer" | "captain" | "member";
+  teamId: string | null;
+};
+
+export type PublicTournamentSummary = {
+  id: string;
+  name: string;
+  sport: "padel" | "golf" | "darts";
+  size: 4 | 8 | 16;
+  status: "draft" | "registration" | "active" | "completed";
+  venueCmsId: string | null;
+  startsAt: string | null;
+  organizerUserId: string;
+  winnerTeamId: string | null;
+  acceptedCount: number;
+  createdAt: string;
+  updatedAt: string;
+  viewer: PublicTournamentViewer;
+};
+
+export type PublicTournament = PublicTournamentSummary & {
+  inviteToken: string | null;
+  registrations: PublicRegistration[];
+  bracket: {
+    rounds: number;
+    slots: PublicSlot[];
+  };
+};
+
+function isStaff(team: Team, userId: string): boolean {
+  const membership = team.membershipOf(userId);
+  return membership?.status.isActive === true && membership.role.canInvite;
+}
+
+function requireStaff(team: Team, userId: string, message: string): void {
+  if (!isStaff(team, userId)) {
+    throw new TournamentForbiddenError(message);
+  }
+}
+
+function toTeamRef(team: Team): PublicTeamRef {
+  return {
+    id: team.id,
+    name: team.name.value,
+    sport: team.sport.value,
+  };
+}
+
+async function loadTeam(teams: TeamRepository, teamId: string): Promise<Team> {
+  const id = requiredTrimmed(teamId, "team id");
+  const team = await teams.findById(id);
+  if (!team) throw new TeamNotFoundError();
+  return team;
+}
+
+async function loadTournament(
+  tournaments: TournamentRepository,
+  tournamentId: string,
+): Promise<Tournament> {
+  const id = requiredTrimmed(tournamentId, "tournament id");
+  const tournament = await tournaments.findById(id);
+  if (!tournament) throw new TournamentNotFoundError();
+  return tournament;
+}
+
+async function teamMap(
+  teams: TeamRepository,
+  teamIds: string[],
+): Promise<Map<string, Team>> {
+  const unique = [...new Set(teamIds.filter(Boolean))];
+  const map = new Map<string, Team>();
+  for (const id of unique) {
+    const team = await teams.findById(id);
+    if (team) map.set(id, team);
+  }
+  return map;
+}
+
+function viewerFor(
+  tournament: Tournament,
+  userId: string,
+  teamsById: Map<string, Team>,
+): PublicTournamentViewer {
+  if (tournament.isOrganizer(userId)) {
+    return { role: "organizer", teamId: null };
+  }
+  for (const entry of tournament.registrations) {
+    if (entry.status.isWithdrawn) continue;
+    const team = teamsById.get(entry.teamId);
+    if (!team) continue;
+    if (isStaff(team, userId)) {
+      return { role: "captain", teamId: team.id };
+    }
+    if (team.isActiveMember(userId)) {
+      return { role: "member", teamId: team.id };
+    }
+  }
+  return { role: "member", teamId: null };
+}
+
+function canView(
+  tournament: Tournament,
+  userId: string,
+  teamsById: Map<string, Team>,
+): boolean {
+  if (tournament.isOrganizer(userId)) return true;
+  for (const entry of tournament.registrations) {
+    const team = teamsById.get(entry.teamId);
+    if (team?.isMember(userId)) return true;
+  }
+  return false;
+}
+
+function toSummary(
+  tournament: Tournament,
+  userId: string,
+  teamsById: Map<string, Team>,
+): PublicTournamentSummary {
+  const snapshot = tournament.toSnapshot();
+  return {
+    id: snapshot.id,
+    name: snapshot.name,
+    sport: snapshot.sport,
+    size: snapshot.size,
+    status: snapshot.status,
+    venueCmsId: snapshot.venueCmsId,
+    startsAt: snapshot.startsAt,
+    organizerUserId: snapshot.organizerUserId,
+    winnerTeamId: snapshot.winnerTeamId,
+    acceptedCount: tournament.acceptedCount,
+    createdAt: snapshot.createdAt,
+    updatedAt: snapshot.updatedAt,
+    viewer: viewerFor(tournament, userId, teamsById),
+  };
+}
+
+function toPublic(
+  tournament: Tournament,
+  userId: string,
+  teamsById: Map<string, Team>,
+): PublicTournament {
+  const snapshot = tournament.toSnapshot();
+  const viewer = viewerFor(tournament, userId, teamsById);
+  return {
+    ...toSummary(tournament, userId, teamsById),
+    inviteToken: viewer.role === "organizer" ? snapshot.inviteToken : null,
+    registrations: snapshot.registrations.map((entry) => {
+      const team = teamsById.get(entry.teamId);
+      return {
+        team: team
+          ? toTeamRef(team)
+          : { id: entry.teamId, name: "Team", sport: snapshot.sport },
+        status: entry.status,
+        seed: entry.seed,
+        registeredBy: entry.registeredBy,
+        createdAt: entry.createdAt,
+        updatedAt: entry.updatedAt,
+      };
+    }),
+    bracket: {
+      rounds: tournament.size.rounds,
+      slots: snapshot.slots.map((slot) => ({
+        id: slot.id,
+        round: slot.round,
+        position: slot.position,
+        homeTeam: slot.homeTeamId
+          ? teamsById.has(slot.homeTeamId)
+            ? toTeamRef(teamsById.get(slot.homeTeamId)!)
+            : { id: slot.homeTeamId, name: "Team", sport: snapshot.sport }
+          : null,
+        awayTeam: slot.awayTeamId
+          ? teamsById.has(slot.awayTeamId)
+            ? toTeamRef(teamsById.get(slot.awayTeamId)!)
+            : { id: slot.awayTeamId, name: "Team", sport: snapshot.sport }
+          : null,
+        homeSeed: slot.homeSeed,
+        awaySeed: slot.awaySeed,
+        teamMatchId: slot.teamMatchId,
+        teamMatchPath: slot.teamMatchId
+          ? `/api/team-matches/${slot.teamMatchId}`
+          : null,
+        winnerTeamId: slot.winnerTeamId,
+        nextSlotId: slot.nextSlotId,
+        nextSide: slot.nextSide,
+      })),
+    },
+  };
+}
+
+async function relatedTeamIds(tournament: Tournament): Promise<string[]> {
+  const ids = new Set<string>();
+  for (const entry of tournament.registrations) ids.add(entry.teamId);
+  for (const slot of tournament.slots) {
+    if (slot.homeTeamId) ids.add(slot.homeTeamId);
+    if (slot.awayTeamId) ids.add(slot.awayTeamId);
+  }
+  return [...ids];
+}
+
+export class TournamentContext {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async toPublic(tournament: Tournament, userId: string): Promise<PublicTournament> {
+    const teamsById = await teamMap(this.teams, await relatedTeamIds(tournament));
+    return toPublic(tournament, userId, teamsById);
+  }
+
+  async toSummary(
+    tournament: Tournament,
+    userId: string,
+  ): Promise<PublicTournamentSummary> {
+    const teamsById = await teamMap(this.teams, await relatedTeamIds(tournament));
+    return toSummary(tournament, userId, teamsById);
+  }
+}
+
+export class CreateTournament {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    name: unknown;
+    sport: unknown;
+    size: unknown;
+    venueCmsId?: unknown;
+    startsAt?: unknown;
+  }): Promise<{ tournament: PublicTournament }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tournament = Tournament.create({
+      name: TournamentName.from(input.name),
+      sport: TeamSport.from(input.sport),
+      size: TournamentSize.from(input.size),
+      organizerUserId: userId,
+      venueCmsId: OptionalVenueCmsId.from(input.venueCmsId),
+      startsAt: OptionalStartsAt.from(input.startsAt ?? null),
+    });
+    const saved = await this.tournaments.create(tournament);
+    return {
+      tournament: await new TournamentContext(this.teams, this.tournaments).toPublic(
+        saved,
+        userId,
+      ),
+    };
+  }
+}
+
+export class GetTournament {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tournamentId: string;
+  }): Promise<{ tournament: PublicTournament }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tournament = await loadTournament(this.tournaments, input.tournamentId);
+    const teamsById = await teamMap(this.teams, await relatedTeamIds(tournament));
+    if (!canView(tournament, userId, teamsById) && !tournament.status.isRegistration) {
+      throw new TournamentForbiddenError(
+        "Only the organizer or an entered team can view this tournament",
+      );
+    }
+    return { tournament: toPublic(tournament, userId, teamsById) };
+  }
+}
+
+export class UpdateTournament {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tournamentId: string;
+    name?: unknown;
+    sport?: unknown;
+    size?: unknown;
+    venueCmsId?: unknown;
+    startsAt?: unknown;
+    hasVenueCmsId: boolean;
+    hasStartsAt: boolean;
+  }): Promise<{ tournament: PublicTournament }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tournament = await loadTournament(this.tournaments, input.tournamentId);
+    tournament.updateDetails(userId, {
+      ...(input.name !== undefined ? { name: TournamentName.from(input.name) } : {}),
+      ...(input.sport !== undefined ? { sport: TeamSport.from(input.sport) } : {}),
+      ...(input.size !== undefined ? { size: TournamentSize.from(input.size) } : {}),
+      ...(input.hasVenueCmsId
+        ? { venueCmsId: OptionalVenueCmsId.from(input.venueCmsId) }
+        : {}),
+      ...(input.hasStartsAt
+        ? { startsAt: OptionalStartsAt.from(input.startsAt ?? null) }
+        : {}),
+    });
+    const saved = await this.tournaments.persist(tournament);
+    return {
+      tournament: await new TournamentContext(this.teams, this.tournaments).toPublic(
+        saved,
+        userId,
+      ),
+    };
+  }
+}
+
+export class DeleteTournament {
+  constructor(private readonly tournaments: TournamentRepository) {}
+
+  async execute(input: { userId: string; tournamentId: string }): Promise<void> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tournament = await loadTournament(this.tournaments, input.tournamentId);
+    tournament.assertCanDelete(userId);
+    await this.tournaments.delete(tournament.id);
+  }
+}
+
+export class OpenRegistration {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tournamentId: string;
+  }): Promise<{ tournament: PublicTournament }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tournament = await loadTournament(this.tournaments, input.tournamentId);
+    tournament.openRegistration(userId);
+    const saved = await this.tournaments.persist(tournament);
+    return {
+      tournament: await new TournamentContext(this.teams, this.tournaments).toPublic(
+        saved,
+        userId,
+      ),
+    };
+  }
+}
+
+async function registerTeam(params: {
+  teams: TeamRepository;
+  tournaments: TournamentRepository;
+  userId: string;
+  tournament: Tournament;
+  teamId: unknown;
+}): Promise<Tournament> {
+  const team = await loadTeam(params.teams, String(params.teamId ?? ""));
+  requireStaff(
+    team,
+    params.userId,
+    "Only an owner or captain can register a team",
+  );
+  if (!team.sport.equals(params.tournament.sport)) {
+    throw new TournamentSportMismatchError();
+  }
+  params.tournament.registerAccepted(team.id, params.userId);
+  return params.tournaments.persist(params.tournament);
+}
+
+export class RegisterTeam {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tournamentId: string;
+    teamId: unknown;
+  }): Promise<{ tournament: PublicTournament }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tournament = await loadTournament(this.tournaments, input.tournamentId);
+    const saved = await registerTeam({
+      teams: this.teams,
+      tournaments: this.tournaments,
+      userId,
+      tournament,
+      teamId: input.teamId,
+    });
+    return {
+      tournament: await new TournamentContext(this.teams, this.tournaments).toPublic(
+        saved,
+        userId,
+      ),
+    };
+  }
+}
+
+export class JoinTournament {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    token: unknown;
+    teamId: unknown;
+  }): Promise<{ tournament: PublicTournament }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const token = TournamentInviteToken.from(input.token);
+    const tournament = await this.tournaments.findByInviteToken(token.value);
+    if (!tournament) throw new TournamentNotFoundError();
+    if (!tournament.inviteToken.equals(token)) {
+      throw new DomainError("token is invalid");
+    }
+    const saved = await registerTeam({
+      teams: this.teams,
+      tournaments: this.tournaments,
+      userId,
+      tournament,
+      teamId: input.teamId,
+    });
+    return {
+      tournament: await new TournamentContext(this.teams, this.tournaments).toPublic(
+        saved,
+        userId,
+      ),
+    };
+  }
+}
+
+export class InviteTeam {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tournamentId: string;
+    teamId: unknown;
+  }): Promise<{ tournament: PublicTournament }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tournament = await loadTournament(this.tournaments, input.tournamentId);
+    const team = await loadTeam(this.teams, String(input.teamId ?? ""));
+    if (!team.sport.equals(tournament.sport)) {
+      throw new TournamentSportMismatchError();
+    }
+    tournament.inviteTeam(userId, team.id);
+    const saved = await this.tournaments.persist(tournament);
+    return {
+      tournament: await new TournamentContext(this.teams, this.tournaments).toPublic(
+        saved,
+        userId,
+      ),
+    };
+  }
+}
+
+export class AcceptRegistration {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tournamentId: string;
+    teamId: string;
+  }): Promise<{ tournament: PublicTournament }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tournament = await loadTournament(this.tournaments, input.tournamentId);
+    const team = await loadTeam(this.teams, input.teamId);
+    requireStaff(
+      team,
+      userId,
+      "Only an owner or captain can accept this entry",
+    );
+    if (!team.sport.equals(tournament.sport)) {
+      throw new TournamentSportMismatchError();
+    }
+    tournament.acceptRegistration(team.id);
+    const saved = await this.tournaments.persist(tournament);
+    return {
+      tournament: await new TournamentContext(this.teams, this.tournaments).toPublic(
+        saved,
+        userId,
+      ),
+    };
+  }
+}
+
+export class WithdrawRegistration {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tournamentId: string;
+    teamId: string;
+  }): Promise<{ tournament: PublicTournament }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tournament = await loadTournament(this.tournaments, input.tournamentId);
+    const team = await loadTeam(this.teams, input.teamId);
+    if (!tournament.isOrganizer(userId)) {
+      requireStaff(
+        team,
+        userId,
+        "Only an owner or captain can withdraw this entry",
+      );
+    }
+    tournament.withdrawRegistration(team.id);
+    const saved = await this.tournaments.persist(tournament);
+    return {
+      tournament: await new TournamentContext(this.teams, this.tournaments).toPublic(
+        saved,
+        userId,
+      ),
+    };
+  }
+}
+
+export class GenerateDraw {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tournamentId: string;
+  }): Promise<{ tournament: PublicTournament }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tournament = await loadTournament(this.tournaments, input.tournamentId);
+    tournament.generateDraw(userId);
+    const saved = await this.tournaments.persist(tournament);
+    return {
+      tournament: await new TournamentContext(this.teams, this.tournaments).toPublic(
+        saved,
+        userId,
+      ),
+    };
+  }
+}
+
+export class StartTournament {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tournamentId: string;
+  }): Promise<{ tournament: PublicTournament }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tournament = await loadTournament(this.tournaments, input.tournamentId);
+    if (!tournament.hasDraw && tournament.acceptedCount === tournament.size.value) {
+      tournament.generateDraw(userId);
+    } else {
+      tournament.start(userId);
+    }
+    const saved = await this.tournaments.persist(tournament);
+    return {
+      tournament: await new TournamentContext(this.teams, this.tournaments).toPublic(
+        saved,
+        userId,
+      ),
+    };
+  }
+}
+
+export class StartFixture {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+    private readonly matches: TeamMatchRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tournamentId: string;
+    slotId: string;
+  }): Promise<{
+    tournament: PublicTournament;
+    fixture: {
+      slotId: string;
+      teamMatchId: string;
+      path: string;
+    };
+  }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tournament = await loadTournament(this.tournaments, input.tournamentId);
+    const slot = tournament.slotById(input.slotId);
+    if (!slot) {
+      throw new TournamentSlotNotFoundError();
+    }
+    if (!slot.homeTeamId || !slot.awayTeamId) {
+      throw new DomainError("Both teams must be set before starting this fixture");
+    }
+
+    const home = await loadTeam(this.teams, slot.homeTeamId);
+    const away = await loadTeam(this.teams, slot.awayTeamId);
+    const allowed =
+      tournament.isOrganizer(userId) ||
+      isStaff(home, userId) ||
+      isStaff(away, userId);
+    if (!allowed) {
+      throw new TournamentForbiddenError(
+        "Only the organizer or a captain of this tie can start the fixture",
+      );
+    }
+
+    if (slot.teamMatchId) {
+      const existing = await this.matches.findById(slot.teamMatchId);
+      if (existing) {
+        const publicTournament = await new TournamentContext(
+          this.teams,
+          this.tournaments,
+        ).toPublic(tournament, userId);
+        return {
+          tournament: publicTournament,
+          fixture: {
+            slotId: slot.id,
+            teamMatchId: existing.id,
+            path: `/api/team-matches/${existing.id}`,
+          },
+        };
+      }
+    }
+
+    const match = TeamMatch.create({
+      homeTeamId: home.id,
+      awayTeamId: away.id,
+      sport: tournament.sport,
+      createdBy: userId,
+      venueCmsId: OptionalVenueCmsId.from(tournament.venueCmsId),
+      startsAt: OptionalStartsAt.from(tournament.startsAt),
+      generateChallengeLink: false,
+    });
+    match.accept(away.id);
+    const savedMatch = await this.matches.create(match);
+    tournament.attachFixture(slot.id, savedMatch.id);
+    const saved = await this.tournaments.persist(tournament);
+    return {
+      tournament: await new TournamentContext(this.teams, this.tournaments).toPublic(
+        saved,
+        userId,
+      ),
+      fixture: {
+        slotId: slot.id,
+        teamMatchId: savedMatch.id,
+        path: `/api/team-matches/${savedMatch.id}`,
+      },
+    };
+  }
+}
+
+export class ListMyTournaments {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: { userId: string }): Promise<{
+    organizing: PublicTournamentSummary[];
+    entered: PublicTournamentSummary[];
+  }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const myTeams = (await this.teams.listForUser(userId)).filter((team) =>
+      team.isActiveMember(userId),
+    );
+    const organizing = await this.tournaments.listForOrganizer(userId);
+    const entered = await this.tournaments.listForTeamIds(
+      myTeams.map((team) => team.id),
+    );
+    const context = new TournamentContext(this.teams, this.tournaments);
+    return {
+      organizing: await Promise.all(
+        organizing.map((row) => context.toSummary(row, userId)),
+      ),
+      entered: await Promise.all(
+        entered.map((row) => context.toSummary(row, userId)),
+      ),
+    };
+  }
+}
+
+export class ListTeamTournaments {
+  constructor(
+    private readonly teams: TeamRepository,
+    private readonly tournaments: TournamentRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    teamId: string;
+  }): Promise<{ tournaments: PublicTournamentSummary[] }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const team = await loadTeam(this.teams, input.teamId);
+    if (!team.isMember(userId)) {
+      throw new TeamForbiddenError("Only a team member can view this team");
+    }
+    const rows = await this.tournaments.listForTeamIds([team.id]);
+    const context = new TournamentContext(this.teams, this.tournaments);
+    return {
+      tournaments: await Promise.all(
+        rows.map((row) => context.toSummary(row, userId)),
+      ),
+    };
+  }
+}
+
+export { TournamentAlreadyActiveError } from "../entities/tournament-already-active-error";
+export { TournamentForbiddenError } from "../entities/tournament-forbidden-error";
+export { TournamentFullError } from "../entities/tournament-full-error";
+export { TournamentNotFoundError } from "../entities/tournament-not-found-error";
+export { TournamentNotReadyError } from "../entities/tournament-not-ready-error";
+export { TournamentSportMismatchError } from "../entities/tournament-sport-mismatch-error";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #46

One-off single-elimination tournaments for teams of one sport. Bracket sizes 4 / 8 / 16 only (no byes). Each fixture is an existing team match (padel / golf / darts scorecard). Completing the final locks the tournament winner.

## What landed
- Rich `Tournament` aggregate (draft → registration → active → completed) with registrations and bracket slots
- Prisma migration `20260908070000_tournament`
- REST routes under `/api/tournaments` plus `GET /api/teams/:id/tournaments`
- Invite-token join for captains
- Random-seed draw when accepted count == size
- Start fixture creates a scheduled `TeamMatch`
- Advancement hook on team-match complete (HTTP complete and scorecard lock)

## Out of scope
Round-robin/pools, leagues, payments, public marketplace, multi-sport.

Do not merge until review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-417be1f2-fef8-4142-9955-ec48cfc9f9c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-417be1f2-fef8-4142-9955-ec48cfc9f9c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

