### PR TITLE
Coverage / conversion notify intents API v1

### DIFF
--- a/prisma/migrations/20260908180000_coverage_intent/migration.sql
+++ b/prisma/migrations/20260908180000_coverage_intent/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "CoverageIntent" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "sport" TEXT NOT NULL DEFAULT '',
+    "city" TEXT NOT NULL DEFAULT '',
+    "sourcePage" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "unsubscribedAt" TIMESTAMP(3),
+
+    CONSTRAINT "CoverageIntent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CoverageIntent_email_sport_city_key" ON "CoverageIntent"("email", "sport", "city");
+
+-- CreateIndex
+CREATE INDEX "CoverageIntent_email_idx" ON "CoverageIntent"("email");
+
+-- CreateIndex
+CREATE INDEX "CoverageIntent_unsubscribedAt_idx" ON "CoverageIntent"("unsubscribedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -765,3 +765,21 @@ model RoadmapRequest {
 
   @@index([status, createdAt])
 }
+
+// SEO landing “notify me when {sport} in {city} fills in.”
+// Unspecified sport/city are stored as "" so (email, sport, city) is unique
+// even when the API omits them. Empty string is never a valid sport/city.
+// Unique rule is Prisma-native; see 20260908180000_coverage_intent.
+model CoverageIntent {
+  id             String    @id @default(uuid())
+  email          String
+  sport          String    @default("")
+  city           String    @default("")
+  sourcePage     String?
+  createdAt      DateTime  @default(now())
+  unsubscribedAt DateTime?
+
+  @@unique([email, sport, city])
+  @@index([email])
+  @@index([unsubscribedAt])
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -81,6 +81,11 @@ import {
   RoadmapRateLimiter,
   RoadmapRepository,
 } from "./modules/roadmap";
+import {
+  CoverageIntentRepository,
+  CoverageRateLimiter,
+  createIntentsModule,
+} from "./modules/intents";
 
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
@@ -104,6 +109,8 @@ export type CreateAppDependencies = {
   roadmapRepository?: RoadmapRepository;
   roadmapEmailSender?: RoadmapEmailSender;
   roadmapVoteRateLimiter?: RoadmapRateLimiter;
+  coverageIntentRepository?: CoverageIntentRepository;
+  coverageRateLimiter?: CoverageRateLimiter;
 };
 
 export async function createApp(
@@ -283,6 +290,12 @@ export async function createApp(
     voteRateLimiter: dependencies.roadmapVoteRateLimiter,
     tryGetSessionUserId: identity.tryGetSessionUserId,
   });
+  const intents = createIntentsModule({
+    prisma,
+    config,
+    coverageIntentRepository: dependencies.coverageIntentRepository,
+    coverageRateLimiter: dependencies.coverageRateLimiter,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
@@ -302,6 +315,7 @@ export async function createApp(
   app.use(teamMatches.router);
   app.use(tournaments.router);
   app.use(roadmap.router);
+  app.use(intents.router);
 
   app.use(
     (

--- a/src/modules/intents/README.md
+++ b/src/modules/intents/README.md
@@ -1,0 +1,91 @@
+# Coverage / conversion notify intents API v1
+
+SEO landings can collect “notify me when {sport} in {city} fills in.” This is **coverage intent**, not roadmap ship-notify. Do not store these rows on `RoadmapNotify`.
+
+## Public contract
+
+No auth. Email is **never** returned on these responses.
+
+| Method | Path | Body | Notes |
+| --- | --- | --- | --- |
+| `POST` | `/api/intents/coverage` | `{ "email", "sport?", "city?", "sourcePage?" }` | Idempotent. `200` `{ intent: { id, sport, city, sourcePage, createdAt } }`. |
+| `POST` | `/api/intents/coverage/unsubscribe` | `{ "token" }` | Soft-unsub all intents for the token email. `200` `{ unsubscribed: true, count }`. |
+
+### Example
+
+```http
+POST /api/intents/coverage
+Content-Type: application/json
+
+{"email":"fan@example.com","sport":"padel","city":"Cape Town","sourcePage":"/padel/cape-town"}
+```
+
+```json
+{
+  "intent": {
+    "id": "…",
+    "sport": "padel",
+    "city": "cape town",
+    "sourcePage": "/padel/cape-town",
+    "createdAt": "2026-09-08T18:00:00.000Z"
+  }
+}
+```
+
+- `sport` = `padel` \| `golf` \| `darts` (extensible in `COVERAGE_SPORTS`). Omit / blank = any sport.
+- `city` is trimmed and lowercased. Omit / blank = any city.
+- `sourcePage` is a path or URL, max 500 chars. Not part of uniqueness.
+- Same `email + sport + city` returns the existing row (`200`) and **reactivates** if `unsubscribedAt` was set.
+- Rate-limit: **20 requests / 60s / IP** (same window as roadmap votes). `429` when exceeded.
+- Email is omitted from JSON so landings cannot leak PII in client logs / analytics. Ops read it from Postgres.
+
+### Uniqueness
+
+`(email, sport, city)` is unique. Unspecified sport/city are **stored as empty string** (`""`), not SQL `NULL`. Postgres `UNIQUE` treats `NULL` as distinct, which would allow duplicate “any sport / any city” rows for one email.
+
+| API input | Stored `sport` | Stored `city` |
+| --- | --- | --- |
+| omitted / `""` / whitespace | `""` | `""` |
+| `"PADEL"` / `"Cape Town"` | `padel` | `cape town` |
+
+`foo@bar.com` + no sport + no city is one row. `foo@bar.com` + `padel` + no city is a different row.
+
+## Unsubscribe token
+
+**Dedicated JWT**, not the roadmap token.
+
+| | Roadmap | Coverage |
+| --- | --- | --- |
+| Purpose claim | `roadmap_unsub` | `coverage_unsub` |
+| Endpoint | `POST /api/roadmap/unsubscribe` | `POST /api/intents/coverage/unsubscribe` |
+| Scope | `RoadmapNotify` rows | `CoverageIntent` rows for that email |
+
+Signed with `JWT_SECRET`, `{ purpose, email }`, `365d`. A roadmap token is rejected here (and vice versa). Storage is ready (`unsubscribedAt`); threshold emails are **not** sent in v1. When those emails ship, include a link that posts this token.
+
+Minimum today: storage + `POST /api/intents/coverage/unsubscribe`. Frontend CTA / mailer / admin UI are out of scope.
+
+## Ops
+
+Active intents (Brandon / ops):
+
+```sql
+SELECT * FROM "CoverageIntent" WHERE "unsubscribedAt" IS NULL;
+```
+
+Useful filters:
+
+```sql
+SELECT sport, city, COUNT(*) 
+FROM "CoverageIntent"
+WHERE "unsubscribedAt" IS NULL
+GROUP BY sport, city
+ORDER BY COUNT(*) DESC;
+```
+
+Empty `sport` / `city` means “any”. Emails are in this table only — do not log them from the API.
+
+## Migration (Railway pre-deploy)
+
+`20260908180000_coverage_intent`
+
+Applied on merge via Railway `preDeployCommand` (`prisma migrate deploy`). Do not merge until ready to migrate.

--- a/src/modules/intents/controllers/coverage-intents.controller.ts
+++ b/src/modules/intents/controllers/coverage-intents.controller.ts
@@ -1,0 +1,89 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { IdentityConfig } from "../../identity/config";
+import { CoveragePersistenceError } from "../entities/coverage-persistence-error";
+import { CoverageRateLimitError } from "../entities/coverage-rate-limit-error";
+import { CoverageRateLimiter } from "../services/rate-limiter";
+import {
+  requireCoverageUnsubscribeEmail,
+  UnsubscribeCoverageIntents,
+  UpsertCoverageIntent,
+} from "../services/coverage-intents.service";
+import { parseCoverageUnsubscribeToken } from "../services/unsubscribe-token";
+
+const createBodySchema = z.object({
+  email: z.string(),
+  sport: z.string().optional().nullable(),
+  city: z.string().optional().nullable(),
+  sourcePage: z.string().optional().nullable(),
+});
+
+const tokenBodySchema = z.object({
+  token: z.string().min(1),
+});
+
+export function createCoverageIntentsController(deps: {
+  config: IdentityConfig;
+  upsert: UpsertCoverageIntent;
+  unsubscribe: UnsubscribeCoverageIntents;
+  rateLimiter: CoverageRateLimiter;
+}) {
+  return {
+    async create(req: Request, res: Response) {
+      try {
+        const ip = req.ip ?? "unknown";
+        if (!deps.rateLimiter.consume(ip)) {
+          throw new CoverageRateLimitError();
+        }
+        const body = z.parse(createBodySchema, req.body ?? {});
+        const result = await deps.upsert.execute({
+          email: body.email,
+          sport: body.sport,
+          city: body.city,
+          sourcePage: body.sourcePage,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendCoverageError(res, error);
+      }
+    },
+
+    async unsubscribe(req: Request, res: Response) {
+      try {
+        const body = z.parse(tokenBodySchema, req.body ?? {});
+        const email = requireCoverageUnsubscribeEmail(
+          parseCoverageUnsubscribeToken,
+          deps.config.JWT_SECRET,
+          body.token,
+        );
+        const result = await deps.unsubscribe.execute({ email });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendCoverageError(res, error);
+      }
+    },
+  };
+}
+
+function sendCoverageError(res: Response, error: unknown) {
+  if (error instanceof CoverageRateLimitError) {
+    return res.status(429).json({ error: error.message });
+  }
+
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid coverage intent payload" });
+  }
+
+  if (error instanceof CoveragePersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error("coverage intent failed");
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/intents/controllers/coverage-intents.http.test.ts
+++ b/src/modules/intents/controllers/coverage-intents.http.test.ts
@@ -1,0 +1,234 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+import jwt from "jsonwebtoken";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryCoverageIntentRepository } from "../repositories/in-memory-coverage-intent.repository";
+import { InMemoryWindowRateLimiter } from "../services/rate-limiter";
+import { signCoverageUnsubscribeToken } from "../services/unsubscribe-token";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+describe("coverage intents HTTP", () => {
+  const config = makeConfig();
+  let repo: InMemoryCoverageIntentRepository;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  beforeEach(async () => {
+    repo = new InMemoryCoverageIntentRepository();
+    app = await createApp(config, {
+      coverageIntentRepository: repo,
+      coverageRateLimiter: new InMemoryWindowRateLimiter(20, 60_000),
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("POST is idempotent, omits email, and reactivates after unsubscribe", async () => {
+    const first = await fetch(`${server.url}/api/intents/coverage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "  Fan@Example.com ",
+        sport: "padel",
+        city: "Cape Town",
+        sourcePage: "/padel/cape-town",
+      }),
+    });
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as {
+      intent: Record<string, unknown>;
+    };
+    expect(firstBody.intent).toMatchObject({
+      sport: "padel",
+      city: "cape town",
+      sourcePage: "/padel/cape-town",
+    });
+    expect(firstBody.intent).not.toHaveProperty("email");
+    expect(JSON.stringify(firstBody)).not.toContain("fan@example.com");
+
+    const second = await fetch(`${server.url}/api/intents/coverage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "fan@example.com",
+        sport: "PADEL",
+        city: "cape town",
+      }),
+    });
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as { intent: { id: string } };
+    expect(secondBody.intent.id).toBe(firstBody.intent.id);
+
+    const token = signCoverageUnsubscribeToken(
+      config.JWT_SECRET,
+      "fan@example.com",
+    );
+    const unsub = await fetch(`${server.url}/api/intents/coverage/unsubscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    expect(unsub.status).toBe(200);
+    expect(await unsub.json()).toEqual({ unsubscribed: true, count: 1 });
+    expect(
+      (
+        await repo.findByEmailSportCity(
+          "fan@example.com",
+          "padel",
+          "cape town",
+        )
+      )?.isActive,
+    ).toBe(false);
+
+    const again = await fetch(`${server.url}/api/intents/coverage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "fan@example.com",
+        sport: "padel",
+        city: "Cape Town",
+      }),
+    });
+    const againBody = (await again.json()) as { intent: { id: string } };
+    expect(againBody.intent.id).toBe(firstBody.intent.id);
+    expect(
+      (await repo.findByEmailSportCity(
+        "fan@example.com",
+        "padel",
+        "cape town",
+      ))?.isActive,
+    ).toBe(true);
+  });
+
+  test("null sport/city uniqueness and validation", async () => {
+    const first = await fetch(`${server.url}/api/intents/coverage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "a@b.com" }),
+    });
+    const firstBody = (await first.json()) as { intent: { id: string } };
+
+    const second = await fetch(`${server.url}/api/intents/coverage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "a@b.com", sport: "", city: "  " }),
+    });
+    const secondBody = (await second.json()) as { intent: { id: string } };
+    expect(secondBody.intent.id).toBe(firstBody.intent.id);
+
+    const other = await fetch(`${server.url}/api/intents/coverage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "a@b.com", sport: "golf" }),
+    });
+    const otherBody = (await other.json()) as { intent: { id: string } };
+    expect(otherBody.intent.id).not.toBe(firstBody.intent.id);
+
+    const badEmail = await fetch(`${server.url}/api/intents/coverage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email" }),
+    });
+    expect(badEmail.status).toBe(400);
+    expect(await badEmail.json()).toEqual({ error: "email is invalid" });
+
+    const unknownSport = await fetch(`${server.url}/api/intents/coverage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "a@b.com", sport: "tennis" }),
+    });
+    expect(unknownSport.status).toBe(400);
+    expect(await unknownSport.json()).toEqual({
+      error: "sport must be padel, golf, or darts",
+    });
+
+    const badToken = await fetch(
+      `${server.url}/api/intents/coverage/unsubscribe`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          token: jwt.sign(
+            { purpose: "roadmap_unsub", email: "a@b.com" },
+            config.JWT_SECRET,
+          ),
+        }),
+      },
+    );
+    expect(badToken.status).toBe(400);
+  });
+
+  test("rate-limit returns 429", async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+    app = await createApp(config, {
+      coverageIntentRepository: repo,
+      coverageRateLimiter: new InMemoryWindowRateLimiter(2, 60_000),
+    });
+    server = await listen(app);
+
+    const body = JSON.stringify({ email: "rl@example.com", sport: "golf" });
+    const headers = { "Content-Type": "application/json" };
+    expect(
+      (
+        await fetch(`${server.url}/api/intents/coverage`, {
+          method: "POST",
+          headers,
+          body,
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await fetch(`${server.url}/api/intents/coverage`, {
+          method: "POST",
+          headers,
+          body,
+        })
+      ).status,
+    ).toBe(200);
+    const third = await fetch(`${server.url}/api/intents/coverage`, {
+      method: "POST",
+      headers,
+      body,
+    });
+    expect(third.status).toBe(429);
+  });
+});

--- a/src/modules/intents/entities/coverage-intent.test.ts
+++ b/src/modules/intents/entities/coverage-intent.test.ts
@@ -1,0 +1,46 @@
+import { DomainError } from "../../../lib/domain-error";
+import {
+  CoverageIntent,
+  coverageUniquenessKey,
+  normalizeCoverageCity,
+  normalizeCoverageEmail,
+  normalizeSourcePage,
+} from "./coverage-intent";
+
+describe("CoverageIntent", () => {
+  test("normalizes email and optional fields", () => {
+    const intent = CoverageIntent.create({
+      email: "  Foo@Bar.com ",
+      sport: "PADEL",
+      city: "  Cape Town ",
+      sourcePage: " /padel/cape-town ",
+    });
+    expect(intent.email).toBe("foo@bar.com");
+    expect(intent.sportValue).toBe("padel");
+    expect(intent.city).toBe("cape town");
+    expect(intent.sourcePage).toBe("/padel/cape-town");
+    expect(intent.uniquenessKey()).toEqual({
+      sport: "padel",
+      city: "cape town",
+    });
+  });
+
+  test("treats omitted sport/city as empty uniqueness keys", () => {
+    const intent = CoverageIntent.create({ email: "a@b.com" });
+    expect(intent.sportValue).toBeNull();
+    expect(intent.city).toBeNull();
+    expect(intent.uniquenessKey()).toEqual({ sport: "", city: "" });
+    expect(coverageUniquenessKey(null, null)).toEqual({ sport: "", city: "" });
+  });
+
+  test("rejects invalid email and unknown sport", () => {
+    expect(() => normalizeCoverageEmail("not-an-email")).toThrow(DomainError);
+    expect(() => CoverageIntent.create({ email: "a@b.com", sport: "tennis" }))
+      .toThrow("sport must be padel, golf, or darts");
+  });
+
+  test("caps city and sourcePage", () => {
+    expect(() => normalizeCoverageCity("x".repeat(81))).toThrow(DomainError);
+    expect(() => normalizeSourcePage("x".repeat(501))).toThrow(DomainError);
+  });
+});

--- a/src/modules/intents/entities/coverage-intent.ts
+++ b/src/modules/intents/entities/coverage-intent.ts
@@ -1,0 +1,184 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import {
+  CoverageSport,
+  CoverageSportValue,
+} from "./coverage-sport";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_CITY_LENGTH = 80;
+const MAX_SOURCE_PAGE_LENGTH = 500;
+
+export function normalizeCoverageEmail(raw: unknown): string {
+  const email = requiredTrimmed(raw, "email").toLowerCase();
+  if (!EMAIL_PATTERN.test(email)) {
+    throw new DomainError("email is invalid");
+  }
+  return email;
+}
+
+/** Trim + lowercase. Blank / omitted → null (stored as "" for uniqueness). */
+export function normalizeCoverageCity(raw: unknown): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") {
+    throw new DomainError("city must be a string");
+  }
+  const city = raw.trim().toLowerCase();
+  if (city.length === 0) return null;
+  if (city.length > MAX_CITY_LENGTH) {
+    throw new DomainError(`city must be at most ${MAX_CITY_LENGTH} characters`);
+  }
+  return city;
+}
+
+export function normalizeSourcePage(raw: unknown): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") {
+    throw new DomainError("sourcePage must be a string");
+  }
+  const value = raw.trim();
+  if (value.length === 0) return null;
+  if (value.length > MAX_SOURCE_PAGE_LENGTH) {
+    throw new DomainError(
+      `sourcePage must be at most ${MAX_SOURCE_PAGE_LENGTH} characters`,
+    );
+  }
+  return value;
+}
+
+/** Empty string is the stored form of unspecified sport/city. */
+export function coverageUniquenessKey(
+  sport: string | null,
+  city: string | null,
+): { sport: string; city: string } {
+  return { sport: sport ?? "", city: city ?? "" };
+}
+
+export type CoverageIntentSnapshot = {
+  id: string;
+  email: string;
+  sport: CoverageSportValue | null;
+  city: string | null;
+  sourcePage: string | null;
+  createdAt: string;
+  unsubscribedAt: string | null;
+};
+
+export class CoverageIntent {
+  private constructor(
+    readonly id: string,
+    readonly email: string,
+    readonly sport: CoverageSport | null,
+    readonly city: string | null,
+    readonly sourcePage: string | null,
+    readonly createdAt: Date,
+    private unsubscribedAtValue: Date | null,
+  ) {}
+
+  static create(props: {
+    id?: string;
+    email: unknown;
+    sport?: unknown;
+    city?: unknown;
+    sourcePage?: unknown;
+    createdAt?: Date;
+  }): CoverageIntent {
+    return new CoverageIntent(
+      props.id ?? randomUUID(),
+      normalizeCoverageEmail(props.email),
+      CoverageSport.from(props.sport),
+      normalizeCoverageCity(props.city),
+      normalizeSourcePage(props.sourcePage),
+      props.createdAt ?? new Date(),
+      null,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    email: string;
+    sport: string | null;
+    city: string | null;
+    sourcePage: string | null;
+    createdAt: Date;
+    unsubscribedAt: Date | null;
+  }): CoverageIntent {
+    return new CoverageIntent(
+      props.id,
+      props.email,
+      CoverageSport.from(props.sport === "" ? null : props.sport),
+      props.city === "" ? null : props.city,
+      props.sourcePage,
+      props.createdAt,
+      props.unsubscribedAt,
+    );
+  }
+
+  static fromSnapshot(snapshot: CoverageIntentSnapshot): CoverageIntent {
+    return CoverageIntent.rehydrate({
+      id: snapshot.id,
+      email: snapshot.email,
+      sport: snapshot.sport,
+      city: snapshot.city,
+      sourcePage: snapshot.sourcePage,
+      createdAt: new Date(snapshot.createdAt),
+      unsubscribedAt: snapshot.unsubscribedAt
+        ? new Date(snapshot.unsubscribedAt)
+        : null,
+    });
+  }
+
+  get unsubscribedAt(): Date | null {
+    return this.unsubscribedAtValue;
+  }
+
+  get isActive(): boolean {
+    return this.unsubscribedAtValue == null;
+  }
+
+  get sportValue(): CoverageSportValue | null {
+    return this.sport?.value ?? null;
+  }
+
+  uniquenessKey(): { sport: string; city: string } {
+    return coverageUniquenessKey(this.sportValue, this.city);
+  }
+
+  reactivate(sourcePage?: string | null): CoverageIntent {
+    return CoverageIntent.rehydrate({
+      id: this.id,
+      email: this.email,
+      sport: this.sportValue,
+      city: this.city,
+      sourcePage: sourcePage !== undefined ? sourcePage : this.sourcePage,
+      createdAt: this.createdAt,
+      unsubscribedAt: null,
+    });
+  }
+
+  unsubscribe(now = new Date()): CoverageIntent {
+    if (this.unsubscribedAtValue) return this;
+    return CoverageIntent.rehydrate({
+      id: this.id,
+      email: this.email,
+      sport: this.sportValue,
+      city: this.city,
+      sourcePage: this.sourcePage,
+      createdAt: this.createdAt,
+      unsubscribedAt: now,
+    });
+  }
+
+  toSnapshot(): CoverageIntentSnapshot {
+    return {
+      id: this.id,
+      email: this.email,
+      sport: this.sportValue,
+      city: this.city,
+      sourcePage: this.sourcePage,
+      createdAt: this.createdAt.toISOString(),
+      unsubscribedAt: this.unsubscribedAtValue?.toISOString() ?? null,
+    };
+  }
+}

--- a/src/modules/intents/entities/coverage-persistence-error.ts
+++ b/src/modules/intents/entities/coverage-persistence-error.ts
@@ -1,0 +1,9 @@
+export class CoveragePersistenceError extends Error {
+  constructor(
+    message = "Unable to save coverage intent",
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "CoveragePersistenceError";
+  }
+}

--- a/src/modules/intents/entities/coverage-rate-limit-error.ts
+++ b/src/modules/intents/entities/coverage-rate-limit-error.ts
@@ -1,0 +1,6 @@
+export class CoverageRateLimitError extends Error {
+  constructor(message = "Too many coverage intents, try again shortly") {
+    super(message);
+    this.name = "CoverageRateLimitError";
+  }
+}

--- a/src/modules/intents/entities/coverage-sport.ts
+++ b/src/modules/intents/entities/coverage-sport.ts
@@ -1,0 +1,35 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const COVERAGE_SPORTS = ["padel", "golf", "darts"] as const;
+export type CoverageSportValue = (typeof COVERAGE_SPORTS)[number];
+
+export class CoverageSport {
+  static readonly PADEL = new CoverageSport("padel");
+  static readonly GOLF = new CoverageSport("golf");
+  static readonly DARTS = new CoverageSport("darts");
+
+  private constructor(readonly value: CoverageSportValue) {}
+
+  /**
+   * Optional sport. `null` / blank means “any sport”.
+   * Unknown values fail closed — add new members here (and tests) to extend.
+   */
+  static from(raw: unknown): CoverageSport | null {
+    if (raw == null) return null;
+    if (typeof raw !== "string") {
+      throw new DomainError("sport must be padel, golf, or darts");
+    }
+
+    const sport = raw.trim().toLowerCase();
+    if (sport.length === 0) return null;
+    if (sport === "padel") return CoverageSport.PADEL;
+    if (sport === "golf") return CoverageSport.GOLF;
+    if (sport === "darts") return CoverageSport.DARTS;
+
+    throw new DomainError("sport must be padel, golf, or darts");
+  }
+
+  equals(other: CoverageSport): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/intents/index.ts
+++ b/src/modules/intents/index.ts
@@ -1,0 +1,71 @@
+import { Router } from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { IdentityConfig } from "../identity/config";
+import { createCoverageIntentsController } from "./controllers/coverage-intents.controller";
+import { PrismaCoverageIntentRepository } from "./repositories/prisma-coverage-intent.repository";
+import { CoverageIntentRepository } from "./repositories/coverage-intent.repository";
+import { createCoverageIntentsRoutes } from "./routes/coverage-intents.routes";
+import {
+  DEFAULT_COVERAGE_RATE_LIMITER,
+  CoverageRateLimiter,
+} from "./services/rate-limiter";
+import {
+  UnsubscribeCoverageIntents,
+  UpsertCoverageIntent,
+} from "./services/coverage-intents.service";
+
+export type CreateIntentsModuleParams = {
+  prisma: PrismaClient;
+  config: IdentityConfig;
+  coverageIntentRepository?: CoverageIntentRepository;
+  coverageRateLimiter?: CoverageRateLimiter;
+};
+
+export type IntentsModule = {
+  router: Router;
+  coverageIntentRepository: CoverageIntentRepository;
+};
+
+export function createIntentsModule({
+  prisma,
+  config,
+  coverageIntentRepository: repositoryOverride,
+  coverageRateLimiter: rateLimiterOverride,
+}: CreateIntentsModuleParams): IntentsModule {
+  const coverageIntentRepository =
+    repositoryOverride ?? new PrismaCoverageIntentRepository(prisma);
+  const rateLimiter = rateLimiterOverride ?? DEFAULT_COVERAGE_RATE_LIMITER;
+
+  const controller = createCoverageIntentsController({
+    config,
+    upsert: new UpsertCoverageIntent(coverageIntentRepository),
+    unsubscribe: new UnsubscribeCoverageIntents(coverageIntentRepository),
+    rateLimiter,
+  });
+
+  return {
+    router: createCoverageIntentsRoutes(controller),
+    coverageIntentRepository,
+  };
+}
+
+export { createCoverageIntentsController } from "./controllers/coverage-intents.controller";
+export { InMemoryCoverageIntentRepository } from "./repositories/in-memory-coverage-intent.repository";
+export { PrismaCoverageIntentRepository } from "./repositories/prisma-coverage-intent.repository";
+export type { CoverageIntentRepository } from "./repositories/coverage-intent.repository";
+export { CoverageIntent } from "./entities/coverage-intent";
+export { CoverageSport, COVERAGE_SPORTS } from "./entities/coverage-sport";
+export { CoveragePersistenceError } from "./entities/coverage-persistence-error";
+export { CoverageRateLimitError } from "./entities/coverage-rate-limit-error";
+export { InMemoryWindowRateLimiter } from "./services/rate-limiter";
+export type { CoverageRateLimiter } from "./services/rate-limiter";
+export {
+  signCoverageUnsubscribeToken,
+  parseCoverageUnsubscribeToken,
+} from "./services/unsubscribe-token";
+export {
+  UpsertCoverageIntent,
+  UnsubscribeCoverageIntents,
+} from "./services/coverage-intents.service";
+export type { PublicCoverageIntent } from "./services/coverage-intents.service";

--- a/src/modules/intents/repositories/coverage-intent.repository.ts
+++ b/src/modules/intents/repositories/coverage-intent.repository.ts
@@ -1,0 +1,11 @@
+import { CoverageIntent } from "../entities/coverage-intent";
+
+export interface CoverageIntentRepository {
+  upsert(intent: CoverageIntent): Promise<CoverageIntent>;
+  findByEmailSportCity(
+    email: string,
+    sport: string,
+    city: string,
+  ): Promise<CoverageIntent | null>;
+  unsubscribeAllByEmail(email: string, now?: Date): Promise<number>;
+}

--- a/src/modules/intents/repositories/in-memory-coverage-intent.repository.ts
+++ b/src/modules/intents/repositories/in-memory-coverage-intent.repository.ts
@@ -1,0 +1,68 @@
+import { CoverageIntent } from "../entities/coverage-intent";
+import { CoverageIntentRepository } from "./coverage-intent.repository";
+
+function rowKey(email: string, sport: string, city: string): string {
+  return `${email}::${sport}::${city}`;
+}
+
+export class InMemoryCoverageIntentRepository
+  implements CoverageIntentRepository
+{
+  private readonly byId = new Map<string, CoverageIntent>();
+  private readonly keys = new Map<string, string>();
+
+  async upsert(intent: CoverageIntent): Promise<CoverageIntent> {
+    const { sport, city } = intent.uniquenessKey();
+    const key = rowKey(intent.email, sport, city);
+    const existingId = this.keys.get(key);
+    if (existingId) {
+      const existing = this.byId.get(existingId)!;
+      const next = existing.reactivate(
+        intent.sourcePage !== null ? intent.sourcePage : undefined,
+      );
+      this.byId.set(next.id, next);
+      return clone(next);
+    }
+    const stored = clone(intent);
+    this.byId.set(stored.id, stored);
+    this.keys.set(key, stored.id);
+    return clone(stored);
+  }
+
+  async findByEmailSportCity(
+    email: string,
+    sport: string,
+    city: string,
+  ): Promise<CoverageIntent | null> {
+    const id = this.keys.get(rowKey(email, sport, city));
+    if (!id) return null;
+    return clone(this.byId.get(id)!);
+  }
+
+  async unsubscribeAllByEmail(email: string, now = new Date()): Promise<number> {
+    let count = 0;
+    for (const intent of this.byId.values()) {
+      if (intent.email !== email || !intent.isActive) continue;
+      const next = intent.unsubscribe(now);
+      this.byId.set(next.id, next);
+      count += 1;
+    }
+    return count;
+  }
+
+  seed(intent: CoverageIntent): CoverageIntent {
+    const stored = clone(intent);
+    const { sport, city } = stored.uniquenessKey();
+    this.byId.set(stored.id, stored);
+    this.keys.set(rowKey(stored.email, sport, city), stored.id);
+    return clone(stored);
+  }
+
+  all(): CoverageIntent[] {
+    return [...this.byId.values()].map(clone);
+  }
+}
+
+function clone(intent: CoverageIntent): CoverageIntent {
+  return CoverageIntent.fromSnapshot(intent.toSnapshot());
+}

--- a/src/modules/intents/repositories/prisma-coverage-intent.repository.ts
+++ b/src/modules/intents/repositories/prisma-coverage-intent.repository.ts
@@ -1,0 +1,97 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { CoverageIntent } from "../entities/coverage-intent";
+import { CoveragePersistenceError } from "../entities/coverage-persistence-error";
+import { CoverageIntentRepository } from "./coverage-intent.repository";
+
+type IntentRow = {
+  id: string;
+  email: string;
+  sport: string;
+  city: string;
+  sourcePage: string | null;
+  createdAt: Date;
+  unsubscribedAt: Date | null;
+};
+
+function toIntent(row: IntentRow): CoverageIntent {
+  return CoverageIntent.rehydrate({
+    id: row.id,
+    email: row.email,
+    sport: row.sport === "" ? null : row.sport,
+    city: row.city === "" ? null : row.city,
+    sourcePage: row.sourcePage,
+    createdAt: row.createdAt,
+    unsubscribedAt: row.unsubscribedAt,
+  });
+}
+
+export class PrismaCoverageIntentRepository
+  implements CoverageIntentRepository
+{
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async upsert(intent: CoverageIntent): Promise<CoverageIntent> {
+    const snapshot = intent.toSnapshot();
+    const { sport, city } = intent.uniquenessKey();
+    try {
+      const row = await this.prisma.coverageIntent.upsert({
+        where: {
+          email_sport_city: { email: snapshot.email, sport, city },
+        },
+        create: {
+          id: snapshot.id,
+          email: snapshot.email,
+          sport,
+          city,
+          sourcePage: snapshot.sourcePage,
+          createdAt: intent.createdAt,
+        },
+        update: {
+          unsubscribedAt: null,
+          ...(snapshot.sourcePage != null
+            ? { sourcePage: snapshot.sourcePage }
+            : {}),
+        },
+      });
+      return toIntent(row);
+    } catch (error) {
+      throw new CoveragePersistenceError("Failed to save coverage intent", {
+        cause: error,
+      });
+    }
+  }
+
+  async findByEmailSportCity(
+    email: string,
+    sport: string,
+    city: string,
+  ): Promise<CoverageIntent | null> {
+    try {
+      const row = await this.prisma.coverageIntent.findUnique({
+        where: { email_sport_city: { email, sport, city } },
+      });
+      return row ? toIntent(row) : null;
+    } catch (error) {
+      throw new CoveragePersistenceError("Failed to load coverage intent", {
+        cause: error,
+      });
+    }
+  }
+
+  async unsubscribeAllByEmail(
+    email: string,
+    now = new Date(),
+  ): Promise<number> {
+    try {
+      const result = await this.prisma.coverageIntent.updateMany({
+        where: { email, unsubscribedAt: null },
+        data: { unsubscribedAt: now },
+      });
+      return result.count;
+    } catch (error) {
+      throw new CoveragePersistenceError("Failed to unsubscribe", {
+        cause: error,
+      });
+    }
+  }
+}

--- a/src/modules/intents/routes/coverage-intents.routes.ts
+++ b/src/modules/intents/routes/coverage-intents.routes.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+
+import { createCoverageIntentsController } from "../controllers/coverage-intents.controller";
+
+export function createCoverageIntentsRoutes(
+  controller: ReturnType<typeof createCoverageIntentsController>,
+): Router {
+  const router = Router();
+
+  router.post("/api/intents/coverage", (req, res) => {
+    void controller.create(req, res);
+  });
+
+  router.post("/api/intents/coverage/unsubscribe", (req, res) => {
+    void controller.unsubscribe(req, res);
+  });
+
+  return router;
+}

--- a/src/modules/intents/services/coverage-intents.service.test.ts
+++ b/src/modules/intents/services/coverage-intents.service.test.ts
@@ -1,0 +1,120 @@
+import { CoverageIntent } from "../entities/coverage-intent";
+import { InMemoryCoverageIntentRepository } from "../repositories/in-memory-coverage-intent.repository";
+import {
+  UnsubscribeCoverageIntents,
+  UpsertCoverageIntent,
+} from "./coverage-intents.service";
+
+describe("coverage intent services", () => {
+  test("upsert is idempotent on email+sport+city", async () => {
+    const repo = new InMemoryCoverageIntentRepository();
+    const upsert = new UpsertCoverageIntent(repo);
+
+    const first = await upsert.execute({
+      email: "  Fan@Example.com ",
+      sport: "padel",
+      city: "Cape Town",
+      sourcePage: "/padel/cape-town",
+    });
+    const second = await upsert.execute({
+      email: "fan@example.com",
+      sport: "PADEL",
+      city: "  cape town ",
+      sourcePage: "/other",
+    });
+
+    expect(second.intent.id).toBe(first.intent.id);
+    expect(second.intent.sport).toBe("padel");
+    expect(second.intent.city).toBe("cape town");
+    expect(repo.all()).toHaveLength(1);
+    expect(JSON.stringify(second)).not.toContain("fan@example.com");
+  });
+
+  test("null sport/city share one uniqueness slot", async () => {
+    const repo = new InMemoryCoverageIntentRepository();
+    const upsert = new UpsertCoverageIntent(repo);
+
+    const first = await upsert.execute({ email: "a@b.com" });
+    const second = await upsert.execute({
+      email: "a@b.com",
+      sport: "",
+      city: "   ",
+    });
+    const otherSport = await upsert.execute({
+      email: "a@b.com",
+      sport: "golf",
+    });
+
+    expect(second.intent.id).toBe(first.intent.id);
+    expect(otherSport.intent.id).not.toBe(first.intent.id);
+    expect(repo.all()).toHaveLength(2);
+  });
+
+  test("unsubscribe then upsert reactivates the same row", async () => {
+    const repo = new InMemoryCoverageIntentRepository();
+    const upsert = new UpsertCoverageIntent(repo);
+    const unsub = new UnsubscribeCoverageIntents(repo);
+
+    const created = await upsert.execute({
+      email: "a@b.com",
+      sport: "darts",
+      city: "johannesburg",
+    });
+    const result = await unsub.execute({ email: "A@B.com" });
+    expect(result).toEqual({ unsubscribed: true, count: 1 });
+
+    const stored = await repo.findByEmailSportCity(
+      "a@b.com",
+      "darts",
+      "johannesburg",
+    );
+    expect(stored?.isActive).toBe(false);
+
+    const again = await upsert.execute({
+      email: "a@b.com",
+      sport: "darts",
+      city: "johannesburg",
+    });
+    expect(again.intent.id).toBe(created.intent.id);
+    expect(
+      (await repo.findByEmailSportCity("a@b.com", "darts", "johannesburg"))
+        ?.isActive,
+    ).toBe(true);
+  });
+
+  test("rejects invalid email and unknown sport", async () => {
+    const upsert = new UpsertCoverageIntent(
+      new InMemoryCoverageIntentRepository(),
+    );
+    await expect(upsert.execute({ email: "nope" })).rejects.toThrow(
+      "email is invalid",
+    );
+    await expect(
+      upsert.execute({ email: "a@b.com", sport: "tennis" }),
+    ).rejects.toThrow("sport must be padel, golf, or darts");
+  });
+
+  test("seeded unsubscribed row reactivates on upsert", async () => {
+    const repo = new InMemoryCoverageIntentRepository();
+    const existing = repo.seed(
+      CoverageIntent.rehydrate({
+        id: "intent-1",
+        email: "a@b.com",
+        sport: "golf",
+        city: "durban",
+        sourcePage: "/old",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        unsubscribedAt: new Date("2026-02-01T00:00:00.000Z"),
+      }),
+    );
+    const result = await new UpsertCoverageIntent(repo).execute({
+      email: "a@b.com",
+      sport: "golf",
+      city: "Durban",
+      sourcePage: "/new",
+    });
+    expect(result.intent.id).toBe(existing.id);
+    expect(result.intent.sourcePage).toBe("/new");
+    expect(result.intent.createdAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+});

--- a/src/modules/intents/services/coverage-intents.service.ts
+++ b/src/modules/intents/services/coverage-intents.service.ts
@@ -1,8 +1,10 @@
 import { DomainError } from "../../../lib/domain-error";
-import { CoverageIntent } from "../entities/coverage-intent";
+import {
+  CoverageIntent,
+  normalizeCoverageEmail,
+} from "../entities/coverage-intent";
 import { CoverageSportValue } from "../entities/coverage-sport";
 import { CoverageIntentRepository } from "../repositories/coverage-intent.repository";
-import { normalizeCoverageEmail } from "../entities/coverage-intent";
 
 export type PublicCoverageIntent = {
   id: string;

--- a/src/modules/intents/services/coverage-intents.service.ts
+++ b/src/modules/intents/services/coverage-intents.service.ts
@@ -1,0 +1,64 @@
+import { DomainError } from "../../../lib/domain-error";
+import { CoverageIntent } from "../entities/coverage-intent";
+import { CoverageSportValue } from "../entities/coverage-sport";
+import { CoverageIntentRepository } from "../repositories/coverage-intent.repository";
+import { normalizeCoverageEmail } from "../entities/coverage-intent";
+
+export type PublicCoverageIntent = {
+  id: string;
+  sport: CoverageSportValue | null;
+  city: string | null;
+  sourcePage: string | null;
+  createdAt: string;
+};
+
+function toPublic(intent: CoverageIntent): PublicCoverageIntent {
+  const snapshot = intent.toSnapshot();
+  return {
+    id: snapshot.id,
+    sport: snapshot.sport,
+    city: snapshot.city,
+    sourcePage: snapshot.sourcePage,
+    createdAt: snapshot.createdAt,
+  };
+}
+
+export class UpsertCoverageIntent {
+  constructor(private readonly repository: CoverageIntentRepository) {}
+
+  async execute(input: {
+    email: unknown;
+    sport?: unknown;
+    city?: unknown;
+    sourcePage?: unknown;
+  }): Promise<{ intent: PublicCoverageIntent }> {
+    const created = CoverageIntent.create(input);
+    const saved = await this.repository.upsert(created);
+    return { intent: toPublic(saved) };
+  }
+}
+
+export class UnsubscribeCoverageIntents {
+  constructor(private readonly repository: CoverageIntentRepository) {}
+
+  async execute(input: { email: string }): Promise<{
+    unsubscribed: true;
+    count: number;
+  }> {
+    const email = normalizeCoverageEmail(input.email);
+    const count = await this.repository.unsubscribeAllByEmail(email);
+    return { unsubscribed: true, count };
+  }
+}
+
+export function requireCoverageUnsubscribeEmail(
+  parse: (secret: string, token: string) => string,
+  secret: string,
+  token: string,
+): string {
+  try {
+    return parse(secret, token);
+  } catch {
+    throw new DomainError("unsubscribe token is invalid");
+  }
+}

--- a/src/modules/intents/services/rate-limiter.ts
+++ b/src/modules/intents/services/rate-limiter.ts
@@ -1,0 +1,33 @@
+export interface CoverageRateLimiter {
+  consume(key: string): boolean;
+}
+
+export class InMemoryWindowRateLimiter implements CoverageRateLimiter {
+  private readonly hits = new Map<string, number[]>();
+
+  constructor(
+    private readonly max: number,
+    private readonly windowMs: number,
+  ) {}
+
+  consume(key: string): boolean {
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+    const timestamps = (this.hits.get(key) ?? []).filter(
+      (stamp) => stamp > windowStart,
+    );
+    if (timestamps.length >= this.max) {
+      this.hits.set(key, timestamps);
+      return false;
+    }
+    timestamps.push(now);
+    this.hits.set(key, timestamps);
+    return true;
+  }
+}
+
+/** Same window as roadmap votes: 20 / 60s / IP. */
+export const DEFAULT_COVERAGE_RATE_LIMITER = new InMemoryWindowRateLimiter(
+  20,
+  60_000,
+);

--- a/src/modules/intents/services/unsubscribe-token.test.ts
+++ b/src/modules/intents/services/unsubscribe-token.test.ts
@@ -1,0 +1,28 @@
+import jwt from "jsonwebtoken";
+
+import {
+  parseCoverageUnsubscribeToken,
+  signCoverageUnsubscribeToken,
+} from "./unsubscribe-token";
+
+describe("coverage unsubscribe token", () => {
+  const secret = "jwt-test-secret";
+
+  test("round-trips a normalized email", () => {
+    const token = signCoverageUnsubscribeToken(secret, "  Foo@Bar.com ");
+    expect(parseCoverageUnsubscribeToken(secret, token)).toBe("foo@bar.com");
+  });
+
+  test("rejects a token signed with a different secret", () => {
+    const token = signCoverageUnsubscribeToken(secret, "a@b.com");
+    expect(() => parseCoverageUnsubscribeToken("other", token)).toThrow();
+  });
+
+  test("rejects a roadmap token (different purpose)", () => {
+    const token = jwt.sign(
+      { purpose: "roadmap_unsub", email: "a@b.com" },
+      secret,
+    );
+    expect(() => parseCoverageUnsubscribeToken(secret, token)).toThrow();
+  });
+});

--- a/src/modules/intents/services/unsubscribe-token.ts
+++ b/src/modules/intents/services/unsubscribe-token.ts
@@ -1,0 +1,27 @@
+import jwt from "jsonwebtoken";
+import { z } from "zod";
+
+const payloadSchema = z.object({
+  purpose: z.literal("coverage_unsub"),
+  email: z.string().email(),
+});
+
+export function signCoverageUnsubscribeToken(
+  secret: string,
+  email: string,
+): string {
+  return jwt.sign(
+    { purpose: "coverage_unsub", email: email.trim().toLowerCase() },
+    secret,
+    { expiresIn: "365d" },
+  );
+}
+
+export function parseCoverageUnsubscribeToken(
+  secret: string,
+  token: string,
+): string {
+  const decoded = jwt.verify(token, secret);
+  const payload = payloadSchema.parse(decoded);
+  return payload.email;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #50

SEO landings need an honest fallback when inventory is thin: collect “notify me when {sport} in {city} fills in.” This is **coverage intent**, separate from roadmap per-feature ship-notify. Do **not** merge until ready to run `20260908180000_coverage_intent` on Railway (`prisma migrate deploy`).

## Public contract
- `POST /api/intents/coverage` `{ email, sport?, city?, sourcePage? }` → `200 { intent: { id, sport, city, sourcePage, createdAt } }`
- Idempotent on `(email, sport, city)`; reactivates if `unsubscribedAt` was set
- Unspecified sport/city stored as `""` so uniqueness treats them as equal
- Rate-limit: 20 / 60s / IP
- No auth; **email omitted** from JSON
- `POST /api/intents/coverage/unsubscribe` `{ token }` — dedicated JWT `purpose=coverage_unsub` (not shared with roadmap)

## Ops
```sql
SELECT * FROM "CoverageIntent" WHERE "unsubscribedAt" IS NULL;
```

See `src/modules/intents/README.md`.

## Out of scope
CTA UI, GA4, admin, threshold emails, roadmap changes.

**Do not merge.**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-765d584f-556a-48ef-beef-f7324e5ee857?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-765d584f-556a-48ef-beef-f7324e5ee857&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

