### PR TITLE
Roadmap / waitlist API v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "prisma:deploy": "prisma migrate deploy"
+    "prisma:deploy": "prisma migrate deploy",
+    "roadmap:seed": "ts-node src/modules/roadmap/cli/seed.ts",
+    "roadmap:ship": "ts-node src/modules/roadmap/cli/ship.ts"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.2.0",

--- a/prisma/migrations/20260908090000_roadmap/migration.sql
+++ b/prisma/migrations/20260908090000_roadmap/migration.sql
@@ -1,0 +1,98 @@
+-- CreateEnum
+CREATE TYPE "RoadmapFeatureStatus" AS ENUM ('PLANNED', 'IN_PROGRESS', 'SHIPPED');
+
+-- CreateEnum
+CREATE TYPE "RoadmapRequestType" AS ENUM ('FEATURE_REQUEST', 'BUG');
+
+-- CreateEnum
+CREATE TYPE "RoadmapRequestStatus" AS ENUM ('NEW', 'PLANNED', 'DONE', 'ARCHIVED');
+
+-- CreateTable
+CREATE TABLE "RoadmapFeature" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "status" "RoadmapFeatureStatus" NOT NULL DEFAULT 'PLANNED',
+    "shippedAt" TIMESTAMP(3),
+    "githubIssueUrl" TEXT,
+    "voteCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "archivedAt" TIMESTAMP(3),
+
+    CONSTRAINT "RoadmapFeature_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RoadmapVote" (
+    "id" TEXT NOT NULL,
+    "featureId" TEXT NOT NULL,
+    "voterKey" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RoadmapVote_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RoadmapNotify" (
+    "id" TEXT NOT NULL,
+    "featureId" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "unsubscribedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RoadmapNotify_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RoadmapRequest" (
+    "id" TEXT NOT NULL,
+    "type" "RoadmapRequestType" NOT NULL,
+    "title" TEXT NOT NULL,
+    "details" TEXT NOT NULL,
+    "email" TEXT,
+    "status" "RoadmapRequestStatus" NOT NULL DEFAULT 'NEW',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RoadmapRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RoadmapFeature_slug_key" ON "RoadmapFeature"("slug");
+
+-- CreateIndex
+CREATE INDEX "RoadmapFeature_status_idx" ON "RoadmapFeature"("status");
+
+-- CreateIndex
+CREATE INDEX "RoadmapFeature_createdAt_idx" ON "RoadmapFeature"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "RoadmapFeature_voteCount_idx" ON "RoadmapFeature"("voteCount");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RoadmapVote_featureId_voterKey_key" ON "RoadmapVote"("featureId", "voterKey");
+
+-- CreateIndex
+CREATE INDEX "RoadmapVote_featureId_idx" ON "RoadmapVote"("featureId");
+
+-- CreateIndex
+CREATE INDEX "RoadmapVote_voterKey_idx" ON "RoadmapVote"("voterKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RoadmapNotify_featureId_email_key" ON "RoadmapNotify"("featureId", "email");
+
+-- CreateIndex
+CREATE INDEX "RoadmapNotify_email_idx" ON "RoadmapNotify"("email");
+
+-- CreateIndex
+CREATE INDEX "RoadmapNotify_featureId_idx" ON "RoadmapNotify"("featureId");
+
+-- CreateIndex
+CREATE INDEX "RoadmapRequest_status_createdAt_idx" ON "RoadmapRequest"("status", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "RoadmapVote" ADD CONSTRAINT "RoadmapVote_featureId_fkey" FOREIGN KEY ("featureId") REFERENCES "RoadmapFeature"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoadmapNotify" ADD CONSTRAINT "RoadmapNotify_featureId_fkey" FOREIGN KEY ("featureId") REFERENCES "RoadmapFeature"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -686,3 +686,82 @@ model DartsTurn {
   @@unique([matchId, turnNumber])
   @@index([matchId])
 }
+
+// Public roadmap / waitlist. githubIssueUrl is DB-only for eng ops —
+// never serialize it on public API responses.
+enum RoadmapFeatureStatus {
+  PLANNED
+  IN_PROGRESS
+  SHIPPED
+}
+
+enum RoadmapRequestType {
+  FEATURE_REQUEST
+  BUG
+}
+
+enum RoadmapRequestStatus {
+  NEW
+  PLANNED
+  DONE
+  ARCHIVED
+}
+
+model RoadmapFeature {
+  id             String               @id @default(uuid())
+  slug           String?              @unique
+  title          String
+  description    String
+  status         RoadmapFeatureStatus @default(PLANNED)
+  shippedAt      DateTime?
+  githubIssueUrl String?
+  voteCount      Int                  @default(0)
+  createdAt      DateTime             @default(now())
+  updatedAt      DateTime             @updatedAt
+  archivedAt     DateTime?
+  votes          RoadmapVote[]
+  notifies       RoadmapNotify[]
+
+  @@index([status])
+  @@index([createdAt])
+  @@index([voteCount])
+}
+
+model RoadmapVote {
+  id        String         @id @default(uuid())
+  featureId String
+  voterKey  String
+  createdAt DateTime       @default(now())
+  feature   RoadmapFeature @relation(fields: [featureId], references: [id], onDelete: Cascade)
+
+  @@unique([featureId, voterKey])
+  @@index([featureId])
+  @@index([voterKey])
+}
+
+// (featureId, email) is always unique. Soft-unsubscribe sets unsubscribedAt;
+// a later notify for the same pair reactivates the row (clears unsubscribedAt).
+model RoadmapNotify {
+  id             String         @id @default(uuid())
+  featureId      String
+  email          String
+  unsubscribedAt DateTime?
+  createdAt      DateTime       @default(now())
+  feature        RoadmapFeature @relation(fields: [featureId], references: [id], onDelete: Cascade)
+
+  @@unique([featureId, email])
+  @@index([email])
+  @@index([featureId])
+}
+
+model RoadmapRequest {
+  id        String               @id @default(uuid())
+  type      RoadmapRequestType
+  title     String
+  details   String
+  email     String?
+  status    RoadmapRequestStatus @default(NEW)
+  createdAt DateTime             @default(now())
+
+  @@index([status, createdAt])
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -75,6 +75,12 @@ import {
 } from "./modules/tournaments";
 import { PrismaTournamentRepository } from "./modules/tournaments/repositories/prisma-tournament.repository";
 import { AdvanceTournamentOnTeamMatchComplete } from "./modules/tournaments/services/advance-on-team-match-complete";
+import {
+  createRoadmapModule,
+  RoadmapEmailSender,
+  RoadmapRateLimiter,
+  RoadmapRepository,
+} from "./modules/roadmap";
 
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
@@ -95,6 +101,9 @@ export type CreateAppDependencies = {
   teamRepository?: TeamRepository;
   teamMatchRepository?: TeamMatchRepository;
   tournamentRepository?: TournamentRepository;
+  roadmapRepository?: RoadmapRepository;
+  roadmapEmailSender?: RoadmapEmailSender;
+  roadmapVoteRateLimiter?: RoadmapRateLimiter;
 };
 
 export async function createApp(
@@ -266,6 +275,14 @@ export async function createApp(
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
+  const roadmap = createRoadmapModule({
+    prisma,
+    config,
+    roadmapRepository: dependencies.roadmapRepository,
+    emailSender: dependencies.roadmapEmailSender,
+    voteRateLimiter: dependencies.roadmapVoteRateLimiter,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
@@ -284,6 +301,7 @@ export async function createApp(
   app.use(teams.router);
   app.use(teamMatches.router);
   app.use(tournaments.router);
+  app.use(roadmap.router);
 
   app.use(
     (

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { identityConfigSchema } from "./modules/identity/config";
 import { googleOauthConfigSchema } from "./modules/google-oauth/config";
+import { roadmapConfigSchema } from "./modules/roadmap/config";
 
 const appConfigSchema = z.object({
   PORT: z.number().default(3000),
@@ -13,7 +14,8 @@ const appConfigSchema = z.object({
 
 export const configSchema = appConfigSchema
   .merge(identityConfigSchema)
-  .merge(googleOauthConfigSchema);
+  .merge(googleOauthConfigSchema)
+  .merge(roadmapConfigSchema);
 
 export type Config = z.infer<typeof configSchema>;
 
@@ -102,6 +104,10 @@ export function getConfig(): Config {
       JWT_SECRET: process.env.JWT_SECRET,
       FRONTEND_URL: frontendUrl,
       CORS_ORIGINS: getCorsOrigins(frontendUrl, extraOrigins),
+      ROADMAP_SHIP_SECRET: process.env.ROADMAP_SHIP_SECRET || undefined,
+      ROADMAP_FROM_EMAIL: process.env.ROADMAP_FROM_EMAIL || undefined,
+      RESEND_API_KEY: process.env.RESEND_API_KEY || undefined,
+      SENDGRID_API_KEY: process.env.SENDGRID_API_KEY || undefined,
     });
   } catch (error) {
     console.error(error);

--- a/src/modules/roadmap/README.md
+++ b/src/modules/roadmap/README.md
@@ -1,0 +1,104 @@
+# Roadmap / waitlist API v1
+
+Public Features | Requests surface. **No admin portal.** Email is behind an interface. `githubIssueUrl` is **DB-only** and is never returned from public JSON.
+
+## Public Frontend contract
+
+All routes are unauthenticated unless noted. Do not render GitHub issue links, issue numbers, or `githubIssueUrl`.
+
+| Method | Path | Notes |
+| --- | --- | --- |
+| `GET` | `/api/roadmap/features?status=&sort=` | `status` = `PLANNED` \| `IN_PROGRESS` \| `SHIPPED`. `sort` = `votes` (default) \| `newest`. Archived rows omitted. **No `githubIssueUrl`.** `viewerHasVoted` is true when the `roadmap_voter_id` cookie and/or session `token` cookie matches a vote. |
+| `POST` | `/api/roadmap/features/:id/vote` | Toggle. Sets httpOnly `roadmap_voter_id` (UUID). Rate-limited (20 / 60s / IP+cookie). |
+| `POST` | `/api/roadmap/features/:id/notify` | Body `{ "email" }`. Idempotent. Re-notify after unsub reactivates that feature. |
+| `POST` | `/api/roadmap/unsubscribe` | Body `{ "token" }`. Global unsubscribe for that email. |
+| `GET` | `/api/roadmap/preferences?token=` | Watching features for the token email. |
+| `DELETE` | `/api/roadmap/preferences` | Body or query `{ token, featureId }`. Stops watching one feature. |
+| `POST` | `/api/roadmap/requests` | Body `{ type, title, details, email? }`. `type` = `FEATURE_REQUEST` \| `BUG`. Creates `NEW`. Response has no email. |
+| `GET` | `/api/roadmap/requests` | Non-archived: `id`, `type`, `title`, `status`, `createdAt` only. **No emails, no details.** |
+
+`:id` on feature routes accepts UUID **or** slug.
+
+### Vote identity
+
+1. Every vote sets/reads httpOnly cookie `roadmap_voter_id` (UUID, 1 year, SameSite/Secure as session cookies).
+2. If the existing session `token` cookie is valid, the vote is stored as `user:<userId>`.
+3. Otherwise it is stored as `cookie:<roadmap_voter_id>`.
+4. Logging in later does **not** migrate anonymous cookie votes; new votes bind to the user.
+
+### Unsubscribe uniqueness
+
+`RoadmapNotify` is unique on `(featureId, email)` always. Soft-unsubscribe sets `unsubscribedAt`. A later `POST .../notify` for the same pair clears `unsubscribedAt` (reactivate). Global unsubscribe sets `unsubscribedAt` on every row for that email. Tokens are signed JWTs (`purpose=roadmap_unsub`) using `JWT_SECRET`, not a table.
+
+## Ops
+
+### Seed
+
+```sh
+yarn roadmap:seed
+```
+
+Inserts three placeholder features by slug (`friends-and-teams`, `live-scorecards`, `club-nights`) if missing. Safe to re-run. You can also insert SQL directly into `RoadmapFeature` (including optional `githubIssueUrl` for eng notes).
+
+### Status without email (Planned / In progress)
+
+Update the row in Postgres. **Do not** set `SHIPPED` this way if you want notify mail.
+
+```sql
+UPDATE "RoadmapFeature"
+SET status = 'IN_PROGRESS', "updatedAt" = NOW()
+WHERE slug = 'live-scorecards';
+
+-- archive (hides from public list)
+UPDATE "RoadmapFeature"
+SET "archivedAt" = NOW(), "updatedAt" = NOW()
+WHERE slug = 'club-nights';
+```
+
+A raw `status = 'SHIPPED'` **does not send email.**
+
+### Ship (sends mail)
+
+Only the ship command / protected endpoint sets `SHIPPED` + `shippedAt` **and** emails active `RoadmapNotify` rows.
+
+```sh
+yarn roadmap:ship -- --feature live-scorecards
+# or
+yarn roadmap:ship -- --feature <uuid>
+```
+
+HTTP (optional, same service):
+
+```
+POST /api/roadmap/features/:id/ship
+X-Roadmap-Ship-Secret: <ROADMAP_SHIP_SECRET>
+```
+
+Re-running a shipped feature returns 409 / CLI error and **does not** resend mail.
+
+### Email
+
+Interface: `RoadmapEmailSender`. Resolution order:
+
+1. `RESEND_API_KEY` → Resend HTTP API
+2. else `SENDGRID_API_KEY` → SendGrid HTTP API
+3. else **console stub** (`[roadmap-email] ...`) — default for local/dev
+
+Env:
+
+| Var | Purpose |
+| --- | --- |
+| `ROADMAP_FROM_EMAIL` | From header (default `League Sports <noreply@leaguesports.co.za>`) |
+| `RESEND_API_KEY` | Resend |
+| `SENDGRID_API_KEY` | SendGrid |
+| `ROADMAP_SHIP_SECRET` | Required for HTTP ship. CLI does not need it. |
+| `FRONTEND_URL` | Product + unsubscribe links (`/roadmap`, `/roadmap/unsubscribe?token=`) |
+| `JWT_SECRET` | Signs unsubscribe tokens |
+
+### `githubIssueUrl`
+
+Nullable column for eng/DB ops only. **Never** in public API JSON. Do not expose it on the Frontend.
+
+## Migration
+
+`20260908090000_roadmap` — applied on merge via Railway `preDeployCommand` (`prisma migrate deploy`). Do not merge until ready to migrate.

--- a/src/modules/roadmap/cli/seed.ts
+++ b/src/modules/roadmap/cli/seed.ts
@@ -1,0 +1,63 @@
+import { getConfig } from "../../../config";
+import { createPrismaClient } from "../../../lib/prisma";
+import { RoadmapFeature } from "../entities/roadmap-feature";
+import { RoadmapFeatureStatus } from "../entities/roadmap-feature-status";
+import { PrismaRoadmapRepository } from "../repositories/prisma-roadmap.repository";
+
+const PLACEHOLDERS: Array<{
+  slug: string;
+  title: string;
+  description: string;
+  status: RoadmapFeatureStatus;
+}> = [
+  {
+    slug: "friends-and-teams",
+    title: "Friends and teams",
+    description:
+      "Find friends, build a squad, and challenge other clubs. Voting here means this would make you join.",
+    status: RoadmapFeatureStatus.PLANNED,
+  },
+  {
+    slug: "live-scorecards",
+    title: "Live scorecards",
+    description:
+      "Keep score together on padel, golf, and darts — then lock the card to history.",
+    status: RoadmapFeatureStatus.IN_PROGRESS,
+  },
+  {
+    slug: "club-nights",
+    title: "Club nights",
+    description:
+      "Host a night at your venue and invite the community without a group chat scramble.",
+    status: RoadmapFeatureStatus.PLANNED,
+  },
+];
+
+async function main() {
+  const config = getConfig();
+  const prisma = createPrismaClient(config);
+  const repository = new PrismaRoadmapRepository(prisma);
+
+  try {
+    for (const placeholder of PLACEHOLDERS) {
+      const existing = await repository.findFeatureByIdOrSlug(
+        placeholder.slug,
+      );
+      if (existing) {
+        console.log(`skip ${placeholder.slug} (${existing.id})`);
+        continue;
+      }
+      const created = await repository.createFeature(
+        RoadmapFeature.create(placeholder),
+      );
+      console.log(`seeded ${created.slug} (${created.id})`);
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/modules/roadmap/cli/ship.ts
+++ b/src/modules/roadmap/cli/ship.ts
@@ -1,0 +1,61 @@
+import { getConfig } from "../../../config";
+import { createPrismaClient } from "../../../lib/prisma";
+import { PrismaRoadmapRepository } from "../repositories/prisma-roadmap.repository";
+import { createRoadmapEmailSender } from "../services/email-sender";
+import { ShipRoadmapFeature } from "../services/roadmap.service";
+
+function parseFeatureArg(argv: string[]): string {
+  const index = argv.indexOf("--feature");
+  const value = index >= 0 ? argv[index + 1] : undefined;
+  if (!value || value.startsWith("--")) {
+    throw new Error(
+      "Usage: yarn roadmap:ship -- --feature <id|slug>",
+    );
+  }
+  return value;
+}
+
+async function main() {
+  const featureIdOrSlug = parseFeatureArg(process.argv.slice(2));
+  const config = getConfig();
+  const prisma = createPrismaClient(config);
+  const repository = new PrismaRoadmapRepository(prisma);
+  const emailSender = createRoadmapEmailSender({
+    fromEmail: config.ROADMAP_FROM_EMAIL,
+    resendApiKey: config.RESEND_API_KEY,
+    sendgridApiKey: config.SENDGRID_API_KEY,
+  });
+  const productUrl = `${config.FRONTEND_URL.replace(/\/$/, "")}/roadmap`;
+  const ship = new ShipRoadmapFeature(repository, emailSender, {
+    jwtSecret: config.JWT_SECRET,
+    productUrl,
+    unsubscribeUrl: (token) =>
+      `${config.FRONTEND_URL.replace(/\/$/, "")}/roadmap/unsubscribe?token=${encodeURIComponent(token)}`,
+  });
+
+  try {
+    const result = await ship.execute({ featureIdOrSlug });
+    console.log(
+      JSON.stringify(
+        {
+          id: result.feature.id,
+          slug: result.feature.slug,
+          title: result.feature.title,
+          status: result.feature.status,
+          shippedAt: result.feature.shippedAt,
+          emailsSent: result.emailsSent,
+          emailErrors: result.emailErrors,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/modules/roadmap/config.ts
+++ b/src/modules/roadmap/config.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const roadmapConfigSchema = z.object({
+  ROADMAP_SHIP_SECRET: z.string().optional(),
+  ROADMAP_FROM_EMAIL: z.string().optional(),
+  RESEND_API_KEY: z.string().optional(),
+  SENDGRID_API_KEY: z.string().optional(),
+});
+
+export type RoadmapConfig = z.infer<typeof roadmapConfigSchema>;

--- a/src/modules/roadmap/controllers/roadmap.controller.ts
+++ b/src/modules/roadmap/controllers/roadmap.controller.ts
@@ -1,0 +1,272 @@
+import { timingSafeEqual } from "node:crypto";
+
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { IdentityConfig } from "../../identity/config";
+import { RoadmapAlreadyShippedError } from "../entities/roadmap-already-shipped-error";
+import { RoadmapNotFoundError } from "../entities/roadmap-not-found-error";
+import { RoadmapPersistenceError } from "../entities/roadmap-persistence-error";
+import { RoadmapRateLimitError } from "../entities/roadmap-rate-limit-error";
+import { RoadmapRateLimiter } from "../services/rate-limiter";
+import {
+  CreateRoadmapRequest,
+  ListRoadmapFeatures,
+  ListRoadmapPreferences,
+  ListRoadmapRequests,
+  NotifyRoadmapFeature,
+  RemoveRoadmapPreference,
+  ShipRoadmapFeature,
+  ToggleRoadmapVote,
+  UnsubscribeRoadmapEmail,
+  voterKeyFor,
+} from "../services/roadmap.service";
+import { parseRoadmapUnsubscribeToken } from "../services/unsubscribe-token";
+import {
+  ensureRoadmapVoterId,
+  readRoadmapVoterId,
+} from "../utils/voter-cookie";
+
+const featureIdParamSchema = z.object({
+  id: z.string().min(1),
+});
+
+const listFeaturesQuerySchema = z.object({
+  status: z.string().optional(),
+  sort: z.string().optional(),
+});
+
+const notifyBodySchema = z.object({
+  email: z.string(),
+});
+
+const tokenBodySchema = z.object({
+  token: z.string().min(1),
+});
+
+const preferencesQuerySchema = z.object({
+  token: z.string().min(1),
+});
+
+const removePreferenceSchema = z.object({
+  token: z.string().min(1),
+  featureId: z.string().min(1),
+});
+
+const createRequestBodySchema = z.object({
+  type: z.string(),
+  title: z.string(),
+  details: z.string(),
+  email: z.string().optional().nullable(),
+});
+
+function emailFromToken(secret: string, token: string): string {
+  try {
+    return parseRoadmapUnsubscribeToken(secret, token);
+  } catch {
+    throw new DomainError("unsubscribe token is invalid");
+  }
+}
+
+function shipSecretMatches(
+  provided: string | undefined,
+  expected: string | undefined,
+): boolean {
+  if (!expected || expected.length === 0) return false;
+  if (!provided) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export function createRoadmapController(deps: {
+  config: IdentityConfig & { ROADMAP_SHIP_SECRET?: string };
+  listFeatures: ListRoadmapFeatures;
+  toggleVote: ToggleRoadmapVote;
+  notifyFeature: NotifyRoadmapFeature;
+  unsubscribe: UnsubscribeRoadmapEmail;
+  listPreferences: ListRoadmapPreferences;
+  removePreference: RemoveRoadmapPreference;
+  createRequest: CreateRoadmapRequest;
+  listRequests: ListRoadmapRequests;
+  shipFeature: ShipRoadmapFeature;
+  voteRateLimiter: RoadmapRateLimiter;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async listFeatures(req: Request, res: Response) {
+      try {
+        const query = z.parse(listFeaturesQuerySchema, req.query ?? {});
+        const cookieId = readRoadmapVoterId(req);
+        const sessionUserId = deps.tryGetSessionUserId(req);
+        const voterKeys: string[] = [];
+        if (sessionUserId) voterKeys.push(`user:${sessionUserId}`);
+        if (cookieId) voterKeys.push(`cookie:${cookieId}`);
+        const result = await deps.listFeatures.execute({
+          status: query.status,
+          sort: query.sort,
+          voterKeys,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendRoadmapError(res, error);
+      }
+    },
+
+    async vote(req: Request, res: Response) {
+      try {
+        const { id } = z.parse(featureIdParamSchema, req.params);
+        const cookieId = ensureRoadmapVoterId(req, res, deps.config);
+        const ip = req.ip ?? "unknown";
+        if (!deps.voteRateLimiter.consume(`${ip}:${cookieId}`)) {
+          throw new RoadmapRateLimitError();
+        }
+        const voterKey = voterKeyFor({
+          sessionUserId: deps.tryGetSessionUserId(req),
+          cookieId,
+        });
+        const result = await deps.toggleVote.execute({
+          featureId: id,
+          voterKey,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendRoadmapError(res, error);
+      }
+    },
+
+    async notify(req: Request, res: Response) {
+      try {
+        const { id } = z.parse(featureIdParamSchema, req.params);
+        const body = z.parse(notifyBodySchema, req.body ?? {});
+        const result = await deps.notifyFeature.execute({
+          featureId: id,
+          email: body.email,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendRoadmapError(res, error);
+      }
+    },
+
+    async unsubscribe(req: Request, res: Response) {
+      try {
+        const body = z.parse(tokenBodySchema, req.body ?? {});
+        const email = emailFromToken(deps.config.JWT_SECRET, body.token);
+        const result = await deps.unsubscribe.execute({ email });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendRoadmapError(res, error);
+      }
+    },
+
+    async preferences(req: Request, res: Response) {
+      try {
+        const query = z.parse(preferencesQuerySchema, req.query ?? {});
+        const email = emailFromToken(deps.config.JWT_SECRET, query.token);
+        const result = await deps.listPreferences.execute({ email });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendRoadmapError(res, error);
+      }
+    },
+
+    async removePreference(req: Request, res: Response) {
+      try {
+        const parsed = z.parse(removePreferenceSchema, {
+          token:
+            typeof req.body?.token === "string"
+              ? req.body.token
+              : req.query?.token,
+          featureId:
+            typeof req.body?.featureId === "string"
+              ? req.body.featureId
+              : req.query?.featureId,
+        });
+        const email = emailFromToken(deps.config.JWT_SECRET, parsed.token);
+        const result = await deps.removePreference.execute({
+          email,
+          featureId: parsed.featureId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendRoadmapError(res, error);
+      }
+    },
+
+    async createRequest(req: Request, res: Response) {
+      try {
+        const body = z.parse(createRequestBodySchema, req.body ?? {});
+        const result = await deps.createRequest.execute(body);
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendRoadmapError(res, error);
+      }
+    },
+
+    async listRequests(req: Request, res: Response) {
+      try {
+        const result = await deps.listRequests.execute();
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendRoadmapError(res, error);
+      }
+    },
+
+    async ship(req: Request, res: Response) {
+      try {
+        const expected = deps.config.ROADMAP_SHIP_SECRET;
+        if (!expected) {
+          return res.status(503).json({
+            error: "ROADMAP_SHIP_SECRET is not configured",
+          });
+        }
+        const provided =
+          typeof req.header("x-roadmap-ship-secret") === "string"
+            ? req.header("x-roadmap-ship-secret")
+            : undefined;
+        if (!shipSecretMatches(provided, expected)) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+        const { id } = z.parse(featureIdParamSchema, req.params);
+        const result = await deps.shipFeature.execute({
+          featureIdOrSlug: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendRoadmapError(res, error);
+      }
+    },
+  };
+}
+
+function sendRoadmapError(res: Response, error: unknown) {
+  if (error instanceof RoadmapNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof RoadmapAlreadyShippedError) {
+    return res.status(409).json({ error: error.message });
+  }
+
+  if (error instanceof RoadmapRateLimitError) {
+    return res.status(429).json({ error: error.message });
+  }
+
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid roadmap payload" });
+  }
+
+  if (error instanceof RoadmapPersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/roadmap/controllers/roadmap.http.test.ts
+++ b/src/modules/roadmap/controllers/roadmap.http.test.ts
@@ -1,0 +1,349 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { signAuthenticationToken } from "../../identity/utils/jwt";
+import { RoadmapFeature } from "../entities/roadmap-feature";
+import { RoadmapFeatureStatus } from "../entities/roadmap-feature-status";
+import { InMemoryRoadmapRepository } from "../repositories/in-memory-roadmap.repository";
+import { RecordingRoadmapEmailSender } from "../services/email-sender";
+import { InMemoryWindowRateLimiter } from "../services/rate-limiter";
+import { signRoadmapUnsubscribeToken } from "../services/unsubscribe-token";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+    ROADMAP_SHIP_SECRET: "ship-test-secret",
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+function cookieHeader(res: Response): string {
+  const headers = res.headers as Headers & { getSetCookie?: () => string[] };
+  const parts = headers.getSetCookie?.() ?? [headers.get("set-cookie") ?? ""];
+  return parts
+    .filter(Boolean)
+    .map((part) => part.split(";")[0])
+    .join("; ");
+}
+
+function voterCookie(res: Response): string | undefined {
+  return cookieHeader(res)
+    .split("; ")
+    .find((part) => part.startsWith("roadmap_voter_id="));
+}
+
+describe("roadmap HTTP", () => {
+  const config = makeConfig();
+  let repo: InMemoryRoadmapRepository;
+  let emails: RecordingRoadmapEmailSender;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+  let feature: RoadmapFeature;
+
+  beforeEach(async () => {
+    repo = new InMemoryRoadmapRepository();
+    emails = new RecordingRoadmapEmailSender();
+    feature = repo.seedFeature(
+      RoadmapFeature.create({
+        slug: "live-scorecards",
+        title: "Live scorecards",
+        description: "Keep score together.",
+        status: RoadmapFeatureStatus.PLANNED,
+        githubIssueUrl:
+          "https://github.com/leaguesports/league-sports-api/issues/999",
+      }),
+    );
+
+    app = await createApp(config, {
+      roadmapRepository: repo,
+      roadmapEmailSender: emails,
+      roadmapVoteRateLimiter: new InMemoryWindowRateLimiter(2, 60_000),
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("GET features omits githubIssueUrl and supports sort", async () => {
+    const res = await fetch(`${server.url}/api/roadmap/features`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      features: Array<Record<string, unknown>>;
+    };
+    expect(body.features).toHaveLength(1);
+    expect(body.features[0]).toMatchObject({
+      id: feature.id,
+      slug: "live-scorecards",
+      title: "Live scorecards",
+      status: "PLANNED",
+      voteCount: 0,
+      viewerHasVoted: false,
+    });
+    expect(body.features[0]).not.toHaveProperty("githubIssueUrl");
+    expect(JSON.stringify(body)).not.toContain("githubIssueUrl");
+    expect(JSON.stringify(body)).not.toContain(
+      "github.com/leaguesports/league-sports-api/issues/999",
+    );
+  });
+
+  test("vote toggles, sets cookie, and viewerHasVoted follows the cookie", async () => {
+    const first = await fetch(
+      `${server.url}/api/roadmap/features/${feature.id}/vote`,
+      { method: "POST" },
+    );
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual({ voted: true, voteCount: 1 });
+    const cookie = voterCookie(first);
+    expect(cookie).toMatch(/^roadmap_voter_id=/);
+
+    const listed = await fetch(`${server.url}/api/roadmap/features`, {
+      headers: { Cookie: cookie! },
+    });
+    const listedBody = (await listed.json()) as {
+      features: Array<{ viewerHasVoted: boolean; voteCount: number }>;
+    };
+    expect(listedBody.features[0].viewerHasVoted).toBe(true);
+    expect(listedBody.features[0].voteCount).toBe(1);
+
+    const second = await fetch(
+      `${server.url}/api/roadmap/features/${feature.id}/vote`,
+      { method: "POST", headers: { Cookie: cookie! } },
+    );
+    expect(await second.json()).toEqual({ voted: false, voteCount: 0 });
+
+    const after = await fetch(`${server.url}/api/roadmap/features`, {
+      headers: { Cookie: cookie! },
+    });
+    const afterBody = (await after.json()) as {
+      features: Array<{ viewerHasVoted: boolean }>;
+    };
+    expect(afterBody.features[0].viewerHasVoted).toBe(false);
+  });
+
+  test("signed-in vote binds userId and still sets the voter cookie", async () => {
+    const session = `token=${signAuthenticationToken(config, { userId: "user-a" })}`;
+    const voted = await fetch(
+      `${server.url}/api/roadmap/features/${feature.id}/vote`,
+      { method: "POST", headers: { Cookie: session } },
+    );
+    expect(voted.status).toBe(200);
+    expect(voterCookie(voted)).toMatch(/^roadmap_voter_id=/);
+    expect(await repo.hasVote(feature.id, "user:user-a")).toBe(true);
+
+    const listed = await fetch(`${server.url}/api/roadmap/features`, {
+      headers: { Cookie: session },
+    });
+    const body = (await listed.json()) as {
+      features: Array<{ viewerHasVoted: boolean }>;
+    };
+    expect(body.features[0].viewerHasVoted).toBe(true);
+  });
+
+  test("notify is idempotent and preferences/unsubscribe work", async () => {
+    const notifyOnce = await fetch(
+      `${server.url}/api/roadmap/features/${feature.id}/notify`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "  Foo@Bar.com " }),
+      },
+    );
+    expect(notifyOnce.status).toBe(200);
+    expect(await notifyOnce.json()).toEqual({ watching: true });
+
+    const notifyTwice = await fetch(
+      `${server.url}/api/roadmap/features/${feature.id}/notify`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "foo@bar.com" }),
+      },
+    );
+    expect(notifyTwice.status).toBe(200);
+
+    const token = signRoadmapUnsubscribeToken(config.JWT_SECRET, "foo@bar.com");
+    const prefs = await fetch(
+      `${server.url}/api/roadmap/preferences?token=${encodeURIComponent(token)}`,
+    );
+    expect(prefs.status).toBe(200);
+    expect(await prefs.json()).toEqual({
+      email: "foo@bar.com",
+      features: [
+        expect.objectContaining({
+          id: feature.id,
+          slug: "live-scorecards",
+          title: "Live scorecards",
+        }),
+      ],
+    });
+
+    const removed = await fetch(`${server.url}/api/roadmap/preferences`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token, featureId: feature.id }),
+    });
+    expect(await removed.json()).toEqual({ removed: true });
+
+    await fetch(
+      `${server.url}/api/roadmap/features/${feature.id}/notify`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "foo@bar.com" }),
+      },
+    );
+
+    const unsub = await fetch(`${server.url}/api/roadmap/unsubscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    expect(unsub.status).toBe(200);
+    expect(await unsub.json()).toMatchObject({
+      email: "foo@bar.com",
+      unsubscribed: true,
+    });
+
+    const empty = await fetch(
+      `${server.url}/api/roadmap/preferences?token=${encodeURIComponent(token)}`,
+    );
+    expect(await empty.json()).toEqual({
+      email: "foo@bar.com",
+      features: [],
+    });
+  });
+
+  test("create request hides email on create and public list", async () => {
+    const created = await fetch(`${server.url}/api/roadmap/requests`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "BUG",
+        title: "Scorecard lock hangs",
+        details: "Locking a padel card never returns.",
+        email: "secret@example.com",
+      }),
+    });
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as {
+      request: Record<string, unknown>;
+    };
+    expect(createdBody.request).toMatchObject({
+      type: "BUG",
+      title: "Scorecard lock hangs",
+      status: "NEW",
+    });
+    expect(createdBody.request).not.toHaveProperty("email");
+    expect(createdBody.request).not.toHaveProperty("details");
+    expect(JSON.stringify(createdBody)).not.toContain("secret@example.com");
+
+    const listed = await fetch(`${server.url}/api/roadmap/requests`);
+    expect(listed.status).toBe(200);
+    const listedBody = (await listed.json()) as {
+      requests: Array<Record<string, unknown>>;
+    };
+    expect(listedBody.requests[0]).toMatchObject({
+      type: "BUG",
+      title: "Scorecard lock hangs",
+      status: "NEW",
+    });
+    expect(listedBody.requests[0]).not.toHaveProperty("email");
+    expect(listedBody.requests[0]).not.toHaveProperty("details");
+    expect(JSON.stringify(listedBody)).not.toContain("secret@example.com");
+  });
+
+  test("ship sets SHIPPED and invokes the email sender", async () => {
+    await fetch(`${server.url}/api/roadmap/features/${feature.id}/notify`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "fan@example.com" }),
+    });
+
+    const denied = await fetch(
+      `${server.url}/api/roadmap/features/${feature.id}/ship`,
+      { method: "POST" },
+    );
+    expect(denied.status).toBe(401);
+
+    const shipped = await fetch(
+      `${server.url}/api/roadmap/features/${feature.slug}/ship`,
+      {
+        method: "POST",
+        headers: { "X-Roadmap-Ship-Secret": "ship-test-secret" },
+      },
+    );
+    expect(shipped.status).toBe(200);
+    const body = (await shipped.json()) as {
+      feature: { status: string; shippedAt: string | null };
+      emailsSent: number;
+    };
+    expect(body.feature.status).toBe("SHIPPED");
+    expect(body.feature.shippedAt).toEqual(expect.any(String));
+    expect(body.emailsSent).toBe(1);
+    expect(emails.sent).toHaveLength(1);
+    expect(emails.sent[0]).toMatchObject({
+      to: "fan@example.com",
+      subject: "Live scorecards shipped",
+    });
+    expect(emails.sent[0].text).toContain("Unsubscribe");
+    expect(JSON.stringify(body)).not.toContain("githubIssueUrl");
+
+    const again = await fetch(
+      `${server.url}/api/roadmap/features/${feature.id}/ship`,
+      {
+        method: "POST",
+        headers: { "X-Roadmap-Ship-Secret": "ship-test-secret" },
+      },
+    );
+    expect(again.status).toBe(409);
+    expect(emails.sent).toHaveLength(1);
+  });
+
+  test("vote rate-limit returns 429", async () => {
+    const first = await fetch(
+      `${server.url}/api/roadmap/features/${feature.id}/vote`,
+      { method: "POST" },
+    );
+    const cookie = cookieHeader(first);
+    const second = await fetch(
+      `${server.url}/api/roadmap/features/${feature.id}/vote`,
+      { method: "POST", headers: { Cookie: cookie } },
+    );
+    expect(second.status).toBe(200);
+    const third = await fetch(
+      `${server.url}/api/roadmap/features/${feature.id}/vote`,
+      { method: "POST", headers: { Cookie: cookie } },
+    );
+    expect(third.status).toBe(429);
+  });
+});

--- a/src/modules/roadmap/entities/roadmap-already-shipped-error.ts
+++ b/src/modules/roadmap/entities/roadmap-already-shipped-error.ts
@@ -1,0 +1,6 @@
+export class RoadmapAlreadyShippedError extends Error {
+  constructor(message = "Feature is already shipped") {
+    super(message);
+    this.name = "RoadmapAlreadyShippedError";
+  }
+}

--- a/src/modules/roadmap/entities/roadmap-feature-status.ts
+++ b/src/modules/roadmap/entities/roadmap-feature-status.ts
@@ -1,0 +1,41 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const ROADMAP_FEATURE_STATUSES = [
+  "PLANNED",
+  "IN_PROGRESS",
+  "SHIPPED",
+] as const;
+
+export type RoadmapFeatureStatusValue =
+  (typeof ROADMAP_FEATURE_STATUSES)[number];
+
+export class RoadmapFeatureStatus {
+  static readonly PLANNED = new RoadmapFeatureStatus("PLANNED");
+  static readonly IN_PROGRESS = new RoadmapFeatureStatus("IN_PROGRESS");
+  static readonly SHIPPED = new RoadmapFeatureStatus("SHIPPED");
+
+  private constructor(readonly value: RoadmapFeatureStatusValue) {}
+
+  static from(raw: unknown): RoadmapFeatureStatus {
+    if (typeof raw !== "string") {
+      throw new DomainError("status must be PLANNED, IN_PROGRESS, or SHIPPED");
+    }
+
+    const status = raw.trim().toUpperCase();
+    if (status === "PLANNED") return RoadmapFeatureStatus.PLANNED;
+    if (status === "IN_PROGRESS" || status === "IN-PROGRESS") {
+      return RoadmapFeatureStatus.IN_PROGRESS;
+    }
+    if (status === "SHIPPED") return RoadmapFeatureStatus.SHIPPED;
+
+    throw new DomainError("status must be PLANNED, IN_PROGRESS, or SHIPPED");
+  }
+
+  get isShipped(): boolean {
+    return this.value === "SHIPPED";
+  }
+
+  equals(other: RoadmapFeatureStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/roadmap/entities/roadmap-feature.ts
+++ b/src/modules/roadmap/entities/roadmap-feature.ts
@@ -1,0 +1,208 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import {
+  RoadmapFeatureStatus,
+  RoadmapFeatureStatusValue,
+} from "./roadmap-feature-status";
+
+export type RoadmapFeatureSnapshot = {
+  id: string;
+  slug: string | null;
+  title: string;
+  description: string;
+  status: RoadmapFeatureStatusValue;
+  shippedAt: string | null;
+  githubIssueUrl: string | null;
+  voteCount: number;
+  createdAt: string;
+  updatedAt: string;
+  archivedAt: string | null;
+};
+
+export type CreateRoadmapFeatureProps = {
+  id?: string;
+  slug?: string | null;
+  title: string;
+  description: string;
+  status?: RoadmapFeatureStatus;
+  githubIssueUrl?: string | null;
+  voteCount?: number;
+  createdAt?: Date;
+  updatedAt?: Date;
+};
+
+function optionalSlug(raw: unknown): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") {
+    throw new DomainError("slug must be a string");
+  }
+  const slug = raw.trim().toLowerCase();
+  if (slug.length === 0) return null;
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+    throw new DomainError("slug must be lowercase kebab-case");
+  }
+  return slug;
+}
+
+function optionalUrl(raw: unknown, field: string): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") {
+    throw new DomainError(`${field} must be a string`);
+  }
+  const value = raw.trim();
+  return value.length === 0 ? null : value;
+}
+
+export class RoadmapFeature {
+  private constructor(
+    readonly id: string,
+    readonly slug: string | null,
+    readonly title: string,
+    readonly description: string,
+    private statusValue: RoadmapFeatureStatus,
+    private shippedAtValue: Date | null,
+    readonly githubIssueUrl: string | null,
+    private voteCountValue: number,
+    readonly createdAt: Date,
+    private updatedAtValue: Date,
+    private archivedAtValue: Date | null,
+  ) {}
+
+  static create(props: CreateRoadmapFeatureProps): RoadmapFeature {
+    const now = props.createdAt ?? new Date();
+    return new RoadmapFeature(
+      props.id ?? randomUUID(),
+      optionalSlug(props.slug),
+      requiredTrimmed(props.title, "title"),
+      requiredTrimmed(props.description, "description"),
+      props.status ?? RoadmapFeatureStatus.PLANNED,
+      null,
+      optionalUrl(props.githubIssueUrl, "githubIssueUrl"),
+      props.voteCount ?? 0,
+      now,
+      props.updatedAt ?? now,
+      null,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    slug: string | null;
+    title: string;
+    description: string;
+    status: RoadmapFeatureStatus;
+    shippedAt: Date | null;
+    githubIssueUrl: string | null;
+    voteCount: number;
+    createdAt: Date;
+    updatedAt: Date;
+    archivedAt: Date | null;
+  }): RoadmapFeature {
+    return new RoadmapFeature(
+      props.id,
+      props.slug,
+      props.title,
+      props.description,
+      props.status,
+      props.shippedAt,
+      props.githubIssueUrl,
+      props.voteCount,
+      props.createdAt,
+      props.updatedAt,
+      props.archivedAt,
+    );
+  }
+
+  static fromSnapshot(snapshot: RoadmapFeatureSnapshot): RoadmapFeature {
+    return RoadmapFeature.rehydrate({
+      id: snapshot.id,
+      slug: snapshot.slug,
+      title: snapshot.title,
+      description: snapshot.description,
+      status: RoadmapFeatureStatus.from(snapshot.status),
+      shippedAt: snapshot.shippedAt ? new Date(snapshot.shippedAt) : null,
+      githubIssueUrl: snapshot.githubIssueUrl,
+      voteCount: snapshot.voteCount,
+      createdAt: new Date(snapshot.createdAt),
+      updatedAt: new Date(snapshot.updatedAt),
+      archivedAt: snapshot.archivedAt ? new Date(snapshot.archivedAt) : null,
+    });
+  }
+
+  get status(): RoadmapFeatureStatus {
+    return this.statusValue;
+  }
+
+  get shippedAt(): Date | null {
+    return this.shippedAtValue;
+  }
+
+  get voteCount(): number {
+    return this.voteCountValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  get archivedAt(): Date | null {
+    return this.archivedAtValue;
+  }
+
+  get isArchived(): boolean {
+    return this.archivedAtValue != null;
+  }
+
+  withVoteCount(voteCount: number, now = new Date()): RoadmapFeature {
+    return RoadmapFeature.rehydrate({
+      ...this.toRehydrate(),
+      voteCount: Math.max(0, voteCount),
+      updatedAt: now,
+    });
+  }
+
+  markShipped(now = new Date()): RoadmapFeature {
+    if (this.isArchived) {
+      throw new DomainError("Cannot ship an archived feature");
+    }
+    return RoadmapFeature.rehydrate({
+      ...this.toRehydrate(),
+      status: RoadmapFeatureStatus.SHIPPED,
+      shippedAt: now,
+      updatedAt: now,
+    });
+  }
+
+  toSnapshot(): RoadmapFeatureSnapshot {
+    return {
+      id: this.id,
+      slug: this.slug,
+      title: this.title,
+      description: this.description,
+      status: this.statusValue.value,
+      shippedAt: this.shippedAtValue?.toISOString() ?? null,
+      githubIssueUrl: this.githubIssueUrl,
+      voteCount: this.voteCountValue,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+      archivedAt: this.archivedAtValue?.toISOString() ?? null,
+    };
+  }
+
+  private toRehydrate() {
+    return {
+      id: this.id,
+      slug: this.slug,
+      title: this.title,
+      description: this.description,
+      status: this.statusValue,
+      shippedAt: this.shippedAtValue,
+      githubIssueUrl: this.githubIssueUrl,
+      voteCount: this.voteCountValue,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAtValue,
+      archivedAt: this.archivedAtValue,
+    };
+  }
+}

--- a/src/modules/roadmap/entities/roadmap-not-found-error.ts
+++ b/src/modules/roadmap/entities/roadmap-not-found-error.ts
@@ -1,0 +1,6 @@
+export class RoadmapNotFoundError extends Error {
+  constructor(message = "Roadmap feature not found") {
+    super(message);
+    this.name = "RoadmapNotFoundError";
+  }
+}

--- a/src/modules/roadmap/entities/roadmap-notify.ts
+++ b/src/modules/roadmap/entities/roadmap-notify.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function normalizeRoadmapEmail(raw: unknown): string {
+  const email = requiredTrimmed(raw, "email").toLowerCase();
+  if (!EMAIL_PATTERN.test(email)) {
+    throw new DomainError("email is invalid");
+  }
+  return email;
+}
+
+export type RoadmapNotifySnapshot = {
+  id: string;
+  featureId: string;
+  email: string;
+  unsubscribedAt: string | null;
+  createdAt: string;
+};
+
+export class RoadmapNotify {
+  private constructor(
+    readonly id: string,
+    readonly featureId: string,
+    readonly email: string,
+    private unsubscribedAtValue: Date | null,
+    readonly createdAt: Date,
+  ) {}
+
+  static create(props: {
+    id?: string;
+    featureId: string;
+    email: unknown;
+    createdAt?: Date;
+  }): RoadmapNotify {
+    return new RoadmapNotify(
+      props.id ?? randomUUID(),
+      requiredTrimmed(props.featureId, "featureId"),
+      normalizeRoadmapEmail(props.email),
+      null,
+      props.createdAt ?? new Date(),
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    featureId: string;
+    email: string;
+    unsubscribedAt: Date | null;
+    createdAt: Date;
+  }): RoadmapNotify {
+    return new RoadmapNotify(
+      props.id,
+      props.featureId,
+      props.email,
+      props.unsubscribedAt,
+      props.createdAt,
+    );
+  }
+
+  static fromSnapshot(snapshot: RoadmapNotifySnapshot): RoadmapNotify {
+    return RoadmapNotify.rehydrate({
+      id: snapshot.id,
+      featureId: snapshot.featureId,
+      email: snapshot.email,
+      unsubscribedAt: snapshot.unsubscribedAt
+        ? new Date(snapshot.unsubscribedAt)
+        : null,
+      createdAt: new Date(snapshot.createdAt),
+    });
+  }
+
+  get unsubscribedAt(): Date | null {
+    return this.unsubscribedAtValue;
+  }
+
+  get isActive(): boolean {
+    return this.unsubscribedAtValue == null;
+  }
+
+  reactivate(): RoadmapNotify {
+    return RoadmapNotify.rehydrate({
+      id: this.id,
+      featureId: this.featureId,
+      email: this.email,
+      unsubscribedAt: null,
+      createdAt: this.createdAt,
+    });
+  }
+
+  unsubscribe(now = new Date()): RoadmapNotify {
+    if (this.unsubscribedAtValue) return this;
+    return RoadmapNotify.rehydrate({
+      id: this.id,
+      featureId: this.featureId,
+      email: this.email,
+      unsubscribedAt: now,
+      createdAt: this.createdAt,
+    });
+  }
+
+  toSnapshot(): RoadmapNotifySnapshot {
+    return {
+      id: this.id,
+      featureId: this.featureId,
+      email: this.email,
+      unsubscribedAt: this.unsubscribedAtValue?.toISOString() ?? null,
+      createdAt: this.createdAt.toISOString(),
+    };
+  }
+}

--- a/src/modules/roadmap/entities/roadmap-persistence-error.ts
+++ b/src/modules/roadmap/entities/roadmap-persistence-error.ts
@@ -1,0 +1,6 @@
+export class RoadmapPersistenceError extends Error {
+  constructor(message = "Unable to save roadmap data", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RoadmapPersistenceError";
+  }
+}

--- a/src/modules/roadmap/entities/roadmap-rate-limit-error.ts
+++ b/src/modules/roadmap/entities/roadmap-rate-limit-error.ts
@@ -1,0 +1,6 @@
+export class RoadmapRateLimitError extends Error {
+  constructor(message = "Too many votes, try again shortly") {
+    super(message);
+    this.name = "RoadmapRateLimitError";
+  }
+}

--- a/src/modules/roadmap/entities/roadmap-request-status.ts
+++ b/src/modules/roadmap/entities/roadmap-request-status.ts
@@ -1,0 +1,44 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const ROADMAP_REQUEST_STATUSES = [
+  "NEW",
+  "PLANNED",
+  "DONE",
+  "ARCHIVED",
+] as const;
+
+export type RoadmapRequestStatusValue =
+  (typeof ROADMAP_REQUEST_STATUSES)[number];
+
+export class RoadmapRequestStatus {
+  static readonly NEW = new RoadmapRequestStatus("NEW");
+  static readonly PLANNED = new RoadmapRequestStatus("PLANNED");
+  static readonly DONE = new RoadmapRequestStatus("DONE");
+  static readonly ARCHIVED = new RoadmapRequestStatus("ARCHIVED");
+
+  private constructor(readonly value: RoadmapRequestStatusValue) {}
+
+  static from(raw: unknown): RoadmapRequestStatus {
+    if (typeof raw !== "string") {
+      throw new DomainError(
+        "status must be NEW, PLANNED, DONE, or ARCHIVED",
+      );
+    }
+
+    const status = raw.trim().toUpperCase();
+    if (status === "NEW") return RoadmapRequestStatus.NEW;
+    if (status === "PLANNED") return RoadmapRequestStatus.PLANNED;
+    if (status === "DONE") return RoadmapRequestStatus.DONE;
+    if (status === "ARCHIVED") return RoadmapRequestStatus.ARCHIVED;
+
+    throw new DomainError("status must be NEW, PLANNED, DONE, or ARCHIVED");
+  }
+
+  get isArchived(): boolean {
+    return this.value === "ARCHIVED";
+  }
+
+  equals(other: RoadmapRequestStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/roadmap/entities/roadmap-request-type.ts
+++ b/src/modules/roadmap/entities/roadmap-request-type.ts
@@ -1,0 +1,29 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const ROADMAP_REQUEST_TYPES = ["FEATURE_REQUEST", "BUG"] as const;
+export type RoadmapRequestTypeValue = (typeof ROADMAP_REQUEST_TYPES)[number];
+
+export class RoadmapRequestType {
+  static readonly FEATURE_REQUEST = new RoadmapRequestType("FEATURE_REQUEST");
+  static readonly BUG = new RoadmapRequestType("BUG");
+
+  private constructor(readonly value: RoadmapRequestTypeValue) {}
+
+  static from(raw: unknown): RoadmapRequestType {
+    if (typeof raw !== "string") {
+      throw new DomainError("type must be FEATURE_REQUEST or BUG");
+    }
+
+    const type = raw.trim().toUpperCase().replace(/[\s-]+/g, "_");
+    if (type === "FEATURE_REQUEST" || type === "FEATURE") {
+      return RoadmapRequestType.FEATURE_REQUEST;
+    }
+    if (type === "BUG") return RoadmapRequestType.BUG;
+
+    throw new DomainError("type must be FEATURE_REQUEST or BUG");
+  }
+
+  equals(other: RoadmapRequestType): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/roadmap/entities/roadmap-request.ts
+++ b/src/modules/roadmap/entities/roadmap-request.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from "node:crypto";
+
+import { requiredTrimmed } from "../../../lib/domain-error";
+import { DomainError } from "../../../lib/domain-error";
+import { normalizeRoadmapEmail } from "./roadmap-notify";
+import {
+  RoadmapRequestStatus,
+  RoadmapRequestStatusValue,
+} from "./roadmap-request-status";
+import {
+  RoadmapRequestType,
+  RoadmapRequestTypeValue,
+} from "./roadmap-request-type";
+
+export type RoadmapRequestSnapshot = {
+  id: string;
+  type: RoadmapRequestTypeValue;
+  title: string;
+  details: string;
+  email: string | null;
+  status: RoadmapRequestStatusValue;
+  createdAt: string;
+};
+
+function optionalEmail(raw: unknown): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") {
+    throw new DomainError("email must be a string");
+  }
+  if (raw.trim().length === 0) return null;
+  return normalizeRoadmapEmail(raw);
+}
+
+function boundedText(raw: unknown, field: string, max: number): string {
+  const value = requiredTrimmed(raw, field);
+  if (value.length > max) {
+    throw new DomainError(`${field} must be at most ${max} characters`);
+  }
+  return value;
+}
+
+export class RoadmapRequest {
+  private constructor(
+    readonly id: string,
+    readonly type: RoadmapRequestType,
+    readonly title: string,
+    readonly details: string,
+    readonly email: string | null,
+    readonly status: RoadmapRequestStatus,
+    readonly createdAt: Date,
+  ) {}
+
+  static create(props: {
+    id?: string;
+    type: unknown;
+    title: unknown;
+    details: unknown;
+    email?: unknown;
+    createdAt?: Date;
+  }): RoadmapRequest {
+    return new RoadmapRequest(
+      props.id ?? randomUUID(),
+      RoadmapRequestType.from(props.type),
+      boundedText(props.title, "title", 200),
+      boundedText(props.details, "details", 5000),
+      optionalEmail(props.email),
+      RoadmapRequestStatus.NEW,
+      props.createdAt ?? new Date(),
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    type: RoadmapRequestType;
+    title: string;
+    details: string;
+    email: string | null;
+    status: RoadmapRequestStatus;
+    createdAt: Date;
+  }): RoadmapRequest {
+    return new RoadmapRequest(
+      props.id,
+      props.type,
+      props.title,
+      props.details,
+      props.email,
+      props.status,
+      props.createdAt,
+    );
+  }
+
+  static fromSnapshot(snapshot: RoadmapRequestSnapshot): RoadmapRequest {
+    return RoadmapRequest.rehydrate({
+      id: snapshot.id,
+      type: RoadmapRequestType.from(snapshot.type),
+      title: snapshot.title,
+      details: snapshot.details,
+      email: snapshot.email,
+      status: RoadmapRequestStatus.from(snapshot.status),
+      createdAt: new Date(snapshot.createdAt),
+    });
+  }
+
+  toSnapshot(): RoadmapRequestSnapshot {
+    return {
+      id: this.id,
+      type: this.type.value,
+      title: this.title,
+      details: this.details,
+      email: this.email,
+      status: this.status.value,
+      createdAt: this.createdAt.toISOString(),
+    };
+  }
+}

--- a/src/modules/roadmap/index.ts
+++ b/src/modules/roadmap/index.ts
@@ -1,0 +1,128 @@
+import { Request, Router } from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { IdentityConfig } from "../identity/config";
+import { createRoadmapController } from "./controllers/roadmap.controller";
+import { RoadmapConfig } from "./config";
+import { PrismaRoadmapRepository } from "./repositories/prisma-roadmap.repository";
+import { RoadmapRepository } from "./repositories/roadmap.repository";
+import { createRoadmapRoutes } from "./routes/roadmap.routes";
+import {
+  createRoadmapEmailSender,
+  RoadmapEmailSender,
+} from "./services/email-sender";
+import {
+  DEFAULT_VOTE_RATE_LIMITER,
+  RoadmapRateLimiter,
+} from "./services/rate-limiter";
+import {
+  CreateRoadmapRequest,
+  ListRoadmapFeatures,
+  ListRoadmapPreferences,
+  ListRoadmapRequests,
+  NotifyRoadmapFeature,
+  RemoveRoadmapPreference,
+  ShipRoadmapFeature,
+  ToggleRoadmapVote,
+  UnsubscribeRoadmapEmail,
+} from "./services/roadmap.service";
+
+export type CreateRoadmapModuleParams = {
+  prisma: PrismaClient;
+  config: IdentityConfig & RoadmapConfig;
+  roadmapRepository?: RoadmapRepository;
+  emailSender?: RoadmapEmailSender;
+  voteRateLimiter?: RoadmapRateLimiter;
+  tryGetSessionUserId: (req: Request) => string | null;
+};
+
+export type RoadmapModule = {
+  router: Router;
+  roadmapRepository: RoadmapRepository;
+  emailSender: RoadmapEmailSender;
+};
+
+export function createRoadmapModule({
+  prisma,
+  config,
+  roadmapRepository: repositoryOverride,
+  emailSender: emailSenderOverride,
+  voteRateLimiter: rateLimiterOverride,
+  tryGetSessionUserId,
+}: CreateRoadmapModuleParams): RoadmapModule {
+  const roadmapRepository =
+    repositoryOverride ?? new PrismaRoadmapRepository(prisma);
+  const emailSender =
+    emailSenderOverride ??
+    createRoadmapEmailSender({
+      fromEmail: config.ROADMAP_FROM_EMAIL,
+      resendApiKey: config.RESEND_API_KEY,
+      sendgridApiKey: config.SENDGRID_API_KEY,
+    });
+  const voteRateLimiter = rateLimiterOverride ?? DEFAULT_VOTE_RATE_LIMITER;
+  const productUrl = `${config.FRONTEND_URL.replace(/\/$/, "")}/roadmap`;
+
+  const controller = createRoadmapController({
+    config,
+    listFeatures: new ListRoadmapFeatures(roadmapRepository),
+    toggleVote: new ToggleRoadmapVote(roadmapRepository),
+    notifyFeature: new NotifyRoadmapFeature(roadmapRepository),
+    unsubscribe: new UnsubscribeRoadmapEmail(roadmapRepository),
+    listPreferences: new ListRoadmapPreferences(roadmapRepository),
+    removePreference: new RemoveRoadmapPreference(roadmapRepository),
+    createRequest: new CreateRoadmapRequest(roadmapRepository),
+    listRequests: new ListRoadmapRequests(roadmapRepository),
+    shipFeature: new ShipRoadmapFeature(roadmapRepository, emailSender, {
+      jwtSecret: config.JWT_SECRET,
+      productUrl,
+      unsubscribeUrl: (token) =>
+        `${config.FRONTEND_URL.replace(/\/$/, "")}/roadmap/unsubscribe?token=${encodeURIComponent(token)}`,
+    }),
+    voteRateLimiter,
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createRoadmapRoutes(controller),
+    roadmapRepository,
+    emailSender,
+  };
+}
+
+export { createRoadmapController } from "./controllers/roadmap.controller";
+export { InMemoryRoadmapRepository } from "./repositories/in-memory-roadmap.repository";
+export { PrismaRoadmapRepository } from "./repositories/prisma-roadmap.repository";
+export type { RoadmapRepository } from "./repositories/roadmap.repository";
+export { RoadmapFeature } from "./entities/roadmap-feature";
+export { RoadmapFeatureStatus } from "./entities/roadmap-feature-status";
+export { RoadmapNotify } from "./entities/roadmap-notify";
+export { RoadmapRequest } from "./entities/roadmap-request";
+export { RoadmapRequestType } from "./entities/roadmap-request-type";
+export { RoadmapRequestStatus } from "./entities/roadmap-request-status";
+export { RoadmapNotFoundError } from "./entities/roadmap-not-found-error";
+export { RoadmapPersistenceError } from "./entities/roadmap-persistence-error";
+export { RoadmapRateLimitError } from "./entities/roadmap-rate-limit-error";
+export { RoadmapAlreadyShippedError } from "./entities/roadmap-already-shipped-error";
+export {
+  ConsoleRoadmapEmailSender,
+  RecordingRoadmapEmailSender,
+  createRoadmapEmailSender,
+} from "./services/email-sender";
+export type { RoadmapEmailSender } from "./services/email-sender";
+export { InMemoryWindowRateLimiter } from "./services/rate-limiter";
+export type { RoadmapRateLimiter } from "./services/rate-limiter";
+export {
+  signRoadmapUnsubscribeToken,
+  parseRoadmapUnsubscribeToken,
+} from "./services/unsubscribe-token";
+export {
+  CreateRoadmapRequest,
+  ListRoadmapFeatures,
+  ListRoadmapPreferences,
+  ListRoadmapRequests,
+  NotifyRoadmapFeature,
+  RemoveRoadmapPreference,
+  ShipRoadmapFeature,
+  ToggleRoadmapVote,
+  UnsubscribeRoadmapEmail,
+} from "./services/roadmap.service";

--- a/src/modules/roadmap/repositories/in-memory-roadmap.repository.ts
+++ b/src/modules/roadmap/repositories/in-memory-roadmap.repository.ts
@@ -1,0 +1,212 @@
+import { RoadmapFeature } from "../entities/roadmap-feature";
+import { RoadmapNotify } from "../entities/roadmap-notify";
+import { RoadmapPersistenceError } from "../entities/roadmap-persistence-error";
+import { RoadmapRequest } from "../entities/roadmap-request";
+import {
+  ListRoadmapFeaturesQuery,
+  RoadmapRepository,
+} from "./roadmap.repository";
+
+export class InMemoryRoadmapRepository implements RoadmapRepository {
+  private readonly features = new Map<string, RoadmapFeature>();
+  private readonly votes = new Map<string, { featureId: string; voterKey: string }>();
+  private readonly notifies = new Map<string, RoadmapNotify>();
+  private readonly requests = new Map<string, RoadmapRequest>();
+
+  seedFeature(feature: RoadmapFeature): RoadmapFeature {
+    const stored = cloneFeature(feature);
+    this.features.set(stored.id, stored);
+    return cloneFeature(stored);
+  }
+
+  async createFeature(feature: RoadmapFeature): Promise<RoadmapFeature> {
+    if (this.features.has(feature.id)) {
+      throw new RoadmapPersistenceError("Feature already exists");
+    }
+    if (feature.slug) {
+      for (const existing of this.features.values()) {
+        if (existing.slug === feature.slug) {
+          throw new RoadmapPersistenceError("Feature slug already exists");
+        }
+      }
+    }
+    return this.seedFeature(feature);
+  }
+
+  async findFeatureById(id: string): Promise<RoadmapFeature | null> {
+    const feature = this.features.get(id);
+    return feature ? cloneFeature(feature) : null;
+  }
+
+  async findFeatureByIdOrSlug(idOrSlug: string): Promise<RoadmapFeature | null> {
+    const key = idOrSlug.trim();
+    const byId = this.features.get(key);
+    if (byId) return cloneFeature(byId);
+    for (const feature of this.features.values()) {
+      if (feature.slug === key) return cloneFeature(feature);
+    }
+    return null;
+  }
+
+  async persistFeature(feature: RoadmapFeature): Promise<RoadmapFeature> {
+    if (!this.features.has(feature.id)) {
+      throw new RoadmapPersistenceError("Unable to save feature");
+    }
+    const stored = cloneFeature(feature);
+    this.features.set(stored.id, stored);
+    return cloneFeature(stored);
+  }
+
+  async listFeatures(query: ListRoadmapFeaturesQuery): Promise<RoadmapFeature[]> {
+    const items = [...this.features.values()].filter((feature) => {
+      if (feature.isArchived) return false;
+      if (query.status && feature.status.value !== query.status) return false;
+      return true;
+    });
+    items.sort((a, b) => {
+      if (query.sort === "votes") {
+        const byVotes = b.voteCount - a.voteCount;
+        if (byVotes !== 0) return byVotes;
+      }
+      const byTime = b.createdAt.getTime() - a.createdAt.getTime();
+      if (byTime !== 0) return byTime;
+      return b.id.localeCompare(a.id);
+    });
+    return items.map(cloneFeature);
+  }
+
+  async hasVote(featureId: string, voterKey: string): Promise<boolean> {
+    return this.votes.has(voteKey(featureId, voterKey));
+  }
+
+  async votedFeatureIds(voterKeys: string[]): Promise<Set<string>> {
+    const keys = new Set(voterKeys.filter(Boolean));
+    const ids = new Set<string>();
+    for (const vote of this.votes.values()) {
+      if (keys.has(vote.voterKey)) ids.add(vote.featureId);
+    }
+    return ids;
+  }
+
+  async addVote(
+    featureId: string,
+    voterKey: string,
+  ): Promise<{ voteCount: number }> {
+    const feature = this.features.get(featureId);
+    if (!feature) {
+      throw new RoadmapPersistenceError("Unable to save vote");
+    }
+    const key = voteKey(featureId, voterKey);
+    if (!this.votes.has(key)) {
+      this.votes.set(key, { featureId, voterKey });
+      this.features.set(featureId, feature.withVoteCount(feature.voteCount + 1));
+    }
+    return { voteCount: this.features.get(featureId)!.voteCount };
+  }
+
+  async removeVote(
+    featureId: string,
+    voterKey: string,
+  ): Promise<{ voteCount: number }> {
+    const feature = this.features.get(featureId);
+    if (!feature) {
+      throw new RoadmapPersistenceError("Unable to save vote");
+    }
+    const key = voteKey(featureId, voterKey);
+    if (this.votes.has(key)) {
+      this.votes.delete(key);
+      this.features.set(featureId, feature.withVoteCount(feature.voteCount - 1));
+    }
+    return { voteCount: this.features.get(featureId)!.voteCount };
+  }
+
+  async upsertNotify(featureId: string, email: string): Promise<RoadmapNotify> {
+    for (const notify of this.notifies.values()) {
+      if (notify.featureId === featureId && notify.email === email) {
+        const next = notify.isActive ? notify : notify.reactivate();
+        this.notifies.set(next.id, next);
+        return cloneNotify(next);
+      }
+    }
+    const created = RoadmapNotify.create({ featureId, email });
+    this.notifies.set(created.id, created);
+    return cloneNotify(created);
+  }
+
+  async listActiveNotifies(featureId: string): Promise<RoadmapNotify[]> {
+    return [...this.notifies.values()]
+      .filter((notify) => notify.featureId === featureId && notify.isActive)
+      .map(cloneNotify);
+  }
+
+  async listActiveNotifiesByEmail(email: string): Promise<RoadmapNotify[]> {
+    return [...this.notifies.values()]
+      .filter((notify) => notify.email === email && notify.isActive)
+      .map(cloneNotify);
+  }
+
+  async unsubscribeAllByEmail(email: string, now = new Date()): Promise<number> {
+    let count = 0;
+    for (const notify of this.notifies.values()) {
+      if (notify.email !== email || !notify.isActive) continue;
+      const next = notify.unsubscribe(now);
+      this.notifies.set(next.id, next);
+      count += 1;
+    }
+    return count;
+  }
+
+  async unsubscribeFeature(
+    email: string,
+    featureId: string,
+    now = new Date(),
+  ): Promise<boolean> {
+    for (const notify of this.notifies.values()) {
+      if (notify.email !== email || notify.featureId !== featureId) continue;
+      if (!notify.isActive) return false;
+      const next = notify.unsubscribe(now);
+      this.notifies.set(next.id, next);
+      return true;
+    }
+    return false;
+  }
+
+  async createRequest(request: RoadmapRequest): Promise<RoadmapRequest> {
+    const stored = cloneRequest(request);
+    this.requests.set(stored.id, stored);
+    return cloneRequest(stored);
+  }
+
+  async listPublicRequests(): Promise<RoadmapRequest[]> {
+    return [...this.requests.values()]
+      .filter((request) => !request.status.isArchived)
+      .sort((a, b) => {
+        const byTime = b.createdAt.getTime() - a.createdAt.getTime();
+        if (byTime !== 0) return byTime;
+        return b.id.localeCompare(a.id);
+      })
+      .map(cloneRequest);
+  }
+
+  seedNotify(notify: RoadmapNotify): RoadmapNotify {
+    const stored = cloneNotify(notify);
+    this.notifies.set(stored.id, stored);
+    return cloneNotify(stored);
+  }
+}
+
+function voteKey(featureId: string, voterKey: string): string {
+  return `${featureId}::${voterKey}`;
+}
+
+function cloneFeature(feature: RoadmapFeature): RoadmapFeature {
+  return RoadmapFeature.fromSnapshot(feature.toSnapshot());
+}
+
+function cloneNotify(notify: RoadmapNotify): RoadmapNotify {
+  return RoadmapNotify.fromSnapshot(notify.toSnapshot());
+}
+
+function cloneRequest(request: RoadmapRequest): RoadmapRequest {
+  return RoadmapRequest.fromSnapshot(request.toSnapshot());
+}

--- a/src/modules/roadmap/repositories/prisma-roadmap.repository.ts
+++ b/src/modules/roadmap/repositories/prisma-roadmap.repository.ts
@@ -1,0 +1,384 @@
+import { randomUUID } from "node:crypto";
+
+import { Prisma, PrismaClient } from "../../../generated/prisma/client";
+import { RoadmapFeature } from "../entities/roadmap-feature";
+import { RoadmapFeatureStatus } from "../entities/roadmap-feature-status";
+import { RoadmapNotify } from "../entities/roadmap-notify";
+import { RoadmapPersistenceError } from "../entities/roadmap-persistence-error";
+import { RoadmapRequest } from "../entities/roadmap-request";
+import { RoadmapRequestStatus } from "../entities/roadmap-request-status";
+import { RoadmapRequestType } from "../entities/roadmap-request-type";
+import {
+  ListRoadmapFeaturesQuery,
+  RoadmapRepository,
+} from "./roadmap.repository";
+
+type FeatureRow = {
+  id: string;
+  slug: string | null;
+  title: string;
+  description: string;
+  status: "PLANNED" | "IN_PROGRESS" | "SHIPPED";
+  shippedAt: Date | null;
+  githubIssueUrl: string | null;
+  voteCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+  archivedAt: Date | null;
+};
+
+type NotifyRow = {
+  id: string;
+  featureId: string;
+  email: string;
+  unsubscribedAt: Date | null;
+  createdAt: Date;
+};
+
+type RequestRow = {
+  id: string;
+  type: "FEATURE_REQUEST" | "BUG";
+  title: string;
+  details: string;
+  email: string | null;
+  status: "NEW" | "PLANNED" | "DONE" | "ARCHIVED";
+  createdAt: Date;
+};
+
+function prismaErrorCode(error: unknown): string {
+  if (error && typeof error === "object" && "code" in error) {
+    return String((error as { code?: unknown }).code);
+  }
+  return "";
+}
+
+function toFeature(row: FeatureRow): RoadmapFeature {
+  return RoadmapFeature.rehydrate({
+    id: row.id,
+    slug: row.slug,
+    title: row.title,
+    description: row.description,
+    status: RoadmapFeatureStatus.from(row.status),
+    shippedAt: row.shippedAt,
+    githubIssueUrl: row.githubIssueUrl,
+    voteCount: row.voteCount,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    archivedAt: row.archivedAt,
+  });
+}
+
+function toNotify(row: NotifyRow): RoadmapNotify {
+  return RoadmapNotify.rehydrate({
+    id: row.id,
+    featureId: row.featureId,
+    email: row.email,
+    unsubscribedAt: row.unsubscribedAt,
+    createdAt: row.createdAt,
+  });
+}
+
+function toRequest(row: RequestRow): RoadmapRequest {
+  return RoadmapRequest.rehydrate({
+    id: row.id,
+    type: RoadmapRequestType.from(row.type),
+    title: row.title,
+    details: row.details,
+    email: row.email,
+    status: RoadmapRequestStatus.from(row.status),
+    createdAt: row.createdAt,
+  });
+}
+
+export class PrismaRoadmapRepository implements RoadmapRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async createFeature(feature: RoadmapFeature): Promise<RoadmapFeature> {
+    const snapshot = feature.toSnapshot();
+    try {
+      const row = await this.prisma.roadmapFeature.create({
+        data: {
+          id: snapshot.id,
+          slug: snapshot.slug,
+          title: snapshot.title,
+          description: snapshot.description,
+          status: snapshot.status,
+          shippedAt: feature.shippedAt,
+          githubIssueUrl: snapshot.githubIssueUrl,
+          voteCount: snapshot.voteCount,
+          createdAt: feature.createdAt,
+          updatedAt: feature.updatedAt,
+          archivedAt: feature.archivedAt,
+        },
+      });
+      return toFeature(row);
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to create feature", {
+        cause: error,
+      });
+    }
+  }
+
+  async findFeatureById(id: string): Promise<RoadmapFeature | null> {
+    try {
+      const row = await this.prisma.roadmapFeature.findUnique({
+        where: { id },
+      });
+      return row ? toFeature(row) : null;
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to load feature", {
+        cause: error,
+      });
+    }
+  }
+
+  async findFeatureByIdOrSlug(idOrSlug: string): Promise<RoadmapFeature | null> {
+    const key = idOrSlug.trim();
+    try {
+      const row = await this.prisma.roadmapFeature.findFirst({
+        where: { OR: [{ id: key }, { slug: key }] },
+      });
+      return row ? toFeature(row) : null;
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to load feature", {
+        cause: error,
+      });
+    }
+  }
+
+  async persistFeature(feature: RoadmapFeature): Promise<RoadmapFeature> {
+    const snapshot = feature.toSnapshot();
+    try {
+      const row = await this.prisma.roadmapFeature.update({
+        where: { id: snapshot.id },
+        data: {
+          status: snapshot.status,
+          shippedAt: feature.shippedAt,
+          voteCount: snapshot.voteCount,
+          updatedAt: feature.updatedAt,
+          archivedAt: feature.archivedAt,
+        },
+      });
+      return toFeature(row);
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to save feature", {
+        cause: error,
+      });
+    }
+  }
+
+  async listFeatures(query: ListRoadmapFeaturesQuery): Promise<RoadmapFeature[]> {
+    const orderBy: Prisma.RoadmapFeatureOrderByWithRelationInput[] =
+      query.sort === "votes"
+        ? [
+            { voteCount: "desc" },
+            { createdAt: "desc" },
+            { id: "desc" },
+          ]
+        : [{ createdAt: "desc" }, { id: "desc" }];
+
+    try {
+      const rows = await this.prisma.roadmapFeature.findMany({
+        where: {
+          archivedAt: null,
+          ...(query.status ? { status: query.status } : {}),
+        },
+        orderBy,
+      });
+      return rows.map(toFeature);
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to list features", {
+        cause: error,
+      });
+    }
+  }
+
+  async hasVote(featureId: string, voterKey: string): Promise<boolean> {
+    try {
+      const vote = await this.prisma.roadmapVote.findUnique({
+        where: {
+          featureId_voterKey: { featureId, voterKey },
+        },
+        select: { id: true },
+      });
+      return vote != null;
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to load vote", { cause: error });
+    }
+  }
+
+  async votedFeatureIds(voterKeys: string[]): Promise<Set<string>> {
+    const keys = voterKeys.map((key) => key.trim()).filter(Boolean);
+    if (keys.length === 0) return new Set();
+    try {
+      const votes = await this.prisma.roadmapVote.findMany({
+        where: { voterKey: { in: keys } },
+        select: { featureId: true },
+      });
+      return new Set(votes.map((vote) => vote.featureId));
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to load votes", {
+        cause: error,
+      });
+    }
+  }
+
+  async addVote(
+    featureId: string,
+    voterKey: string,
+  ): Promise<{ voteCount: number }> {
+    try {
+      const result = await this.prisma.$transaction(async (tx) => {
+        try {
+          await tx.roadmapVote.create({
+            data: { id: randomUUID(), featureId, voterKey },
+          });
+        } catch (error) {
+          if (prismaErrorCode(error) !== "P2002") throw error;
+        }
+        const count = await tx.roadmapVote.count({ where: { featureId } });
+        const feature = await tx.roadmapFeature.update({
+          where: { id: featureId },
+          data: { voteCount: count },
+          select: { voteCount: true },
+        });
+        return feature;
+      });
+      return { voteCount: result.voteCount };
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to save vote", { cause: error });
+    }
+  }
+
+  async removeVote(
+    featureId: string,
+    voterKey: string,
+  ): Promise<{ voteCount: number }> {
+    try {
+      const result = await this.prisma.$transaction(async (tx) => {
+        await tx.roadmapVote.deleteMany({
+          where: { featureId, voterKey },
+        });
+        const count = await tx.roadmapVote.count({ where: { featureId } });
+        const feature = await tx.roadmapFeature.update({
+          where: { id: featureId },
+          data: { voteCount: count },
+          select: { voteCount: true },
+        });
+        return feature;
+      });
+      return { voteCount: result.voteCount };
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to save vote", { cause: error });
+    }
+  }
+
+  async upsertNotify(featureId: string, email: string): Promise<RoadmapNotify> {
+    try {
+      const row = await this.prisma.roadmapNotify.upsert({
+        where: { featureId_email: { featureId, email } },
+        create: { id: randomUUID(), featureId, email },
+        update: { unsubscribedAt: null },
+      });
+      return toNotify(row);
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to save notify", {
+        cause: error,
+      });
+    }
+  }
+
+  async listActiveNotifies(featureId: string): Promise<RoadmapNotify[]> {
+    try {
+      const rows = await this.prisma.roadmapNotify.findMany({
+        where: { featureId, unsubscribedAt: null },
+      });
+      return rows.map(toNotify);
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to list notifies", {
+        cause: error,
+      });
+    }
+  }
+
+  async listActiveNotifiesByEmail(email: string): Promise<RoadmapNotify[]> {
+    try {
+      const rows = await this.prisma.roadmapNotify.findMany({
+        where: { email, unsubscribedAt: null },
+      });
+      return rows.map(toNotify);
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to list notifies", {
+        cause: error,
+      });
+    }
+  }
+
+  async unsubscribeAllByEmail(email: string, now = new Date()): Promise<number> {
+    try {
+      const result = await this.prisma.roadmapNotify.updateMany({
+        where: { email, unsubscribedAt: null },
+        data: { unsubscribedAt: now },
+      });
+      return result.count;
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to unsubscribe", {
+        cause: error,
+      });
+    }
+  }
+
+  async unsubscribeFeature(
+    email: string,
+    featureId: string,
+    now = new Date(),
+  ): Promise<boolean> {
+    try {
+      const result = await this.prisma.roadmapNotify.updateMany({
+        where: { email, featureId, unsubscribedAt: null },
+        data: { unsubscribedAt: now },
+      });
+      return result.count > 0;
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to unsubscribe", {
+        cause: error,
+      });
+    }
+  }
+
+  async createRequest(request: RoadmapRequest): Promise<RoadmapRequest> {
+    const snapshot = request.toSnapshot();
+    try {
+      const row = await this.prisma.roadmapRequest.create({
+        data: {
+          id: snapshot.id,
+          type: snapshot.type,
+          title: snapshot.title,
+          details: snapshot.details,
+          email: snapshot.email,
+          status: snapshot.status,
+          createdAt: request.createdAt,
+        },
+      });
+      return toRequest(row);
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to create request", {
+        cause: error,
+      });
+    }
+  }
+
+  async listPublicRequests(): Promise<RoadmapRequest[]> {
+    try {
+      const rows = await this.prisma.roadmapRequest.findMany({
+        where: { status: { not: "ARCHIVED" } },
+        orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      });
+      return rows.map(toRequest);
+    } catch (error) {
+      throw new RoadmapPersistenceError("Failed to list requests", {
+        cause: error,
+      });
+    }
+  }
+}

--- a/src/modules/roadmap/repositories/roadmap.repository.ts
+++ b/src/modules/roadmap/repositories/roadmap.repository.ts
@@ -1,0 +1,41 @@
+import { RoadmapFeature } from "../entities/roadmap-feature";
+import { RoadmapFeatureStatusValue } from "../entities/roadmap-feature-status";
+import { RoadmapNotify } from "../entities/roadmap-notify";
+import { RoadmapRequest } from "../entities/roadmap-request";
+
+export type ListRoadmapFeaturesQuery = {
+  status?: RoadmapFeatureStatusValue;
+  sort: "votes" | "newest";
+};
+
+export interface RoadmapRepository {
+  createFeature(feature: RoadmapFeature): Promise<RoadmapFeature>;
+  findFeatureById(id: string): Promise<RoadmapFeature | null>;
+  findFeatureByIdOrSlug(idOrSlug: string): Promise<RoadmapFeature | null>;
+  persistFeature(feature: RoadmapFeature): Promise<RoadmapFeature>;
+  listFeatures(query: ListRoadmapFeaturesQuery): Promise<RoadmapFeature[]>;
+
+  hasVote(featureId: string, voterKey: string): Promise<boolean>;
+  votedFeatureIds(voterKeys: string[]): Promise<Set<string>>;
+  addVote(
+    featureId: string,
+    voterKey: string,
+  ): Promise<{ voteCount: number }>;
+  removeVote(
+    featureId: string,
+    voterKey: string,
+  ): Promise<{ voteCount: number }>;
+
+  upsertNotify(featureId: string, email: string): Promise<RoadmapNotify>;
+  listActiveNotifies(featureId: string): Promise<RoadmapNotify[]>;
+  listActiveNotifiesByEmail(email: string): Promise<RoadmapNotify[]>;
+  unsubscribeAllByEmail(email: string, now?: Date): Promise<number>;
+  unsubscribeFeature(
+    email: string,
+    featureId: string,
+    now?: Date,
+  ): Promise<boolean>;
+
+  createRequest(request: RoadmapRequest): Promise<RoadmapRequest>;
+  listPublicRequests(): Promise<RoadmapRequest[]>;
+}

--- a/src/modules/roadmap/routes/roadmap.routes.ts
+++ b/src/modules/roadmap/routes/roadmap.routes.ts
@@ -1,0 +1,47 @@
+import { Router } from "express";
+
+import { createRoadmapController } from "../controllers/roadmap.controller";
+
+export function createRoadmapRoutes(
+  controller: ReturnType<typeof createRoadmapController>,
+): Router {
+  const router = Router();
+
+  router.get("/api/roadmap/features", (req, res) => {
+    void controller.listFeatures(req, res);
+  });
+
+  router.post("/api/roadmap/features/:id/vote", (req, res) => {
+    void controller.vote(req, res);
+  });
+
+  router.post("/api/roadmap/features/:id/notify", (req, res) => {
+    void controller.notify(req, res);
+  });
+
+  router.post("/api/roadmap/features/:id/ship", (req, res) => {
+    void controller.ship(req, res);
+  });
+
+  router.post("/api/roadmap/unsubscribe", (req, res) => {
+    void controller.unsubscribe(req, res);
+  });
+
+  router.get("/api/roadmap/preferences", (req, res) => {
+    void controller.preferences(req, res);
+  });
+
+  router.delete("/api/roadmap/preferences", (req, res) => {
+    void controller.removePreference(req, res);
+  });
+
+  router.get("/api/roadmap/requests", (req, res) => {
+    void controller.listRequests(req, res);
+  });
+
+  router.post("/api/roadmap/requests", (req, res) => {
+    void controller.createRequest(req, res);
+  });
+
+  return router;
+}

--- a/src/modules/roadmap/services/email-sender.ts
+++ b/src/modules/roadmap/services/email-sender.ts
@@ -1,0 +1,104 @@
+export type RoadmapEmailMessage = {
+  to: string;
+  subject: string;
+  text: string;
+  html?: string;
+};
+
+export interface RoadmapEmailSender {
+  send(message: RoadmapEmailMessage): Promise<void>;
+}
+
+export class ConsoleRoadmapEmailSender implements RoadmapEmailSender {
+  async send(message: RoadmapEmailMessage): Promise<void> {
+    console.log("[roadmap-email]", JSON.stringify(message));
+  }
+}
+
+export class RecordingRoadmapEmailSender implements RoadmapEmailSender {
+  readonly sent: RoadmapEmailMessage[] = [];
+
+  async send(message: RoadmapEmailMessage): Promise<void> {
+    this.sent.push(message);
+  }
+}
+
+export class ResendRoadmapEmailSender implements RoadmapEmailSender {
+  constructor(
+    private readonly apiKey: string,
+    private readonly from: string,
+  ) {}
+
+  async send(message: RoadmapEmailMessage): Promise<void> {
+    const response = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: this.from,
+        to: [message.to],
+        subject: message.subject,
+        text: message.text,
+        html: message.html ?? message.text,
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Resend email failed (${response.status}): ${body}`);
+    }
+  }
+}
+
+export class SendGridRoadmapEmailSender implements RoadmapEmailSender {
+  constructor(
+    private readonly apiKey: string,
+    private readonly from: string,
+  ) {}
+
+  async send(message: RoadmapEmailMessage): Promise<void> {
+    const response = await fetch("https://api.sendgrid.com/v3/mail/send", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        personalizations: [{ to: [{ email: message.to }] }],
+        from: parseFrom(this.from),
+        subject: message.subject,
+        content: [
+          { type: "text/plain", value: message.text },
+          { type: "text/html", value: message.html ?? message.text },
+        ],
+      }),
+    });
+    if (!response.ok && response.status !== 202) {
+      const body = await response.text();
+      throw new Error(`SendGrid email failed (${response.status}): ${body}`);
+    }
+  }
+}
+
+function parseFrom(from: string): { email: string; name?: string } {
+  const match = from.match(/^(.*)<([^>]+)>$/);
+  if (!match) return { email: from.trim() };
+  return { name: match[1].trim().replace(/^"|"$/g, ""), email: match[2].trim() };
+}
+
+export function createRoadmapEmailSender(input: {
+  fromEmail?: string;
+  resendApiKey?: string;
+  sendgridApiKey?: string;
+}): RoadmapEmailSender {
+  const from =
+    input.fromEmail?.trim() || "League Sports <noreply@leaguesports.co.za>";
+  if (input.resendApiKey) {
+    return new ResendRoadmapEmailSender(input.resendApiKey, from);
+  }
+  if (input.sendgridApiKey) {
+    return new SendGridRoadmapEmailSender(input.sendgridApiKey, from);
+  }
+  return new ConsoleRoadmapEmailSender();
+}

--- a/src/modules/roadmap/services/rate-limiter.ts
+++ b/src/modules/roadmap/services/rate-limiter.ts
@@ -1,0 +1,32 @@
+export interface RoadmapRateLimiter {
+  consume(key: string): boolean;
+}
+
+export class InMemoryWindowRateLimiter implements RoadmapRateLimiter {
+  private readonly hits = new Map<string, number[]>();
+
+  constructor(
+    private readonly max: number,
+    private readonly windowMs: number,
+  ) {}
+
+  consume(key: string): boolean {
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+    const timestamps = (this.hits.get(key) ?? []).filter(
+      (stamp) => stamp > windowStart,
+    );
+    if (timestamps.length >= this.max) {
+      this.hits.set(key, timestamps);
+      return false;
+    }
+    timestamps.push(now);
+    this.hits.set(key, timestamps);
+    return true;
+  }
+}
+
+export const DEFAULT_VOTE_RATE_LIMITER = new InMemoryWindowRateLimiter(
+  20,
+  60_000,
+);

--- a/src/modules/roadmap/services/roadmap.service.test.ts
+++ b/src/modules/roadmap/services/roadmap.service.test.ts
@@ -1,0 +1,91 @@
+import { RoadmapFeature } from "../entities/roadmap-feature";
+import { RoadmapFeatureStatus } from "../entities/roadmap-feature-status";
+import { InMemoryRoadmapRepository } from "../repositories/in-memory-roadmap.repository";
+import { RecordingRoadmapEmailSender } from "./email-sender";
+import {
+  ListRoadmapFeatures,
+  NotifyRoadmapFeature,
+  ShipRoadmapFeature,
+  ToggleRoadmapVote,
+} from "./roadmap.service";
+
+describe("roadmap services", () => {
+  test("public feature list never includes githubIssueUrl", async () => {
+    const repo = new InMemoryRoadmapRepository();
+    repo.seedFeature(
+      RoadmapFeature.create({
+        title: "Hidden issue",
+        description: "Internal tracker only.",
+        githubIssueUrl: "https://github.com/leaguesports/x/issues/1",
+        status: RoadmapFeatureStatus.PLANNED,
+      }),
+    );
+    const result = await new ListRoadmapFeatures(repo).execute({
+      voterKeys: [],
+    });
+    expect(result.features[0]).not.toHaveProperty("githubIssueUrl");
+    expect(JSON.stringify(result)).not.toContain("github.com");
+  });
+
+  test("notify is idempotent across mixed-case email", async () => {
+    const repo = new InMemoryRoadmapRepository();
+    const feature = repo.seedFeature(
+      RoadmapFeature.create({
+        title: "Pools",
+        description: "Tip with friends.",
+      }),
+    );
+    const notify = new NotifyRoadmapFeature(repo);
+    await notify.execute({ featureId: feature.id, email: "A@B.com" });
+    await notify.execute({ featureId: feature.id, email: "a@b.com" });
+    const watching = await repo.listActiveNotifies(feature.id);
+    expect(watching).toHaveLength(1);
+    expect(watching[0].email).toBe("a@b.com");
+  });
+
+  test("ship marks SHIPPED and sends one email per active notify", async () => {
+    const repo = new InMemoryRoadmapRepository();
+    const emails = new RecordingRoadmapEmailSender();
+    const feature = repo.seedFeature(
+      RoadmapFeature.create({
+        slug: "club-nights",
+        title: "Club nights",
+        description: "Host a night.",
+      }),
+    );
+    await repo.upsertNotify(feature.id, "one@example.com");
+    await repo.upsertNotify(feature.id, "two@example.com");
+    await repo.unsubscribeFeature("two@example.com", feature.id);
+
+    const result = await new ShipRoadmapFeature(repo, emails, {
+      jwtSecret: "secret",
+      productUrl: "http://localhost:3001/roadmap",
+      unsubscribeUrl: (token) =>
+        `http://localhost:3001/roadmap/unsubscribe?token=${token}`,
+    }).execute({ featureIdOrSlug: "club-nights" });
+
+    expect(result.feature.status).toBe("SHIPPED");
+    expect(result.emailsSent).toBe(1);
+    expect(emails.sent.map((message) => message.to)).toEqual([
+      "one@example.com",
+    ]);
+    expect(emails.sent[0].subject).toBe("Club nights shipped");
+  });
+
+  test("toggle vote increments then decrements", async () => {
+    const repo = new InMemoryRoadmapRepository();
+    const feature = repo.seedFeature(
+      RoadmapFeature.create({
+        title: "Mobile",
+        description: "App later.",
+      }),
+    );
+    const toggle = new ToggleRoadmapVote(repo);
+    expect(
+      await toggle.execute({ featureId: feature.id, voterKey: "cookie:abc" }),
+    ).toEqual({ voted: true, voteCount: 1 });
+    expect(
+      await toggle.execute({ featureId: feature.id, voterKey: "cookie:abc" }),
+    ).toEqual({ voted: false, voteCount: 0 });
+  });
+});

--- a/src/modules/roadmap/services/roadmap.service.ts
+++ b/src/modules/roadmap/services/roadmap.service.ts
@@ -1,0 +1,327 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { RoadmapAlreadyShippedError } from "../entities/roadmap-already-shipped-error";
+import { RoadmapFeature } from "../entities/roadmap-feature";
+import {
+  RoadmapFeatureStatus,
+  RoadmapFeatureStatusValue,
+} from "../entities/roadmap-feature-status";
+import { RoadmapNotFoundError } from "../entities/roadmap-not-found-error";
+import { normalizeRoadmapEmail } from "../entities/roadmap-notify";
+import { RoadmapRequest } from "../entities/roadmap-request";
+import { RoadmapRepository } from "../repositories/roadmap.repository";
+import { RoadmapEmailSender } from "./email-sender";
+import { signRoadmapUnsubscribeToken } from "./unsubscribe-token";
+
+export type PublicRoadmapFeature = {
+  id: string;
+  slug: string | null;
+  title: string;
+  description: string;
+  status: RoadmapFeatureStatusValue;
+  shippedAt: string | null;
+  voteCount: number;
+  createdAt: string;
+  updatedAt: string;
+  viewerHasVoted: boolean;
+};
+
+export type PublicRoadmapRequest = {
+  id: string;
+  type: "FEATURE_REQUEST" | "BUG";
+  title: string;
+  status: "NEW" | "PLANNED" | "DONE";
+  createdAt: string;
+};
+
+export type PublicWatchingFeature = {
+  id: string;
+  slug: string | null;
+  title: string;
+  status: RoadmapFeatureStatusValue;
+};
+
+function toPublicFeature(
+  feature: RoadmapFeature,
+  viewerHasVoted: boolean,
+): PublicRoadmapFeature {
+  const snapshot = feature.toSnapshot();
+  return {
+    id: snapshot.id,
+    slug: snapshot.slug,
+    title: snapshot.title,
+    description: snapshot.description,
+    status: snapshot.status,
+    shippedAt: snapshot.shippedAt,
+    voteCount: snapshot.voteCount,
+    createdAt: snapshot.createdAt,
+    updatedAt: snapshot.updatedAt,
+    viewerHasVoted,
+  };
+}
+
+function requirePublicFeature(feature: RoadmapFeature | null): RoadmapFeature {
+  if (!feature || feature.isArchived) {
+    throw new RoadmapNotFoundError();
+  }
+  return feature;
+}
+
+export function voterKeyFor(input: {
+  sessionUserId: string | null;
+  cookieId: string;
+}): string {
+  if (input.sessionUserId) return `user:${input.sessionUserId}`;
+  return `cookie:${input.cookieId}`;
+}
+
+export class ListRoadmapFeatures {
+  constructor(private readonly repository: RoadmapRepository) {}
+
+  async execute(input: {
+    status?: unknown;
+    sort?: unknown;
+    voterKeys: string[];
+  }): Promise<{ features: PublicRoadmapFeature[] }> {
+    const sort =
+      input.sort == null || input.sort === ""
+        ? "votes"
+        : String(input.sort).trim().toLowerCase();
+    if (sort !== "votes" && sort !== "newest") {
+      throw new DomainError("sort must be votes or newest");
+    }
+
+    const status =
+      input.status == null || input.status === ""
+        ? undefined
+        : RoadmapFeatureStatus.from(input.status).value;
+
+    const features = await this.repository.listFeatures({ status, sort });
+    const votedIds = await this.repository.votedFeatureIds(input.voterKeys);
+    return {
+      features: features.map((feature) =>
+        toPublicFeature(feature, votedIds.has(feature.id)),
+      ),
+    };
+  }
+}
+
+export class ToggleRoadmapVote {
+  constructor(private readonly repository: RoadmapRepository) {}
+
+  async execute(input: {
+    featureId: string;
+    voterKey: string;
+  }): Promise<{ voted: boolean; voteCount: number }> {
+    const feature = requirePublicFeature(
+      await this.repository.findFeatureByIdOrSlug(input.featureId),
+    );
+    const exists = await this.repository.hasVote(feature.id, input.voterKey);
+    if (exists) {
+      const { voteCount } = await this.repository.removeVote(
+        feature.id,
+        input.voterKey,
+      );
+      return { voted: false, voteCount };
+    }
+    const { voteCount } = await this.repository.addVote(
+      feature.id,
+      input.voterKey,
+    );
+    return { voted: true, voteCount };
+  }
+}
+
+export class NotifyRoadmapFeature {
+  constructor(private readonly repository: RoadmapRepository) {}
+
+  async execute(input: { featureId: string; email: unknown }): Promise<{
+    watching: true;
+  }> {
+    const feature = requirePublicFeature(
+      await this.repository.findFeatureByIdOrSlug(input.featureId),
+    );
+    const email = normalizeRoadmapEmail(input.email);
+    await this.repository.upsertNotify(feature.id, email);
+    return { watching: true };
+  }
+}
+
+export class UnsubscribeRoadmapEmail {
+  constructor(private readonly repository: RoadmapRepository) {}
+
+  async execute(input: { email: string }): Promise<{
+    email: string;
+    unsubscribed: true;
+    count: number;
+  }> {
+    const email = normalizeRoadmapEmail(input.email);
+    const count = await this.repository.unsubscribeAllByEmail(email);
+    return { email, unsubscribed: true, count };
+  }
+}
+
+export class ListRoadmapPreferences {
+  constructor(private readonly repository: RoadmapRepository) {}
+
+  async execute(input: { email: string }): Promise<{
+    email: string;
+    features: PublicWatchingFeature[];
+  }> {
+    const email = normalizeRoadmapEmail(input.email);
+    const notifies = await this.repository.listActiveNotifiesByEmail(email);
+    const features: PublicWatchingFeature[] = [];
+    for (const notify of notifies) {
+      const feature = await this.repository.findFeatureById(notify.featureId);
+      if (!feature || feature.isArchived) continue;
+      features.push({
+        id: feature.id,
+        slug: feature.slug,
+        title: feature.title,
+        status: feature.status.value,
+      });
+    }
+    return { email, features };
+  }
+}
+
+export class RemoveRoadmapPreference {
+  constructor(private readonly repository: RoadmapRepository) {}
+
+  async execute(input: {
+    email: string;
+    featureId: string;
+  }): Promise<{ removed: boolean }> {
+    const email = normalizeRoadmapEmail(input.email);
+    const feature = await this.repository.findFeatureByIdOrSlug(
+      requiredTrimmed(input.featureId, "featureId"),
+    );
+    if (!feature) return { removed: false };
+    const removed = await this.repository.unsubscribeFeature(
+      email,
+      feature.id,
+    );
+    return { removed };
+  }
+}
+
+export class CreateRoadmapRequest {
+  constructor(private readonly repository: RoadmapRepository) {}
+
+  async execute(input: {
+    type: unknown;
+    title: unknown;
+    details: unknown;
+    email?: unknown;
+  }): Promise<{
+    request: {
+      id: string;
+      type: "FEATURE_REQUEST" | "BUG";
+      title: string;
+      status: "NEW";
+      createdAt: string;
+    };
+  }> {
+    const created = await this.repository.createRequest(
+      RoadmapRequest.create(input),
+    );
+    const snapshot = created.toSnapshot();
+    return {
+      request: {
+        id: snapshot.id,
+        type: snapshot.type,
+        title: snapshot.title,
+        status: "NEW",
+        createdAt: snapshot.createdAt,
+      },
+    };
+  }
+}
+
+export class ListRoadmapRequests {
+  constructor(private readonly repository: RoadmapRepository) {}
+
+  async execute(): Promise<{ requests: PublicRoadmapRequest[] }> {
+    const requests = await this.repository.listPublicRequests();
+    return {
+      requests: requests.map((request) => {
+        const snapshot = request.toSnapshot();
+        return {
+          id: snapshot.id,
+          type: snapshot.type,
+          title: snapshot.title,
+          status: snapshot.status as PublicRoadmapRequest["status"],
+          createdAt: snapshot.createdAt,
+        };
+      }),
+    };
+  }
+}
+
+export class ShipRoadmapFeature {
+  constructor(
+    private readonly repository: RoadmapRepository,
+    private readonly emailSender: RoadmapEmailSender,
+    private readonly options: {
+      jwtSecret: string;
+      productUrl: string;
+      unsubscribeUrl: (token: string) => string;
+    },
+  ) {}
+
+  async execute(input: { featureIdOrSlug: string }): Promise<{
+    feature: PublicRoadmapFeature;
+    emailsSent: number;
+    emailErrors: number;
+  }> {
+    const feature = requirePublicFeature(
+      await this.repository.findFeatureByIdOrSlug(input.featureIdOrSlug),
+    );
+    if (feature.status.isShipped) {
+      throw new RoadmapAlreadyShippedError();
+    }
+
+    const shipped = await this.repository.persistFeature(feature.markShipped());
+    const notifies = await this.repository.listActiveNotifies(shipped.id);
+    let emailsSent = 0;
+    let emailErrors = 0;
+
+    for (const notify of notifies) {
+      const token = signRoadmapUnsubscribeToken(
+        this.options.jwtSecret,
+        notify.email,
+      );
+      const unsubscribeUrl = this.options.unsubscribeUrl(token);
+      try {
+        await this.emailSender.send({
+          to: notify.email,
+          subject: `${shipped.title} shipped`,
+          text: [
+            `${shipped.title} is now live on League Sports.`,
+            this.options.productUrl,
+            "",
+            `Unsubscribe from roadmap emails: ${unsubscribeUrl}`,
+          ].join("\n"),
+          html: `<p>${escapeHtml(shipped.title)} is now live on League Sports.</p><p><a href="${escapeHtml(this.options.productUrl)}">Open the product</a></p><p><a href="${escapeHtml(unsubscribeUrl)}">Unsubscribe from roadmap emails</a></p>`,
+        });
+        emailsSent += 1;
+      } catch (error) {
+        emailErrors += 1;
+        console.error("roadmap ship email failed", error);
+      }
+    }
+
+    return {
+      feature: toPublicFeature(shipped, false),
+      emailsSent,
+      emailErrors,
+    };
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}

--- a/src/modules/roadmap/services/unsubscribe-token.test.ts
+++ b/src/modules/roadmap/services/unsubscribe-token.test.ts
@@ -1,0 +1,25 @@
+import jwt from "jsonwebtoken";
+
+import {
+  parseRoadmapUnsubscribeToken,
+  signRoadmapUnsubscribeToken,
+} from "./unsubscribe-token";
+
+describe("roadmap unsubscribe token", () => {
+  const secret = "jwt-test-secret";
+
+  test("round-trips a normalized email", () => {
+    const token = signRoadmapUnsubscribeToken(secret, "  Foo@Bar.com ");
+    expect(parseRoadmapUnsubscribeToken(secret, token)).toBe("foo@bar.com");
+  });
+
+  test("rejects a token signed with a different secret", () => {
+    const token = signRoadmapUnsubscribeToken(secret, "a@b.com");
+    expect(() => parseRoadmapUnsubscribeToken("other", token)).toThrow();
+  });
+
+  test("rejects a token with the wrong purpose", () => {
+    const token = jwt.sign({ purpose: "other", email: "a@b.com" }, secret);
+    expect(() => parseRoadmapUnsubscribeToken(secret, token)).toThrow();
+  });
+});

--- a/src/modules/roadmap/services/unsubscribe-token.ts
+++ b/src/modules/roadmap/services/unsubscribe-token.ts
@@ -1,0 +1,27 @@
+import jwt from "jsonwebtoken";
+import { z } from "zod";
+
+const payloadSchema = z.object({
+  purpose: z.literal("roadmap_unsub"),
+  email: z.string().email(),
+});
+
+export function signRoadmapUnsubscribeToken(
+  secret: string,
+  email: string,
+): string {
+  return jwt.sign(
+    { purpose: "roadmap_unsub", email: email.trim().toLowerCase() },
+    secret,
+    { expiresIn: "365d" },
+  );
+}
+
+export function parseRoadmapUnsubscribeToken(
+  secret: string,
+  token: string,
+): string {
+  const decoded = jwt.verify(token, secret);
+  const payload = payloadSchema.parse(decoded);
+  return payload.email;
+}

--- a/src/modules/roadmap/utils/voter-cookie.ts
+++ b/src/modules/roadmap/utils/voter-cookie.ts
@@ -1,0 +1,44 @@
+import { randomUUID } from "node:crypto";
+
+import { CookieOptions, Request, Response } from "express";
+
+import { getAuthCookieOptions } from "../../identity/utils/cookie";
+import { IdentityConfig } from "../../identity/config";
+
+export const ROADMAP_VOTER_COOKIE = "roadmap_voter_id";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function getRoadmapVoterCookieOptions(
+  config: IdentityConfig,
+): CookieOptions {
+  return {
+    ...getAuthCookieOptions(config),
+    maxAge: 1000 * 60 * 60 * 24 * 365,
+  };
+}
+
+export function readRoadmapVoterId(req: Request): string | null {
+  const raw = req.cookies?.[ROADMAP_VOTER_COOKIE];
+  if (typeof raw !== "string") return null;
+  const value = raw.trim();
+  if (!UUID_PATTERN.test(value)) return null;
+  return value;
+}
+
+export function ensureRoadmapVoterId(
+  req: Request,
+  res: Response,
+  config: IdentityConfig,
+): string {
+  const existing = readRoadmapVoterId(req);
+  if (existing) return existing;
+  const id = randomUUID();
+  res.cookie(
+    ROADMAP_VOTER_COOKIE,
+    id,
+    getRoadmapVoterCookieOptions(config),
+  );
+  return id;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #48

Public roadmap/waitlist API for a later Frontend `/roadmap` (Features | Requests). **No admin portal.** Extractable module at `/api/roadmap/*` with its own tables. Email is behind an interface.

**Do not merge yet** — migrate on merge via Railway pre-deploy (`20260908090000_roadmap`).

## Public Frontend contract

No GitHub mention. `githubIssueUrl` is DB-only and **never** returned from public JSON.

| Method | Path | Notes |
| --- | --- | --- |
| `GET` | `/api/roadmap/features?status=&sort=` | `status`: `PLANNED` \| `IN_PROGRESS` \| `SHIPPED`. `sort`: `votes` (default) \| `newest`. Includes `viewerHasVoted` when the voter cookie / session is present. |
| `POST` | `/api/roadmap/features/:id/vote` | Toggle. httpOnly `roadmap_voter_id` UUID cookie. Prefers `user:<userId>` when the session `token` cookie is valid. Rate-limited (20/min IP+cookie). |
| `POST` | `/api/roadmap/features/:id/notify` | `{ email }` — idempotent. |
| `POST` | `/api/roadmap/unsubscribe` | `{ token }` — global unsubscribe for that email. |
| `GET` | `/api/roadmap/preferences?token=` | Watching features. |
| `DELETE` | `/api/roadmap/preferences` | `{ token, featureId }` — stop watching one feature. |
| `POST` | `/api/roadmap/requests` | `{ type, title, details, email? }` → `NEW`. Response has no email. |
| `GET` | `/api/roadmap/requests` | Non-archived: title, type, status, createdAt only — **no emails**. |

`:id` accepts UUID or slug. Ops docs: `src/modules/roadmap/README.md`.

## Ops

- **Seed:** `yarn roadmap:seed` (placeholder features by slug; safe to re-run).
- **Status without email:** SQL `UPDATE "RoadmapFeature" SET status = 'IN_PROGRESS' ...` — does **not** send mail.
- **Ship (sends mail):** `yarn roadmap:ship -- --feature <id\|slug>` or `POST /api/roadmap/features/:id/ship` with `X-Roadmap-Ship-Secret`. Sets `SHIPPED` + `shippedAt` and emails active notifies. Re-run does not resend.
- Email: Resend / SendGrid / console stub. Env: `RESEND_API_KEY`, `SENDGRID_API_KEY`, `ROADMAP_FROM_EMAIL`, `ROADMAP_SHIP_SECRET`.

## Tests

Covers omit `githubIssueUrl`, vote toggle + cookie, signed-in user binding, notify idempotent, unsubscribe, create request, public requests hide email, ship + email stub, basic rate-limit. Local: `yarn test` 369 passed; `yarn build` green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e3b5191-a73c-4b26-bd62-1e61134dcfd8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e3b5191-a73c-4b26-bd62-1e61134dcfd8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

