### PR TITLE
feat: Matchmaking lobby v1

### DIFF
--- a/prisma/migrations/20260908200000_lobby/migration.sql
+++ b/prisma/migrations/20260908200000_lobby/migration.sql
@@ -1,0 +1,150 @@
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE 'lobby_open_game_compatible';
+ALTER TYPE "NotificationType" ADD VALUE 'lobby_proposal_ready';
+ALTER TYPE "NotificationType" ADD VALUE 'lobby_open_game_joined';
+ALTER TYPE "NotificationType" ADD VALUE 'lobby_open_game_filled';
+
+-- CreateEnum
+CREATE TYPE "LobbySport" AS ENUM ('padel', 'darts', 'golf');
+
+-- CreateEnum
+CREATE TYPE "LobbySkill" AS ENUM ('casual', 'intermediate', 'competitive');
+
+-- CreateEnum
+CREATE TYPE "LobbyOpenGameStatus" AS ENUM ('open', 'filled', 'cancelled', 'expired');
+
+-- CreateEnum
+CREATE TYPE "LobbyProposalStatus" AS ENUM ('pending', 'accepted', 'expired', 'cancelled');
+
+-- CreateEnum
+CREATE TYPE "LobbyProposalResponse" AS ENUM ('pending', 'accept', 'pass');
+
+-- CreateTable
+CREATE TABLE "LobbyLooking" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "sport" "LobbySport" NOT NULL,
+    "windowStart" TIMESTAMP(3) NOT NULL,
+    "windowEnd" TIMESTAMP(3) NOT NULL,
+    "city" TEXT NOT NULL,
+    "area" TEXT,
+    "venueCmsId" TEXT,
+    "partySize" INTEGER NOT NULL,
+    "skill" "LobbySkill",
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LobbyLooking_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LobbyOpenGame" (
+    "id" TEXT NOT NULL,
+    "hostUserId" TEXT NOT NULL,
+    "sport" "LobbySport" NOT NULL,
+    "windowStart" TIMESTAMP(3) NOT NULL,
+    "windowEnd" TIMESTAMP(3) NOT NULL,
+    "city" TEXT NOT NULL,
+    "area" TEXT,
+    "venueCmsId" TEXT,
+    "slotsNeeded" INTEGER NOT NULL,
+    "slotsFilled" INTEGER NOT NULL,
+    "skill" "LobbySkill",
+    "status" "LobbyOpenGameStatus" NOT NULL DEFAULT 'open',
+    "organiseGameId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "LobbyOpenGame_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LobbyOpenGameMember" (
+    "id" TEXT NOT NULL,
+    "openGameId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "partySize" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LobbyOpenGameMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LobbyProposal" (
+    "id" TEXT NOT NULL,
+    "sport" "LobbySport" NOT NULL,
+    "city" TEXT NOT NULL,
+    "area" TEXT,
+    "windowStart" TIMESTAMP(3) NOT NULL,
+    "windowEnd" TIMESTAMP(3) NOT NULL,
+    "venueCmsId" TEXT,
+    "skill" "LobbySkill",
+    "status" "LobbyProposalStatus" NOT NULL DEFAULT 'pending',
+    "organiseGameId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "LobbyProposal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LobbyProposalMember" (
+    "id" TEXT NOT NULL,
+    "proposalId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "partySize" INTEGER NOT NULL,
+    "response" "LobbyProposalResponse" NOT NULL DEFAULT 'pending',
+    "lookingId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "respondedAt" TIMESTAMP(3),
+
+    CONSTRAINT "LobbyProposalMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LobbyLooking_userId_key" ON "LobbyLooking"("userId");
+
+-- CreateIndex
+CREATE INDEX "LobbyLooking_sport_city_expiresAt_idx" ON "LobbyLooking"("sport", "city", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "LobbyLooking_expiresAt_idx" ON "LobbyLooking"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "LobbyOpenGame_sport_city_status_idx" ON "LobbyOpenGame"("sport", "city", "status");
+
+-- CreateIndex
+CREATE INDEX "LobbyOpenGame_hostUserId_idx" ON "LobbyOpenGame"("hostUserId");
+
+-- CreateIndex
+CREATE INDEX "LobbyOpenGame_status_windowEnd_idx" ON "LobbyOpenGame"("status", "windowEnd");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LobbyOpenGameMember_openGameId_userId_key" ON "LobbyOpenGameMember"("openGameId", "userId");
+
+-- CreateIndex
+CREATE INDEX "LobbyOpenGameMember_userId_idx" ON "LobbyOpenGameMember"("userId");
+
+-- CreateIndex
+CREATE INDEX "LobbyOpenGameMember_openGameId_idx" ON "LobbyOpenGameMember"("openGameId");
+
+-- CreateIndex
+CREATE INDEX "LobbyProposal_sport_city_status_idx" ON "LobbyProposal"("sport", "city", "status");
+
+-- CreateIndex
+CREATE INDEX "LobbyProposal_status_windowEnd_idx" ON "LobbyProposal"("status", "windowEnd");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LobbyProposalMember_proposalId_userId_key" ON "LobbyProposalMember"("proposalId", "userId");
+
+-- CreateIndex
+CREATE INDEX "LobbyProposalMember_userId_idx" ON "LobbyProposalMember"("userId");
+
+-- CreateIndex
+CREATE INDEX "LobbyProposalMember_proposalId_idx" ON "LobbyProposalMember"("proposalId");
+
+-- AddForeignKey
+ALTER TABLE "LobbyOpenGameMember" ADD CONSTRAINT "LobbyOpenGameMember_openGameId_fkey" FOREIGN KEY ("openGameId") REFERENCES "LobbyOpenGame"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LobbyProposalMember" ADD CONSTRAINT "LobbyProposalMember_proposalId_fkey" FOREIGN KEY ("proposalId") REFERENCES "LobbyProposal"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -493,6 +493,10 @@ model TeamMatchLineup {
 
 enum NotificationType {
   organised_game_invite
+  lobby_open_game_compatible
+  lobby_proposal_ready
+  lobby_open_game_joined
+  lobby_open_game_filled
 }
 
 // In-app inbox. No User FK — same as Friendship / OrganisedGameInvite.
@@ -782,4 +786,129 @@ model CoverageIntent {
   @@unique([email, sport, city])
   @@index([email])
   @@index([unsubscribedAt])
+}
+
+// Hybrid matchmaking lobby (seeker Looking + host open-game + proposal).
+// Not booking. No User FK — same as Friendship / OrganisedGame.
+// organiseGameId is a plain id (OrganisedGame is padel/golf only; darts
+// conversion is blocked until Organise supports it).
+enum LobbySport {
+  padel
+  darts
+  golf
+}
+
+enum LobbySkill {
+  casual
+  intermediate
+  competitive
+}
+
+enum LobbyOpenGameStatus {
+  open
+  filled
+  cancelled
+  expired
+}
+
+enum LobbyProposalStatus {
+  pending
+  accepted
+  expired
+  cancelled
+}
+
+enum LobbyProposalResponse {
+  pending
+  accept
+  pass
+}
+
+model LobbyLooking {
+  id         String     @id @default(uuid())
+  userId     String     @unique
+  sport      LobbySport
+  windowStart DateTime
+  windowEnd   DateTime
+  city       String
+  area       String?
+  venueCmsId String?
+  partySize  Int
+  skill      LobbySkill?
+  expiresAt  DateTime
+  createdAt  DateTime   @default(now())
+
+  @@index([sport, city, expiresAt])
+  @@index([expiresAt])
+}
+
+model LobbyOpenGame {
+  id              String               @id @default(uuid())
+  hostUserId      String
+  sport           LobbySport
+  windowStart     DateTime
+  windowEnd       DateTime
+  city            String
+  area            String?
+  venueCmsId      String?
+  slotsNeeded     Int
+  slotsFilled     Int
+  skill           LobbySkill?
+  status          LobbyOpenGameStatus  @default(open)
+  organiseGameId  String?
+  createdAt       DateTime             @default(now())
+  updatedAt       DateTime             @updatedAt
+  members         LobbyOpenGameMember[]
+
+  @@index([sport, city, status])
+  @@index([hostUserId])
+  @@index([status, windowEnd])
+}
+
+model LobbyOpenGameMember {
+  id         String        @id @default(uuid())
+  openGameId String
+  userId     String
+  partySize  Int
+  createdAt  DateTime      @default(now())
+  openGame   LobbyOpenGame @relation(fields: [openGameId], references: [id], onDelete: Cascade)
+
+  @@unique([openGameId, userId])
+  @@index([userId])
+  @@index([openGameId])
+}
+
+model LobbyProposal {
+  id             String                @id @default(uuid())
+  sport          LobbySport
+  city           String
+  area           String?
+  windowStart    DateTime
+  windowEnd      DateTime
+  venueCmsId     String?
+  skill          LobbySkill?
+  status         LobbyProposalStatus   @default(pending)
+  organiseGameId String?
+  createdAt      DateTime              @default(now())
+  updatedAt      DateTime              @updatedAt
+  members        LobbyProposalMember[]
+
+  @@index([sport, city, status])
+  @@index([status, windowEnd])
+}
+
+model LobbyProposalMember {
+  id         String                 @id @default(uuid())
+  proposalId String
+  userId     String
+  partySize  Int
+  response   LobbyProposalResponse  @default(pending)
+  lookingId  String?
+  createdAt  DateTime               @default(now())
+  respondedAt DateTime?
+  proposal   LobbyProposal          @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+
+  @@unique([proposalId, userId])
+  @@index([userId])
+  @@index([proposalId])
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -86,6 +86,10 @@ import {
   CoverageRateLimiter,
   createIntentsModule,
 } from "./modules/intents";
+import {
+  createLobbyModule,
+  LobbyRepository,
+} from "./modules/lobby";
 
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
@@ -111,6 +115,7 @@ export type CreateAppDependencies = {
   roadmapVoteRateLimiter?: RoadmapRateLimiter;
   coverageIntentRepository?: CoverageIntentRepository;
   coverageRateLimiter?: CoverageRateLimiter;
+  lobbyRepository?: LobbyRepository;
 };
 
 export async function createApp(
@@ -296,6 +301,18 @@ export async function createApp(
     coverageIntentRepository: dependencies.coverageIntentRepository,
     coverageRateLimiter: dependencies.coverageRateLimiter,
   });
+  const lobby = createLobbyModule({
+    prisma,
+    lobbyRepository: dependencies.lobbyRepository,
+    organisedGameRepository: organisedGames.organisedGameRepository,
+    venueRepository: venue.venueRepository,
+    friendshipRepository: friends.friendshipRepository,
+    teamRepository: teams.teamRepository,
+    friendProfileLookup: friends.friendProfileLookup,
+    lobbyNotifier: notifications.lobbyNotifier,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
@@ -316,6 +333,7 @@ export async function createApp(
   app.use(tournaments.router);
   app.use(roadmap.router);
   app.use(intents.router);
+  app.use(lobby.router);
 
   app.use(
     (

--- a/src/modules/lobby/README.md
+++ b/src/modules/lobby/README.md
@@ -1,0 +1,47 @@
+# Matchmaking lobby v1
+
+Hybrid lobby (sport → community → moments). **Not booking.** Seekers set Looking; hosts post open games; compatible lookings become a proposal (Accept/Pass). Filled open games and accepted proposals materialize through existing Organise APIs.
+
+Migration: `20260908200000_lobby`
+
+## TTL
+
+Looking `expiresAt` is `min(now + 24h, windowEnd)`. A looking whose window has already ended is rejected. Open games and pending proposals are treated as expired once `windowEnd` has passed (lazy, request-time — no worker). Replacing or clearing Looking cancels that user’s pending proposals.
+
+## Propose matching (request-time)
+
+Evaluated on Looking / open-game writes. No background worker.
+
+Compatible lookings share **sport + city** (case-insensitive) and have an overlapping window. Skill is soft (not required). Users already on an OPEN open-game or a PENDING proposal are skipped.
+
+Pack until sport slots are filled:
+
+| Sport | Default slotsNeeded | Range |
+| --- | --- | --- |
+| padel | 4 | 4 |
+| darts | 2 | 2 |
+| golf | 4 | 2–4 (host may set on the open-game post) |
+
+A proposal is created when packed party sizes reach the sport minimum. Every member must Accept; a Pass that drops remaining slots below the minimum cancels the proposal.
+
+Open games are **instant join** (not proposed). While Looking, compatible OPEN games notify the seeker.
+
+## Organise conversion
+
+On open-game fill or unanimous proposal accept, lobby calls `OrganisedGame.create` (same aggregate as Organise — no parallel match engine), auto-accepts invitees, and sets `organiseGameId`. Host later calls existing **Start**.
+
+Blocked (game/proposal stays filled/accepted, `organiseGameId` null):
+
+- `venue_required` — venue is optional on lobby posts; Organise requires one
+- `venue_not_found`
+- `unsupported_sport` — Organise is padel/golf only (darts waits)
+
+Notes on the organised game: `source=lobby openGame=<id>` or `source=lobby proposal=<id>`. Responses expose `source: "lobby"` and `organiseGameId`.
+
+## Privacy
+
+`GET /api/lobby` public rows: **first name + sport + window + area** (plus open-game slot counts). No user id, handle, email, last name, or avatar. Signed-in viewers also get `viewer.looking` (own extra fields) and friends/teammates sort boost.
+
+## Auth
+
+Looking / post / join / kick / accept / pass / list-mine require session cookie + `requireAuth`. `GET /api/lobby` is optional-auth (privacy shape always).

--- a/src/modules/lobby/controllers/lobby.controller.ts
+++ b/src/modules/lobby/controllers/lobby.controller.ts
@@ -1,0 +1,227 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { LobbyCapacityError } from "../entities/lobby-capacity-error";
+import { LobbyForbiddenError } from "../entities/lobby-forbidden-error";
+import { LobbyNotFoundError } from "../entities/lobby-not-found-error";
+import { LobbyNotOpenError } from "../entities/lobby-not-open-error";
+import { LobbyPersistenceError } from "../entities/lobby-persistence-error";
+import {
+  ClearLooking,
+  CreateOpenGame,
+  JoinOpenGame,
+  KickOpenGame,
+  ListLobby,
+  ListMyProposals,
+  RespondToProposal,
+  SetLooking,
+} from "../services/lobby.service";
+
+const listQuerySchema = z.object({
+  sport: z.string().optional(),
+  city: z.string().optional(),
+});
+
+const lookingBodySchema = z.object({
+  sport: z.string(),
+  windowStart: z.string(),
+  windowEnd: z.string(),
+  city: z.string(),
+  area: z.string().nullable().optional(),
+  venueCmsId: z.string().nullable().optional(),
+  partySizeWithMe: z.number().optional(),
+  skill: z.string().nullable().optional(),
+});
+
+const openGameBodySchema = lookingBodySchema.extend({
+  slotsNeeded: z.number().optional(),
+});
+
+const idParamSchema = z.object({
+  id: z.string(),
+});
+
+const joinBodySchema = z.object({
+  partySizeWithMe: z.number().optional(),
+});
+
+const kickBodySchema = z.object({
+  userId: z.string(),
+});
+
+export function createLobbyController(deps: {
+  listLobby: ListLobby;
+  setLooking: SetLooking;
+  clearLooking: ClearLooking;
+  createOpenGame: CreateOpenGame;
+  joinOpenGame: JoinOpenGame;
+  kickOpenGame: KickOpenGame;
+  listMyProposals: ListMyProposals;
+  respondToProposal: RespondToProposal;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async list(req: Request, res: Response) {
+      try {
+        const query = z.parse(listQuerySchema, req.query ?? {});
+        const result = await deps.listLobby.execute({
+          userId: deps.tryGetSessionUserId(req),
+          sport: query.sport,
+          city: query.city,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendLobbyError(res, error);
+      }
+    },
+
+    async setLooking(req: Request, res: Response) {
+      try {
+        const userId = requireUser(req, res, deps.tryGetSessionUserId);
+        if (!userId) return;
+        const body = z.parse(lookingBodySchema, req.body ?? {});
+        const result = await deps.setLooking.execute({ userId, ...body });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendLobbyError(res, error);
+      }
+    },
+
+    async clearLooking(req: Request, res: Response) {
+      try {
+        const userId = requireUser(req, res, deps.tryGetSessionUserId);
+        if (!userId) return;
+        const result = await deps.clearLooking.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendLobbyError(res, error);
+      }
+    },
+
+    async createOpenGame(req: Request, res: Response) {
+      try {
+        const userId = requireUser(req, res, deps.tryGetSessionUserId);
+        if (!userId) return;
+        const body = z.parse(openGameBodySchema, req.body ?? {});
+        const result = await deps.createOpenGame.execute({ userId, ...body });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendLobbyError(res, error);
+      }
+    },
+
+    async joinOpenGame(req: Request, res: Response) {
+      try {
+        const userId = requireUser(req, res, deps.tryGetSessionUserId);
+        if (!userId) return;
+        const { id } = z.parse(idParamSchema, req.params);
+        const body = z.parse(joinBodySchema, req.body ?? {});
+        const result = await deps.joinOpenGame.execute({
+          userId,
+          openGameId: id,
+          partySizeWithMe: body.partySizeWithMe,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendLobbyError(res, error);
+      }
+    },
+
+    async kickOpenGame(req: Request, res: Response) {
+      try {
+        const userId = requireUser(req, res, deps.tryGetSessionUserId);
+        if (!userId) return;
+        const { id } = z.parse(idParamSchema, req.params);
+        const body = z.parse(kickBodySchema, req.body ?? {});
+        const result = await deps.kickOpenGame.execute({
+          userId,
+          openGameId: id,
+          targetUserId: body.userId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendLobbyError(res, error);
+      }
+    },
+
+    async listProposals(req: Request, res: Response) {
+      try {
+        const userId = requireUser(req, res, deps.tryGetSessionUserId);
+        if (!userId) return;
+        const result = await deps.listMyProposals.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendLobbyError(res, error);
+      }
+    },
+
+    async acceptProposal(req: Request, res: Response) {
+      try {
+        const userId = requireUser(req, res, deps.tryGetSessionUserId);
+        if (!userId) return;
+        const { id } = z.parse(idParamSchema, req.params);
+        const result = await deps.respondToProposal.execute({
+          userId,
+          proposalId: id,
+          decision: "accept",
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendLobbyError(res, error);
+      }
+    },
+
+    async passProposal(req: Request, res: Response) {
+      try {
+        const userId = requireUser(req, res, deps.tryGetSessionUserId);
+        if (!userId) return;
+        const { id } = z.parse(idParamSchema, req.params);
+        const result = await deps.respondToProposal.execute({
+          userId,
+          proposalId: id,
+          decision: "pass",
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendLobbyError(res, error);
+      }
+    },
+  };
+}
+
+function requireUser(
+  req: Request,
+  res: Response,
+  tryGetSessionUserId: (req: Request) => string | null,
+): string | null {
+  const userId = tryGetSessionUserId(req);
+  if (!userId) {
+    res.status(401).json({ error: "Unauthorized" });
+    return null;
+  }
+  return userId;
+}
+
+function sendLobbyError(res: Response, error: unknown) {
+  if (error instanceof LobbyNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+  if (error instanceof LobbyForbiddenError) {
+    return res.status(403).json({ error: error.message });
+  }
+  if (error instanceof LobbyNotOpenError || error instanceof LobbyCapacityError) {
+    return res.status(409).json({ error: error.message });
+  }
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid lobby payload" });
+  }
+  if (error instanceof LobbyPersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/lobby/controllers/lobby.http.test.ts
+++ b/src/modules/lobby/controllers/lobby.http.test.ts
@@ -1,0 +1,380 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { signAuthenticationToken } from "../../identity/utils/jwt";
+import { InMemoryNotificationRepository } from "../../notifications/repositories/in-memory-notification.repository";
+import { InMemoryOrganisedGameRepository } from "../../organised-games/repositories/in-memory-organised-game.repository";
+import { InMemoryTeamRepository } from "../../teams/repositories/in-memory-team.repository";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { InMemoryLobbyRepository } from "../repositories/in-memory-lobby.repository";
+
+const WINDOW = {
+  windowStart: "2026-12-01T16:00:00.000Z",
+  windowEnd: "2026-12-01T18:00:00.000Z",
+};
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+describe("lobby HTTP", () => {
+  const config = makeConfig();
+  let venues: InMemoryVenueRepository;
+  let friendships: InMemoryFriendshipRepository;
+  let profiles: InMemoryFriendProfileLookup;
+  let lobby: InMemoryLobbyRepository;
+  let organised: InMemoryOrganisedGameRepository;
+  let notifications: InMemoryNotificationRepository;
+  let teams: InMemoryTeamRepository;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  function cookie(userId: string) {
+    return `token=${signAuthenticationToken(config, { userId })}`;
+  }
+
+  beforeEach(async () => {
+    venues = new InMemoryVenueRepository();
+    friendships = new InMemoryFriendshipRepository();
+    profiles = new InMemoryFriendProfileLookup();
+    lobby = new InMemoryLobbyRepository();
+    organised = new InMemoryOrganisedGameRepository();
+    notifications = new InMemoryNotificationRepository();
+    teams = new InMemoryTeamRepository();
+
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-court-1"),
+        VenueName.from("Padel Club"),
+        Slug.from("padel-club"),
+      ),
+      { refreshDetails: false },
+    );
+
+    profiles.seed({
+      userId: "user-a",
+      displayName: "Alex Smith",
+      handle: "alex",
+      avatarUrl: "https://cdn.example/alex.png",
+    });
+    profiles.seed({
+      userId: "user-b",
+      displayName: "Blake Jones",
+      handle: "blake",
+      avatarUrl: null,
+    });
+    profiles.seed({
+      userId: "user-c",
+      displayName: "Casey Lee",
+      handle: "casey",
+      avatarUrl: null,
+    });
+
+    app = await createApp(config, {
+      venueRepository: venues,
+      friendshipRepository: friendships,
+      friendProfileLookup: profiles,
+      lobbyRepository: lobby,
+      organisedGameRepository: organised,
+      notificationRepository: notifications,
+      teamRepository: teams,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("looking / post / join / kick / accept require auth", async () => {
+    const looking = await fetch(`${server.url}/api/lobby/looking`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sport: "padel",
+        ...WINDOW,
+        city: "Cape Town",
+      }),
+    });
+    expect(looking.status).toBe(401);
+
+    const open = await fetch(`${server.url}/api/lobby/open-games`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sport: "padel",
+        ...WINDOW,
+        city: "Cape Town",
+      }),
+    });
+    expect(open.status).toBe(401);
+
+    const join = await fetch(`${server.url}/api/lobby/open-games/x/join`, {
+      method: "POST",
+    });
+    expect(join.status).toBe(401);
+
+    const kick = await fetch(`${server.url}/api/lobby/open-games/x/kick`, {
+      method: "POST",
+    });
+    expect(kick.status).toBe(401);
+
+    const accept = await fetch(`${server.url}/api/lobby/proposals/x/accept`, {
+      method: "POST",
+    });
+    expect(accept.status).toBe(401);
+  });
+
+  test("looking CRUD and public list privacy", async () => {
+    const created = await fetch(`${server.url}/api/lobby/looking`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        sport: "golf",
+        ...WINDOW,
+        city: "Cape Town",
+        area: "Sea Point",
+        skill: "casual",
+        partySizeWithMe: 1,
+      }),
+    });
+    expect(created.status).toBe(200);
+    const createdBody = (await created.json()) as {
+      looking: { id: string; firstName: string; expiresAt: string };
+    };
+    expect(createdBody.looking.firstName).toBe("Alex");
+    expect(createdBody.looking.expiresAt).toBeTruthy();
+
+    const listed = await fetch(`${server.url}/api/lobby?city=Cape%20Town`);
+    expect(listed.status).toBe(200);
+    const listBody = (await listed.json()) as {
+      lookings: Array<Record<string, unknown>>;
+    };
+    expect(listBody.lookings).toEqual([
+      {
+        id: createdBody.looking.id,
+        firstName: "Alex",
+        sport: "golf",
+        windowStart: WINDOW.windowStart,
+        windowEnd: WINDOW.windowEnd,
+        city: "Cape Town",
+        area: "Sea Point",
+      },
+    ]);
+    expect(JSON.stringify(listBody.lookings[0])).not.toContain("alex");
+    expect(JSON.stringify(listBody.lookings[0])).not.toContain("Smith");
+
+    const cleared = await fetch(`${server.url}/api/lobby/looking`, {
+      method: "DELETE",
+      headers: { Cookie: cookie("user-a") },
+    });
+    expect(cleared.status).toBe(200);
+    const after = await fetch(`${server.url}/api/lobby?sport=golf`);
+    const afterBody = (await after.json()) as { lookings: unknown[] };
+    expect(afterBody.lookings).toEqual([]);
+  });
+
+  test("open game create, join, kick", async () => {
+    const created = await fetch(`${server.url}/api/lobby/open-games`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        sport: "padel",
+        ...WINDOW,
+        city: "Cape Town",
+        venueCmsId: "sanity-court-1",
+        slotsNeeded: 4,
+      }),
+    });
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as {
+      openGame: { id: string; slotsRemaining: number };
+    };
+    expect(createdBody.openGame.slotsRemaining).toBe(3);
+
+    const joined = await fetch(
+      `${server.url}/api/lobby/open-games/${createdBody.openGame.id}/join`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-b"),
+        },
+        body: JSON.stringify({ partySizeWithMe: 1 }),
+      },
+    );
+    expect(joined.status).toBe(200);
+    const joinedBody = (await joined.json()) as {
+      openGame: { slotsFilled: number; status: string };
+    };
+    expect(joinedBody.openGame.slotsFilled).toBe(2);
+    expect(joinedBody.openGame.status).toBe("open");
+
+    const kicked = await fetch(
+      `${server.url}/api/lobby/open-games/${createdBody.openGame.id}/kick`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-a"),
+        },
+        body: JSON.stringify({ userId: "user-b" }),
+      },
+    );
+    expect(kicked.status).toBe(200);
+    const kickedBody = (await kicked.json()) as {
+      openGame: { slotsFilled: number };
+    };
+    expect(kickedBody.openGame.slotsFilled).toBe(1);
+
+    const forbidden = await fetch(
+      `${server.url}/api/lobby/open-games/${createdBody.openGame.id}/kick`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: cookie("user-b"),
+        },
+        body: JSON.stringify({ userId: "user-a" }),
+      },
+    );
+    expect(forbidden.status).toBe(403);
+  });
+
+  test("proposal accept converts to Organise; pass cancels", async () => {
+    await fetch(`${server.url}/api/lobby/looking`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        sport: "padel",
+        ...WINDOW,
+        city: "Cape Town",
+        venueCmsId: "sanity-court-1",
+        partySizeWithMe: 2,
+      }),
+    });
+    const lookingB = await fetch(`${server.url}/api/lobby/looking`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-b"),
+      },
+      body: JSON.stringify({
+        sport: "padel",
+        ...WINDOW,
+        city: "Cape Town",
+        partySizeWithMe: 2,
+      }),
+    });
+    const lookingBody = (await lookingB.json()) as {
+      proposals: Array<{ id: string }>;
+    };
+    expect(lookingBody.proposals).toHaveLength(1);
+    const proposalId = lookingBody.proposals[0].id;
+
+    const acceptA = await fetch(
+      `${server.url}/api/lobby/proposals/${proposalId}/accept`,
+      { method: "POST", headers: { Cookie: cookie("user-a") } },
+    );
+    expect(acceptA.status).toBe(200);
+
+    const acceptB = await fetch(
+      `${server.url}/api/lobby/proposals/${proposalId}/accept`,
+      { method: "POST", headers: { Cookie: cookie("user-b") } },
+    );
+    expect(acceptB.status).toBe(200);
+    const accepted = (await acceptB.json()) as {
+      proposal: {
+        status: string;
+        organiseGameId: string | null;
+        source: string;
+      };
+    };
+    expect(accepted.proposal.status).toBe("accepted");
+    expect(accepted.proposal.source).toBe("lobby");
+    expect(accepted.proposal.organiseGameId).toBeTruthy();
+    expect(
+      await organised.findById(accepted.proposal.organiseGameId!),
+    ).toBeTruthy();
+
+    await fetch(`${server.url}/api/lobby/looking`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-a"),
+      },
+      body: JSON.stringify({
+        sport: "darts",
+        ...WINDOW,
+        city: "Cape Town",
+      }),
+    });
+    const dartsB = await fetch(`${server.url}/api/lobby/looking`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-b"),
+      },
+      body: JSON.stringify({
+        sport: "darts",
+        ...WINDOW,
+        city: "Cape Town",
+      }),
+    });
+    const dartsBody = (await dartsB.json()) as {
+      proposals: Array<{ id: string }>;
+    };
+    const pass = await fetch(
+      `${server.url}/api/lobby/proposals/${dartsBody.proposals[0].id}/pass`,
+      { method: "POST", headers: { Cookie: cookie("user-a") } },
+    );
+    expect(pass.status).toBe(200);
+    const passed = (await pass.json()) as { proposal: { status: string } };
+    expect(passed.proposal.status).toBe("cancelled");
+  });
+});

--- a/src/modules/lobby/entities/area.ts
+++ b/src/modules/lobby/entities/area.ts
@@ -1,0 +1,20 @@
+import { DomainError } from "../../../lib/domain-error";
+
+const MAX_LENGTH = 80;
+
+export class Area {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): Area | null {
+    if (raw == null) return null;
+    if (typeof raw !== "string") {
+      throw new DomainError("area must be a string");
+    }
+    const area = raw.trim();
+    if (area.length === 0) return null;
+    if (area.length > MAX_LENGTH) {
+      throw new DomainError(`area must be at most ${MAX_LENGTH} characters`);
+    }
+    return new Area(area);
+  }
+}

--- a/src/modules/lobby/entities/city.ts
+++ b/src/modules/lobby/entities/city.ts
@@ -1,0 +1,23 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const MAX_LENGTH = 80;
+
+export class City {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): City {
+    const city = requiredTrimmed(raw, "city");
+    if (city.length > MAX_LENGTH) {
+      throw new DomainError(`city must be at most ${MAX_LENGTH} characters`);
+    }
+    return new City(city);
+  }
+
+  get normalized(): string {
+    return this.value.toLowerCase();
+  }
+
+  equals(other: City): boolean {
+    return this.normalized === other.normalized;
+  }
+}

--- a/src/modules/lobby/entities/lobby-capacity-error.ts
+++ b/src/modules/lobby/entities/lobby-capacity-error.ts
@@ -1,0 +1,6 @@
+export class LobbyCapacityError extends Error {
+  constructor(message = "Not enough slots remaining") {
+    super(message);
+    this.name = "LobbyCapacityError";
+  }
+}

--- a/src/modules/lobby/entities/lobby-forbidden-error.ts
+++ b/src/modules/lobby/entities/lobby-forbidden-error.ts
@@ -1,0 +1,6 @@
+export class LobbyForbiddenError extends Error {
+  constructor(message = "Forbidden") {
+    super(message);
+    this.name = "LobbyForbiddenError";
+  }
+}

--- a/src/modules/lobby/entities/lobby-looking.test.ts
+++ b/src/modules/lobby/entities/lobby-looking.test.ts
@@ -1,0 +1,64 @@
+import { City } from "./city";
+import { LOOKING_TTL_MS, LobbyLooking } from "./lobby-looking";
+import { LobbySport } from "./lobby-sport";
+import { PartySize } from "./party-size";
+import { TimeWindow } from "./time-window";
+
+describe("LobbyLooking", () => {
+  const now = new Date("2026-09-08T12:00:00.000Z");
+
+  test("TTL is the earlier of 24h and windowEnd", () => {
+    const short = LobbyLooking.create({
+      userId: "user-a",
+      sport: LobbySport.PADEL,
+      window: TimeWindow.from(
+        "2026-09-08T16:00:00.000Z",
+        "2026-09-08T18:00:00.000Z",
+      ),
+      city: City.from("Cape Town"),
+      area: null,
+      venueCmsId: null,
+      partySize: PartySize.from(1),
+      skill: null,
+      now,
+    });
+    expect(short.expiresAt.toISOString()).toBe("2026-09-08T18:00:00.000Z");
+    expect(short.isActive(now)).toBe(true);
+    expect(short.isExpired(new Date("2026-09-08T18:00:00.000Z"))).toBe(true);
+
+    const long = LobbyLooking.create({
+      userId: "user-a",
+      sport: LobbySport.GOLF,
+      window: TimeWindow.from(
+        "2026-09-09T08:00:00.000Z",
+        "2026-09-12T18:00:00.000Z",
+      ),
+      city: City.from("Cape Town"),
+      area: null,
+      venueCmsId: null,
+      partySize: PartySize.from(2),
+      skill: null,
+      now,
+    });
+    expect(long.expiresAt.getTime()).toBe(now.getTime() + LOOKING_TTL_MS);
+  });
+
+  test("rejects a window that has already ended", () => {
+    expect(() =>
+      LobbyLooking.create({
+        userId: "user-a",
+        sport: LobbySport.DARTS,
+        window: TimeWindow.from(
+          "2026-09-08T08:00:00.000Z",
+          "2026-09-08T11:00:00.000Z",
+        ),
+        city: City.from("Cape Town"),
+        area: null,
+        venueCmsId: null,
+        partySize: PartySize.from(1),
+        skill: null,
+        now,
+      }),
+    ).toThrow("windowEnd must be in the future");
+  });
+});

--- a/src/modules/lobby/entities/lobby-looking.ts
+++ b/src/modules/lobby/entities/lobby-looking.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { Area } from "./area";
+import { City } from "./city";
+import { LobbySkill } from "./lobby-skill";
+import { LobbySport } from "./lobby-sport";
+import { PartySize } from "./party-size";
+import { TimeWindow } from "./time-window";
+
+export const LOOKING_TTL_MS = 24 * 60 * 60 * 1000;
+
+export type LobbyLookingSnapshot = {
+  id: string;
+  userId: string;
+  sport: "padel" | "darts" | "golf";
+  windowStart: string;
+  windowEnd: string;
+  city: string;
+  area: string | null;
+  venueCmsId: string | null;
+  partySize: number;
+  skill: "casual" | "intermediate" | "competitive" | null;
+  expiresAt: string;
+  createdAt: string;
+};
+
+export type CreateLobbyLookingProps = {
+  userId: string;
+  sport: LobbySport;
+  window: TimeWindow;
+  city: City;
+  area: Area | null;
+  venueCmsId: string | null;
+  partySize: PartySize;
+  skill: LobbySkill | null;
+  now?: Date;
+};
+
+export class LobbyLooking {
+  private constructor(
+    readonly id: string,
+    readonly userId: string,
+    readonly sport: LobbySport,
+    readonly window: TimeWindow,
+    readonly city: City,
+    readonly area: Area | null,
+    readonly venueCmsId: string | null,
+    readonly partySize: PartySize,
+    readonly skill: LobbySkill | null,
+    readonly expiresAt: Date,
+    readonly createdAt: Date,
+  ) {}
+
+  static create(props: CreateLobbyLookingProps): LobbyLooking {
+    const userId = requiredTrimmed(props.userId, "userId");
+    const now = props.now ?? new Date();
+    if (props.window.end.getTime() <= now.getTime()) {
+      throw new DomainError("windowEnd must be in the future");
+    }
+    const ttlCap = new Date(now.getTime() + LOOKING_TTL_MS);
+    const expiresAt =
+      props.window.end.getTime() < ttlCap.getTime() ? props.window.end : ttlCap;
+
+    return new LobbyLooking(
+      randomUUID(),
+      userId,
+      props.sport,
+      props.window,
+      props.city,
+      props.area,
+      props.venueCmsId,
+      props.partySize,
+      props.skill,
+      expiresAt,
+      now,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    userId: string;
+    sport: LobbySport;
+    window: TimeWindow;
+    city: City;
+    area: Area | null;
+    venueCmsId: string | null;
+    partySize: PartySize;
+    skill: LobbySkill | null;
+    expiresAt: Date;
+    createdAt: Date;
+  }): LobbyLooking {
+    return new LobbyLooking(
+      props.id,
+      props.userId,
+      props.sport,
+      props.window,
+      props.city,
+      props.area,
+      props.venueCmsId,
+      props.partySize,
+      props.skill,
+      props.expiresAt,
+      props.createdAt,
+    );
+  }
+
+  static fromSnapshot(snapshot: LobbyLookingSnapshot): LobbyLooking {
+    return LobbyLooking.rehydrate({
+      id: snapshot.id,
+      userId: snapshot.userId,
+      sport: LobbySport.from(snapshot.sport),
+      window: TimeWindow.from(snapshot.windowStart, snapshot.windowEnd),
+      city: City.from(snapshot.city),
+      area: Area.from(snapshot.area),
+      venueCmsId: snapshot.venueCmsId,
+      partySize: PartySize.from(snapshot.partySize),
+      skill: LobbySkill.from(snapshot.skill),
+      expiresAt: new Date(snapshot.expiresAt),
+      createdAt: new Date(snapshot.createdAt),
+    });
+  }
+
+  isExpired(now = new Date()): boolean {
+    return this.expiresAt.getTime() <= now.getTime();
+  }
+
+  isActive(now = new Date()): boolean {
+    return !this.isExpired(now);
+  }
+
+  toSnapshot(): LobbyLookingSnapshot {
+    return {
+      id: this.id,
+      userId: this.userId,
+      sport: this.sport.value,
+      windowStart: this.window.start.toISOString(),
+      windowEnd: this.window.end.toISOString(),
+      city: this.city.value,
+      area: this.area?.value ?? null,
+      venueCmsId: this.venueCmsId,
+      partySize: this.partySize.value,
+      skill: this.skill?.value ?? null,
+      expiresAt: this.expiresAt.toISOString(),
+      createdAt: this.createdAt.toISOString(),
+    };
+  }
+}

--- a/src/modules/lobby/entities/lobby-not-found-error.ts
+++ b/src/modules/lobby/entities/lobby-not-found-error.ts
@@ -1,0 +1,6 @@
+export class LobbyNotFoundError extends Error {
+  constructor(message = "Lobby item not found") {
+    super(message);
+    this.name = "LobbyNotFoundError";
+  }
+}

--- a/src/modules/lobby/entities/lobby-not-open-error.ts
+++ b/src/modules/lobby/entities/lobby-not-open-error.ts
@@ -1,0 +1,6 @@
+export class LobbyNotOpenError extends Error {
+  constructor(message = "Open game is not open") {
+    super(message);
+    this.name = "LobbyNotOpenError";
+  }
+}

--- a/src/modules/lobby/entities/lobby-open-game-member.ts
+++ b/src/modules/lobby/entities/lobby-open-game-member.ts
@@ -1,0 +1,56 @@
+import { randomUUID } from "node:crypto";
+
+import { requiredTrimmed } from "../../../lib/domain-error";
+import { PartySize } from "./party-size";
+
+export type LobbyOpenGameMemberSnapshot = {
+  id: string;
+  userId: string;
+  partySize: number;
+  createdAt: string;
+};
+
+export class LobbyOpenGameMember {
+  private constructor(
+    readonly id: string,
+    readonly userId: string,
+    readonly partySize: PartySize,
+    readonly createdAt: Date,
+  ) {}
+
+  static create(
+    userId: string,
+    partySize: PartySize,
+    now = new Date(),
+  ): LobbyOpenGameMember {
+    return new LobbyOpenGameMember(
+      randomUUID(),
+      requiredTrimmed(userId, "userId"),
+      partySize,
+      now,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    userId: string;
+    partySize: PartySize;
+    createdAt: Date;
+  }): LobbyOpenGameMember {
+    return new LobbyOpenGameMember(
+      props.id,
+      props.userId,
+      props.partySize,
+      props.createdAt,
+    );
+  }
+
+  toSnapshot(): LobbyOpenGameMemberSnapshot {
+    return {
+      id: this.id,
+      userId: this.userId,
+      partySize: this.partySize.value,
+      createdAt: this.createdAt.toISOString(),
+    };
+  }
+}

--- a/src/modules/lobby/entities/lobby-open-game-status.ts
+++ b/src/modules/lobby/entities/lobby-open-game-status.ts
@@ -1,0 +1,42 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const LOBBY_OPEN_GAME_STATUSES = [
+  "open",
+  "filled",
+  "cancelled",
+  "expired",
+] as const;
+export type LobbyOpenGameStatusValue = (typeof LOBBY_OPEN_GAME_STATUSES)[number];
+
+export class LobbyOpenGameStatus {
+  static readonly OPEN = new LobbyOpenGameStatus("open");
+  static readonly FILLED = new LobbyOpenGameStatus("filled");
+  static readonly CANCELLED = new LobbyOpenGameStatus("cancelled");
+  static readonly EXPIRED = new LobbyOpenGameStatus("expired");
+
+  private constructor(readonly value: LobbyOpenGameStatusValue) {}
+
+  static from(raw: unknown): LobbyOpenGameStatus {
+    if (typeof raw !== "string") {
+      throw new DomainError("status must be open, filled, cancelled, or expired");
+    }
+    const status = raw.trim().toLowerCase();
+    if (status === "open") return LobbyOpenGameStatus.OPEN;
+    if (status === "filled") return LobbyOpenGameStatus.FILLED;
+    if (status === "cancelled") return LobbyOpenGameStatus.CANCELLED;
+    if (status === "expired") return LobbyOpenGameStatus.EXPIRED;
+    throw new DomainError("status must be open, filled, cancelled, or expired");
+  }
+
+  get isOpen(): boolean {
+    return this.value === "open";
+  }
+
+  get isFilled(): boolean {
+    return this.value === "filled";
+  }
+
+  equals(other: LobbyOpenGameStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/lobby/entities/lobby-open-game.test.ts
+++ b/src/modules/lobby/entities/lobby-open-game.test.ts
@@ -1,0 +1,67 @@
+import { City } from "./city";
+import { LobbyOpenGame } from "./lobby-open-game";
+import { LobbySport } from "./lobby-sport";
+import { PartySize } from "./party-size";
+import { TimeWindow } from "./time-window";
+
+function makeOpenGame(overrides: { slotsNeeded?: number } = {}) {
+  return LobbyOpenGame.create({
+    hostUserId: "host-1",
+    sport: LobbySport.PADEL,
+    window: TimeWindow.from(
+      "2026-09-08T16:00:00.000Z",
+      "2026-09-08T18:00:00.000Z",
+    ),
+    city: City.from("Cape Town"),
+    area: null,
+    venueCmsId: "sanity-court-1",
+    slotsNeeded: overrides.slotsNeeded ?? 4,
+    hostPartySize: PartySize.from(1),
+    skill: null,
+    now: new Date("2026-09-08T12:00:00.000Z"),
+  });
+}
+
+describe("LobbyOpenGame", () => {
+  test("host occupies slots and join fills then blocks extras", () => {
+    const game = makeOpenGame();
+    expect(game.slotsFilled()).toBe(1);
+    expect(game.remainingSlots()).toBe(3);
+    expect(game.status.isOpen).toBe(true);
+
+    game.join("joiner-1", PartySize.from(2));
+    expect(game.slotsFilled()).toBe(3);
+    expect(game.status.isOpen).toBe(true);
+
+    game.join("joiner-2", PartySize.from(1));
+    expect(game.slotsFilled()).toBe(4);
+    expect(game.status.isFilled).toBe(true);
+
+    expect(() => game.join("late", PartySize.from(1))).toThrow(
+      "Open game is not open",
+    );
+  });
+
+  test("host can kick a joiner and reopen a filled game", () => {
+    const game = makeOpenGame();
+    game.join("joiner-1", PartySize.from(3));
+    expect(game.status.isFilled).toBe(true);
+
+    expect(() => game.kick("joiner-1", "host-1")).toThrow(
+      "Only the host can kick a player",
+    );
+    expect(() => game.kick("host-1", "host-1")).toThrow("Host cannot be kicked");
+
+    game.kick("host-1", "joiner-1");
+    expect(game.memberOf("joiner-1")).toBeNull();
+    expect(game.status.isOpen).toBe(true);
+    expect(game.remainingSlots()).toBe(3);
+  });
+
+  test("does not mark ready until slots are filled", () => {
+    const game = makeOpenGame({ slotsNeeded: 4 });
+    game.join("joiner-1", PartySize.from(1));
+    expect(game.status.isFilled).toBe(false);
+    expect(game.remainingSlots()).toBe(2);
+  });
+});

--- a/src/modules/lobby/entities/lobby-open-game.test.ts
+++ b/src/modules/lobby/entities/lobby-open-game.test.ts
@@ -4,6 +4,8 @@ import { LobbySport } from "./lobby-sport";
 import { PartySize } from "./party-size";
 import { TimeWindow } from "./time-window";
 
+const NOW = new Date("2026-09-08T12:00:00.000Z");
+
 function makeOpenGame(overrides: { slotsNeeded?: number } = {}) {
   return LobbyOpenGame.create({
     hostUserId: "host-1",
@@ -18,7 +20,7 @@ function makeOpenGame(overrides: { slotsNeeded?: number } = {}) {
     slotsNeeded: overrides.slotsNeeded ?? 4,
     hostPartySize: PartySize.from(1),
     skill: null,
-    now: new Date("2026-09-08T12:00:00.000Z"),
+    now: NOW,
   });
 }
 
@@ -29,30 +31,32 @@ describe("LobbyOpenGame", () => {
     expect(game.remainingSlots()).toBe(3);
     expect(game.status.isOpen).toBe(true);
 
-    game.join("joiner-1", PartySize.from(2));
+    game.join("joiner-1", PartySize.from(2), NOW);
     expect(game.slotsFilled()).toBe(3);
     expect(game.status.isOpen).toBe(true);
 
-    game.join("joiner-2", PartySize.from(1));
+    game.join("joiner-2", PartySize.from(1), NOW);
     expect(game.slotsFilled()).toBe(4);
     expect(game.status.isFilled).toBe(true);
 
-    expect(() => game.join("late", PartySize.from(1))).toThrow(
+    expect(() => game.join("late", PartySize.from(1), NOW)).toThrow(
       "Open game is not open",
     );
   });
 
   test("host can kick a joiner and reopen a filled game", () => {
     const game = makeOpenGame();
-    game.join("joiner-1", PartySize.from(3));
+    game.join("joiner-1", PartySize.from(3), NOW);
     expect(game.status.isFilled).toBe(true);
 
-    expect(() => game.kick("joiner-1", "host-1")).toThrow(
+    expect(() => game.kick("joiner-1", "host-1", NOW)).toThrow(
       "Only the host can kick a player",
     );
-    expect(() => game.kick("host-1", "host-1")).toThrow("Host cannot be kicked");
+    expect(() => game.kick("host-1", "host-1", NOW)).toThrow(
+      "Host cannot be kicked",
+    );
 
-    game.kick("host-1", "joiner-1");
+    game.kick("host-1", "joiner-1", NOW);
     expect(game.memberOf("joiner-1")).toBeNull();
     expect(game.status.isOpen).toBe(true);
     expect(game.remainingSlots()).toBe(3);
@@ -60,7 +64,7 @@ describe("LobbyOpenGame", () => {
 
   test("does not mark ready until slots are filled", () => {
     const game = makeOpenGame({ slotsNeeded: 4 });
-    game.join("joiner-1", PartySize.from(1));
+    game.join("joiner-1", PartySize.from(1), NOW);
     expect(game.status.isFilled).toBe(false);
     expect(game.remainingSlots()).toBe(2);
   });

--- a/src/modules/lobby/entities/lobby-open-game.ts
+++ b/src/modules/lobby/entities/lobby-open-game.ts
@@ -1,0 +1,318 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { Area } from "./area";
+import { City } from "./city";
+import { LobbyCapacityError } from "./lobby-capacity-error";
+import { LobbyForbiddenError } from "./lobby-forbidden-error";
+import { LobbyNotOpenError } from "./lobby-not-open-error";
+import { LobbyOpenGameMember } from "./lobby-open-game-member";
+import { LobbyOpenGameStatus } from "./lobby-open-game-status";
+import { LobbySkill } from "./lobby-skill";
+import { LobbySport } from "./lobby-sport";
+import { PartySize } from "./party-size";
+import { TimeWindow } from "./time-window";
+
+export type LobbyOpenGameSnapshot = {
+  id: string;
+  hostUserId: string;
+  sport: "padel" | "darts" | "golf";
+  windowStart: string;
+  windowEnd: string;
+  city: string;
+  area: string | null;
+  venueCmsId: string | null;
+  slotsNeeded: number;
+  slotsFilled: number;
+  skill: "casual" | "intermediate" | "competitive" | null;
+  status: "open" | "filled" | "cancelled" | "expired";
+  organiseGameId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  members: ReturnType<LobbyOpenGameMember["toSnapshot"]>[];
+};
+
+export type CreateLobbyOpenGameProps = {
+  hostUserId: string;
+  sport: LobbySport;
+  window: TimeWindow;
+  city: City;
+  area: Area | null;
+  venueCmsId: string | null;
+  slotsNeeded?: number;
+  hostPartySize: PartySize;
+  skill: LobbySkill | null;
+  now?: Date;
+};
+
+export class LobbyOpenGame {
+  private constructor(
+    readonly id: string,
+    readonly hostUserId: string,
+    readonly sport: LobbySport,
+    readonly window: TimeWindow,
+    readonly city: City,
+    readonly area: Area | null,
+    readonly venueCmsId: string | null,
+    readonly slotsNeeded: number,
+    readonly skill: LobbySkill | null,
+    private statusValue: LobbyOpenGameStatus,
+    private organiseGameIdValue: string | null,
+    readonly createdAt: Date,
+    private updatedAtValue: Date,
+    private membersValue: LobbyOpenGameMember[],
+  ) {}
+
+  static create(props: CreateLobbyOpenGameProps): LobbyOpenGame {
+    const hostUserId = requiredTrimmed(props.hostUserId, "userId");
+    const now = props.now ?? new Date();
+    if (props.window.end.getTime() <= now.getTime()) {
+      throw new DomainError("windowEnd must be in the future");
+    }
+    const slotsNeeded = parseSlotsNeeded(props.slotsNeeded, props.sport);
+    if (props.hostPartySize.value > slotsNeeded) {
+      throw new DomainError("partySize cannot exceed slotsNeeded");
+    }
+
+    const host = LobbyOpenGameMember.create(
+      hostUserId,
+      props.hostPartySize,
+      now,
+    );
+
+    return new LobbyOpenGame(
+      randomUUID(),
+      hostUserId,
+      props.sport,
+      props.window,
+      props.city,
+      props.area,
+      props.venueCmsId,
+      slotsNeeded,
+      props.skill,
+      LobbyOpenGameStatus.OPEN,
+      null,
+      now,
+      now,
+      [host],
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    hostUserId: string;
+    sport: LobbySport;
+    window: TimeWindow;
+    city: City;
+    area: Area | null;
+    venueCmsId: string | null;
+    slotsNeeded: number;
+    skill: LobbySkill | null;
+    status: LobbyOpenGameStatus;
+    organiseGameId: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+    members: LobbyOpenGameMember[];
+  }): LobbyOpenGame {
+    return new LobbyOpenGame(
+      props.id,
+      props.hostUserId,
+      props.sport,
+      props.window,
+      props.city,
+      props.area,
+      props.venueCmsId,
+      props.slotsNeeded,
+      props.skill,
+      props.status,
+      props.organiseGameId,
+      props.createdAt,
+      props.updatedAt,
+      [...props.members],
+    );
+  }
+
+  static fromSnapshot(snapshot: LobbyOpenGameSnapshot): LobbyOpenGame {
+    return LobbyOpenGame.rehydrate({
+      id: snapshot.id,
+      hostUserId: snapshot.hostUserId,
+      sport: LobbySport.from(snapshot.sport),
+      window: TimeWindow.from(snapshot.windowStart, snapshot.windowEnd),
+      city: City.from(snapshot.city),
+      area: Area.from(snapshot.area),
+      venueCmsId: snapshot.venueCmsId,
+      slotsNeeded: snapshot.slotsNeeded,
+      skill: LobbySkill.from(snapshot.skill),
+      status: LobbyOpenGameStatus.from(snapshot.status),
+      organiseGameId: snapshot.organiseGameId,
+      createdAt: new Date(snapshot.createdAt),
+      updatedAt: new Date(snapshot.updatedAt),
+      members: snapshot.members.map((member) =>
+        LobbyOpenGameMember.rehydrate({
+          id: member.id,
+          userId: member.userId,
+          partySize: PartySize.from(member.partySize),
+          createdAt: new Date(member.createdAt),
+        }),
+      ),
+    });
+  }
+
+  get status(): LobbyOpenGameStatus {
+    return this.statusValue;
+  }
+
+  get organiseGameId(): string | null {
+    return this.organiseGameIdValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  get members(): readonly LobbyOpenGameMember[] {
+    return this.membersValue;
+  }
+
+  slotsFilled(): number {
+    return this.membersValue.reduce(
+      (sum, member) => sum + member.partySize.value,
+      0,
+    );
+  }
+
+  remainingSlots(): number {
+    return this.slotsNeeded - this.slotsFilled();
+  }
+
+  isHost(userId: string): boolean {
+    return this.hostUserId === userId.trim();
+  }
+
+  memberOf(userId: string): LobbyOpenGameMember | null {
+    const id = userId.trim();
+    return this.membersValue.find((member) => member.userId === id) ?? null;
+  }
+
+  isExpired(now = new Date()): boolean {
+    return this.window.end.getTime() <= now.getTime();
+  }
+
+  expireIfNeeded(now = new Date()): void {
+    if (this.statusValue.isOpen && this.isExpired(now)) {
+      this.statusValue = LobbyOpenGameStatus.EXPIRED;
+      this.touch(now);
+    }
+  }
+
+  join(userId: string, partySize: PartySize, now = new Date()): void {
+    const id = requiredTrimmed(userId, "userId");
+    this.expireIfNeeded(now);
+    if (!this.statusValue.isOpen) {
+      throw new LobbyNotOpenError();
+    }
+    if (this.memberOf(id)) {
+      throw new DomainError("Already joined this open game");
+    }
+    if (partySize.value > this.remainingSlots()) {
+      throw new LobbyCapacityError();
+    }
+
+    this.membersValue = [
+      ...this.membersValue,
+      LobbyOpenGameMember.create(id, partySize, now),
+    ];
+    if (this.remainingSlots() === 0) {
+      this.statusValue = LobbyOpenGameStatus.FILLED;
+    }
+    this.touch(now);
+  }
+
+  kick(actorId: string, targetUserId: string, now = new Date()): void {
+    if (!this.isHost(actorId)) {
+      throw new LobbyForbiddenError("Only the host can kick a player");
+    }
+    if (this.organiseGameIdValue) {
+      throw new LobbyForbiddenError("Cannot kick after Organise conversion");
+    }
+    this.expireIfNeeded(now);
+    if (!this.statusValue.isOpen && !this.statusValue.isFilled) {
+      throw new LobbyNotOpenError();
+    }
+
+    const target = requiredTrimmed(targetUserId, "userId");
+    if (this.isHost(target)) {
+      throw new DomainError("Host cannot be kicked");
+    }
+    if (!this.memberOf(target)) {
+      throw new DomainError("Player is not in this open game");
+    }
+
+    this.membersValue = this.membersValue.filter(
+      (member) => member.userId !== target,
+    );
+    if (this.statusValue.isFilled && this.remainingSlots() > 0) {
+      this.statusValue = LobbyOpenGameStatus.OPEN;
+    }
+    this.touch(now);
+  }
+
+  cancel(actorId: string, now = new Date()): void {
+    if (!this.isHost(actorId)) {
+      throw new LobbyForbiddenError("Only the host can cancel");
+    }
+    if (!this.statusValue.isOpen) {
+      throw new LobbyNotOpenError();
+    }
+    this.statusValue = LobbyOpenGameStatus.CANCELLED;
+    this.touch(now);
+  }
+
+  linkOrganisedGame(organiseGameId: string, now = new Date()): void {
+    this.organiseGameIdValue = requiredTrimmed(organiseGameId, "organiseGameId");
+    if (this.remainingSlots() === 0) {
+      this.statusValue = LobbyOpenGameStatus.FILLED;
+    }
+    this.touch(now);
+  }
+
+  toSnapshot(): LobbyOpenGameSnapshot {
+    return {
+      id: this.id,
+      hostUserId: this.hostUserId,
+      sport: this.sport.value,
+      windowStart: this.window.start.toISOString(),
+      windowEnd: this.window.end.toISOString(),
+      city: this.city.value,
+      area: this.area?.value ?? null,
+      venueCmsId: this.venueCmsId,
+      slotsNeeded: this.slotsNeeded,
+      slotsFilled: this.slotsFilled(),
+      skill: this.skill?.value ?? null,
+      status: this.statusValue.value,
+      organiseGameId: this.organiseGameIdValue,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+      members: this.membersValue.map((member) => member.toSnapshot()),
+    };
+  }
+
+  private touch(now: Date): void {
+    this.updatedAtValue = now;
+  }
+}
+
+function parseSlotsNeeded(raw: unknown, sport: LobbySport): number {
+  if (raw == null) return sport.defaultSlotsNeeded();
+  if (typeof raw !== "number" || !Number.isInteger(raw)) {
+    throw new DomainError(
+      `slotsNeeded must be an integer between ${sport.minSlots()} and ${sport.maxSlots()}`,
+    );
+  }
+  if (raw < sport.minSlots() || raw > sport.maxSlots()) {
+    throw new DomainError(
+      `slotsNeeded must be an integer between ${sport.minSlots()} and ${sport.maxSlots()}`,
+    );
+  }
+  return raw;
+}

--- a/src/modules/lobby/entities/lobby-persistence-error.ts
+++ b/src/modules/lobby/entities/lobby-persistence-error.ts
@@ -1,0 +1,6 @@
+export class LobbyPersistenceError extends Error {
+  constructor(message = "Unable to save lobby item", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "LobbyPersistenceError";
+  }
+}

--- a/src/modules/lobby/entities/lobby-proposal-member.ts
+++ b/src/modules/lobby/entities/lobby-proposal-member.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from "node:crypto";
+
+import { requiredTrimmed } from "../../../lib/domain-error";
+import { LobbyProposalResponse } from "./lobby-proposal-response";
+import { PartySize } from "./party-size";
+
+export type LobbyProposalMemberSnapshot = {
+  id: string;
+  userId: string;
+  partySize: number;
+  response: "pending" | "accept" | "pass";
+  lookingId: string | null;
+  createdAt: string;
+  respondedAt: string | null;
+};
+
+export class LobbyProposalMember {
+  private constructor(
+    readonly id: string,
+    readonly userId: string,
+    readonly partySize: PartySize,
+    private responseValue: LobbyProposalResponse,
+    readonly lookingId: string | null,
+    readonly createdAt: Date,
+    private respondedAtValue: Date | null,
+  ) {}
+
+  static create(props: {
+    userId: string;
+    partySize: PartySize;
+    lookingId?: string | null;
+    now?: Date;
+  }): LobbyProposalMember {
+    const now = props.now ?? new Date();
+    return new LobbyProposalMember(
+      randomUUID(),
+      requiredTrimmed(props.userId, "userId"),
+      props.partySize,
+      LobbyProposalResponse.PENDING,
+      props.lookingId ?? null,
+      now,
+      null,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    userId: string;
+    partySize: PartySize;
+    response: LobbyProposalResponse;
+    lookingId: string | null;
+    createdAt: Date;
+    respondedAt: Date | null;
+  }): LobbyProposalMember {
+    return new LobbyProposalMember(
+      props.id,
+      props.userId,
+      props.partySize,
+      props.response,
+      props.lookingId,
+      props.createdAt,
+      props.respondedAt,
+    );
+  }
+
+  get response(): LobbyProposalResponse {
+    return this.responseValue;
+  }
+
+  get respondedAt(): Date | null {
+    return this.respondedAtValue;
+  }
+
+  setResponse(response: LobbyProposalResponse, now = new Date()): void {
+    this.responseValue = response;
+    this.respondedAtValue = response.isPending ? null : now;
+  }
+
+  toSnapshot(): LobbyProposalMemberSnapshot {
+    return {
+      id: this.id,
+      userId: this.userId,
+      partySize: this.partySize.value,
+      response: this.responseValue.value,
+      lookingId: this.lookingId,
+      createdAt: this.createdAt.toISOString(),
+      respondedAt: this.respondedAtValue?.toISOString() ?? null,
+    };
+  }
+}

--- a/src/modules/lobby/entities/lobby-proposal-response.ts
+++ b/src/modules/lobby/entities/lobby-proposal-response.ts
@@ -1,0 +1,40 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const LOBBY_PROPOSAL_RESPONSES = ["pending", "accept", "pass"] as const;
+export type LobbyProposalResponseValue =
+  (typeof LOBBY_PROPOSAL_RESPONSES)[number];
+
+export class LobbyProposalResponse {
+  static readonly PENDING = new LobbyProposalResponse("pending");
+  static readonly ACCEPT = new LobbyProposalResponse("accept");
+  static readonly PASS = new LobbyProposalResponse("pass");
+
+  private constructor(readonly value: LobbyProposalResponseValue) {}
+
+  static from(raw: unknown): LobbyProposalResponse {
+    if (typeof raw !== "string") {
+      throw new DomainError("response must be pending, accept, or pass");
+    }
+    const response = raw.trim().toLowerCase();
+    if (response === "pending") return LobbyProposalResponse.PENDING;
+    if (response === "accept") return LobbyProposalResponse.ACCEPT;
+    if (response === "pass") return LobbyProposalResponse.PASS;
+    throw new DomainError("response must be pending, accept, or pass");
+  }
+
+  get isPending(): boolean {
+    return this.value === "pending";
+  }
+
+  get isAccept(): boolean {
+    return this.value === "accept";
+  }
+
+  get isPass(): boolean {
+    return this.value === "pass";
+  }
+
+  equals(other: LobbyProposalResponse): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/lobby/entities/lobby-proposal-status.ts
+++ b/src/modules/lobby/entities/lobby-proposal-status.ts
@@ -1,0 +1,46 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const LOBBY_PROPOSAL_STATUSES = [
+  "pending",
+  "accepted",
+  "expired",
+  "cancelled",
+] as const;
+export type LobbyProposalStatusValue = (typeof LOBBY_PROPOSAL_STATUSES)[number];
+
+export class LobbyProposalStatus {
+  static readonly PENDING = new LobbyProposalStatus("pending");
+  static readonly ACCEPTED = new LobbyProposalStatus("accepted");
+  static readonly EXPIRED = new LobbyProposalStatus("expired");
+  static readonly CANCELLED = new LobbyProposalStatus("cancelled");
+
+  private constructor(readonly value: LobbyProposalStatusValue) {}
+
+  static from(raw: unknown): LobbyProposalStatus {
+    if (typeof raw !== "string") {
+      throw new DomainError(
+        "status must be pending, accepted, expired, or cancelled",
+      );
+    }
+    const status = raw.trim().toLowerCase();
+    if (status === "pending") return LobbyProposalStatus.PENDING;
+    if (status === "accepted") return LobbyProposalStatus.ACCEPTED;
+    if (status === "expired") return LobbyProposalStatus.EXPIRED;
+    if (status === "cancelled") return LobbyProposalStatus.CANCELLED;
+    throw new DomainError(
+      "status must be pending, accepted, expired, or cancelled",
+    );
+  }
+
+  get isPending(): boolean {
+    return this.value === "pending";
+  }
+
+  get isAccepted(): boolean {
+    return this.value === "accepted";
+  }
+
+  equals(other: LobbyProposalStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/lobby/entities/lobby-proposal.test.ts
+++ b/src/modules/lobby/entities/lobby-proposal.test.ts
@@ -28,9 +28,10 @@ describe("LobbyProposal", () => {
     expect(proposal.isReadyToConvert()).toBe(false);
     proposal.accept("user-a");
     expect(proposal.isReadyToConvert()).toBe(false);
+    expect(proposal.status.isPending).toBe(true);
     proposal.accept("user-b");
-    expect(proposal.isReadyToConvert()).toBe(true);
     expect(proposal.status.isAccepted).toBe(true);
+    expect(proposal.acceptedSlots()).toBe(2);
   });
 
   test("pass cancels when remaining parties cannot fill", () => {

--- a/src/modules/lobby/entities/lobby-proposal.test.ts
+++ b/src/modules/lobby/entities/lobby-proposal.test.ts
@@ -1,0 +1,49 @@
+import { City } from "./city";
+import { LobbyProposal } from "./lobby-proposal";
+import { LobbySport } from "./lobby-sport";
+import { PartySize } from "./party-size";
+import { TimeWindow } from "./time-window";
+
+function makeProposal() {
+  return LobbyProposal.create({
+    sport: LobbySport.DARTS,
+    city: City.from("Cape Town"),
+    area: null,
+    window: TimeWindow.from(
+      "2026-09-08T16:00:00.000Z",
+      "2026-09-08T18:00:00.000Z",
+    ),
+    venueCmsId: null,
+    skill: null,
+    members: [
+      { userId: "user-a", partySize: PartySize.from(1), lookingId: "look-a" },
+      { userId: "user-b", partySize: PartySize.from(1), lookingId: "look-b" },
+    ],
+  });
+}
+
+describe("LobbyProposal", () => {
+  test("unanimous accept is ready to convert", () => {
+    const proposal = makeProposal();
+    expect(proposal.isReadyToConvert()).toBe(false);
+    proposal.accept("user-a");
+    expect(proposal.isReadyToConvert()).toBe(false);
+    proposal.accept("user-b");
+    expect(proposal.isReadyToConvert()).toBe(true);
+    expect(proposal.status.isAccepted).toBe(true);
+  });
+
+  test("pass cancels when remaining parties cannot fill", () => {
+    const proposal = makeProposal();
+    proposal.pass("user-b");
+    expect(proposal.status.value).toBe("cancelled");
+    expect(proposal.isReadyToConvert()).toBe(false);
+  });
+
+  test("non-members cannot respond", () => {
+    const proposal = makeProposal();
+    expect(() => proposal.accept("stranger")).toThrow(
+      "Only a proposal member can respond",
+    );
+  });
+});

--- a/src/modules/lobby/entities/lobby-proposal.ts
+++ b/src/modules/lobby/entities/lobby-proposal.ts
@@ -1,0 +1,275 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { Area } from "./area";
+import { City } from "./city";
+import { LobbyForbiddenError } from "./lobby-forbidden-error";
+import { LobbyProposalMember } from "./lobby-proposal-member";
+import { LobbyProposalResponse } from "./lobby-proposal-response";
+import { LobbyProposalStatus } from "./lobby-proposal-status";
+import { LobbySkill } from "./lobby-skill";
+import { LobbySport } from "./lobby-sport";
+import { PartySize } from "./party-size";
+import { TimeWindow } from "./time-window";
+
+export type LobbyProposalSnapshot = {
+  id: string;
+  sport: "padel" | "darts" | "golf";
+  city: string;
+  area: string | null;
+  windowStart: string;
+  windowEnd: string;
+  venueCmsId: string | null;
+  skill: "casual" | "intermediate" | "competitive" | null;
+  status: "pending" | "accepted" | "expired" | "cancelled";
+  organiseGameId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  members: ReturnType<LobbyProposalMember["toSnapshot"]>[];
+};
+
+export type CreateLobbyProposalProps = {
+  sport: LobbySport;
+  city: City;
+  area: Area | null;
+  window: TimeWindow;
+  venueCmsId: string | null;
+  skill: LobbySkill | null;
+  members: Array<{
+    userId: string;
+    partySize: PartySize;
+    lookingId?: string | null;
+  }>;
+  now?: Date;
+};
+
+export class LobbyProposal {
+  private constructor(
+    readonly id: string,
+    readonly sport: LobbySport,
+    readonly city: City,
+    readonly area: Area | null,
+    readonly window: TimeWindow,
+    readonly venueCmsId: string | null,
+    readonly skill: LobbySkill | null,
+    private statusValue: LobbyProposalStatus,
+    private organiseGameIdValue: string | null,
+    readonly createdAt: Date,
+    private updatedAtValue: Date,
+    private membersValue: LobbyProposalMember[],
+  ) {}
+
+  static create(props: CreateLobbyProposalProps): LobbyProposal {
+    const now = props.now ?? new Date();
+    if (props.members.length < 2) {
+      throw new DomainError("proposal needs at least two parties");
+    }
+
+    const members = props.members.map((member) =>
+      LobbyProposalMember.create({
+        userId: member.userId,
+        partySize: member.partySize,
+        lookingId: member.lookingId,
+        now,
+      }),
+    );
+
+    return new LobbyProposal(
+      randomUUID(),
+      props.sport,
+      props.city,
+      props.area,
+      props.window,
+      props.venueCmsId,
+      props.skill,
+      LobbyProposalStatus.PENDING,
+      null,
+      now,
+      now,
+      members,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    sport: LobbySport;
+    city: City;
+    area: Area | null;
+    window: TimeWindow;
+    venueCmsId: string | null;
+    skill: LobbySkill | null;
+    status: LobbyProposalStatus;
+    organiseGameId: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+    members: LobbyProposalMember[];
+  }): LobbyProposal {
+    return new LobbyProposal(
+      props.id,
+      props.sport,
+      props.city,
+      props.area,
+      props.window,
+      props.venueCmsId,
+      props.skill,
+      props.status,
+      props.organiseGameId,
+      props.createdAt,
+      props.updatedAt,
+      [...props.members],
+    );
+  }
+
+  static fromSnapshot(snapshot: LobbyProposalSnapshot): LobbyProposal {
+    return LobbyProposal.rehydrate({
+      id: snapshot.id,
+      sport: LobbySport.from(snapshot.sport),
+      city: City.from(snapshot.city),
+      area: Area.from(snapshot.area),
+      window: TimeWindow.from(snapshot.windowStart, snapshot.windowEnd),
+      venueCmsId: snapshot.venueCmsId,
+      skill: LobbySkill.from(snapshot.skill),
+      status: LobbyProposalStatus.from(snapshot.status),
+      organiseGameId: snapshot.organiseGameId,
+      createdAt: new Date(snapshot.createdAt),
+      updatedAt: new Date(snapshot.updatedAt),
+      members: snapshot.members.map((member) =>
+        LobbyProposalMember.rehydrate({
+          id: member.id,
+          userId: member.userId,
+          partySize: PartySize.from(member.partySize),
+          response: LobbyProposalResponse.from(member.response),
+          lookingId: member.lookingId,
+          createdAt: new Date(member.createdAt),
+          respondedAt: member.respondedAt
+            ? new Date(member.respondedAt)
+            : null,
+        }),
+      ),
+    });
+  }
+
+  get status(): LobbyProposalStatus {
+    return this.statusValue;
+  }
+
+  get organiseGameId(): string | null {
+    return this.organiseGameIdValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  get members(): readonly LobbyProposalMember[] {
+    return this.membersValue;
+  }
+
+  organizerUserId(): string {
+    return this.membersValue[0]?.userId ?? "";
+  }
+
+  memberOf(userId: string): LobbyProposalMember | null {
+    const id = userId.trim();
+    return this.membersValue.find((member) => member.userId === id) ?? null;
+  }
+
+  isMember(userId: string): boolean {
+    return this.memberOf(userId) != null;
+  }
+
+  acceptedSlots(): number {
+    return this.membersValue
+      .filter((member) => member.response.isAccept)
+      .reduce((sum, member) => sum + member.partySize.value, 0);
+  }
+
+  remainingActiveSlots(): number {
+    return this.membersValue
+      .filter((member) => !member.response.isPass)
+      .reduce((sum, member) => sum + member.partySize.value, 0);
+  }
+
+  hasPending(): boolean {
+    return this.membersValue.some((member) => member.response.isPending);
+  }
+
+  isReadyToConvert(): boolean {
+    if (!this.statusValue.isPending) return false;
+    if (this.hasPending()) return false;
+    return this.acceptedSlots() >= this.sport.minSlots();
+  }
+
+  accept(userId: string, now = new Date()): void {
+    this.respond(userId, LobbyProposalResponse.ACCEPT, now);
+    if (this.isReadyToConvert()) {
+      this.statusValue = LobbyProposalStatus.ACCEPTED;
+    }
+  }
+
+  pass(userId: string, now = new Date()): void {
+    this.respond(userId, LobbyProposalResponse.PASS, now);
+    if (this.remainingActiveSlots() < this.sport.minSlots()) {
+      this.statusValue = LobbyProposalStatus.CANCELLED;
+    }
+  }
+
+  cancel(now = new Date()): void {
+    if (!this.statusValue.isPending) return;
+    this.statusValue = LobbyProposalStatus.CANCELLED;
+    this.touch(now);
+  }
+
+  expire(now = new Date()): void {
+    if (!this.statusValue.isPending) return;
+    this.statusValue = LobbyProposalStatus.EXPIRED;
+    this.touch(now);
+  }
+
+  linkOrganisedGame(organiseGameId: string, now = new Date()): void {
+    this.organiseGameIdValue = requiredTrimmed(organiseGameId, "organiseGameId");
+    this.statusValue = LobbyProposalStatus.ACCEPTED;
+    this.touch(now);
+  }
+
+  toSnapshot(): LobbyProposalSnapshot {
+    return {
+      id: this.id,
+      sport: this.sport.value,
+      city: this.city.value,
+      area: this.area?.value ?? null,
+      windowStart: this.window.start.toISOString(),
+      windowEnd: this.window.end.toISOString(),
+      venueCmsId: this.venueCmsId,
+      skill: this.skill?.value ?? null,
+      status: this.statusValue.value,
+      organiseGameId: this.organiseGameIdValue,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+      members: this.membersValue.map((member) => member.toSnapshot()),
+    };
+  }
+
+  private respond(
+    userId: string,
+    response: LobbyProposalResponse,
+    now: Date,
+  ): void {
+    if (!this.statusValue.isPending) {
+      throw new DomainError("Proposal is no longer pending");
+    }
+    const member = this.memberOf(userId);
+    if (!member) {
+      throw new LobbyForbiddenError("Only a proposal member can respond");
+    }
+    if (!member.response.isPending) {
+      throw new DomainError("Already responded to this proposal");
+    }
+    member.setResponse(response, now);
+    this.touch(now);
+  }
+
+  private touch(now: Date): void {
+    this.updatedAtValue = now;
+  }
+}

--- a/src/modules/lobby/entities/lobby-skill.ts
+++ b/src/modules/lobby/entities/lobby-skill.ts
@@ -1,0 +1,31 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const LOBBY_SKILLS = ["casual", "intermediate", "competitive"] as const;
+export type LobbySkillValue = (typeof LOBBY_SKILLS)[number];
+
+export class LobbySkill {
+  static readonly CASUAL = new LobbySkill("casual");
+  static readonly INTERMEDIATE = new LobbySkill("intermediate");
+  static readonly COMPETITIVE = new LobbySkill("competitive");
+
+  private constructor(readonly value: LobbySkillValue) {}
+
+  static from(raw: unknown): LobbySkill | null {
+    if (raw == null) return null;
+    if (typeof raw !== "string") {
+      throw new DomainError(
+        "skill must be casual, intermediate, or competitive",
+      );
+    }
+    const skill = raw.trim().toLowerCase();
+    if (skill.length === 0) return null;
+    if (skill === "casual") return LobbySkill.CASUAL;
+    if (skill === "intermediate") return LobbySkill.INTERMEDIATE;
+    if (skill === "competitive") return LobbySkill.COMPETITIVE;
+    throw new DomainError("skill must be casual, intermediate, or competitive");
+  }
+
+  equals(other: LobbySkill): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/lobby/entities/lobby-sport.ts
+++ b/src/modules/lobby/entities/lobby-sport.ts
@@ -1,0 +1,46 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const LOBBY_SPORTS = ["padel", "darts", "golf"] as const;
+export type LobbySportValue = (typeof LOBBY_SPORTS)[number];
+
+export class LobbySport {
+  static readonly PADEL = new LobbySport("padel");
+  static readonly DARTS = new LobbySport("darts");
+  static readonly GOLF = new LobbySport("golf");
+
+  private constructor(readonly value: LobbySportValue) {}
+
+  static from(raw: unknown): LobbySport {
+    if (typeof raw !== "string") {
+      throw new DomainError("sport must be padel, darts, or golf");
+    }
+    const sport = raw.trim().toLowerCase();
+    if (sport === "padel") return LobbySport.PADEL;
+    if (sport === "darts") return LobbySport.DARTS;
+    if (sport === "golf") return LobbySport.GOLF;
+    throw new DomainError("sport must be padel, darts, or golf");
+  }
+
+  defaultSlotsNeeded(): number {
+    if (this.value === "darts") return 2;
+    return 4;
+  }
+
+  minSlots(): number {
+    if (this.value === "golf") return 2;
+    return this.defaultSlotsNeeded();
+  }
+
+  maxSlots(): number {
+    if (this.value === "golf") return 4;
+    return this.defaultSlotsNeeded();
+  }
+
+  canOrganise(): boolean {
+    return this.value === "padel" || this.value === "golf";
+  }
+
+  equals(other: LobbySport): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/lobby/entities/party-size.ts
+++ b/src/modules/lobby/entities/party-size.ts
@@ -1,0 +1,23 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const PARTY_SIZE_MIN = 1;
+export const PARTY_SIZE_MAX = 3;
+
+export class PartySize {
+  private constructor(readonly value: number) {}
+
+  static from(raw: unknown, fallback = 1): PartySize {
+    if (raw == null) return new PartySize(fallback);
+    if (typeof raw !== "number" || !Number.isInteger(raw)) {
+      throw new DomainError(
+        `partySize must be an integer between ${PARTY_SIZE_MIN} and ${PARTY_SIZE_MAX}`,
+      );
+    }
+    if (raw < PARTY_SIZE_MIN || raw > PARTY_SIZE_MAX) {
+      throw new DomainError(
+        `partySize must be an integer between ${PARTY_SIZE_MIN} and ${PARTY_SIZE_MAX}`,
+      );
+    }
+    return new PartySize(raw);
+  }
+}

--- a/src/modules/lobby/entities/time-window.ts
+++ b/src/modules/lobby/entities/time-window.ts
@@ -1,0 +1,58 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export class TimeWindow {
+  private constructor(
+    readonly start: Date,
+    readonly end: Date,
+  ) {}
+
+  static from(startRaw: unknown, endRaw: unknown): TimeWindow {
+    const start = parseDate(startRaw, "windowStart");
+    const end = parseDate(endRaw, "windowEnd");
+    if (end.getTime() <= start.getTime()) {
+      throw new DomainError("windowEnd must be after windowStart");
+    }
+    return new TimeWindow(start, end);
+  }
+
+  overlaps(other: TimeWindow): boolean {
+    return this.start.getTime() < other.end.getTime() &&
+      other.start.getTime() < this.end.getTime();
+  }
+
+  intersection(other: TimeWindow): TimeWindow | null {
+    if (!this.overlaps(other)) return null;
+    const start = new Date(Math.max(this.start.getTime(), other.start.getTime()));
+    const end = new Date(Math.min(this.end.getTime(), other.end.getTime()));
+    return new TimeWindow(start, end);
+  }
+
+  contains(date: Date): boolean {
+    const t = date.getTime();
+    return t >= this.start.getTime() && t <= this.end.getTime();
+  }
+
+  equals(other: TimeWindow): boolean {
+    return (
+      this.start.getTime() === other.start.getTime() &&
+      this.end.getTime() === other.end.getTime()
+    );
+  }
+}
+
+function parseDate(raw: unknown, field: string): Date {
+  if (raw instanceof Date) {
+    if (Number.isNaN(raw.getTime())) {
+      throw new DomainError(`${field} must be a valid date`);
+    }
+    return raw;
+  }
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new DomainError(`${field} is required`);
+  }
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new DomainError(`${field} must be a valid date`);
+  }
+  return parsed;
+}

--- a/src/modules/lobby/index.ts
+++ b/src/modules/lobby/index.ts
@@ -1,0 +1,130 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import {
+  FriendProfileLookup,
+  FriendshipRepository,
+} from "../friends/repositories/friendship.repository";
+import { LobbyNotifier } from "../notifications/services/notifications.service";
+import { OrganisedGameRepository } from "../organised-games/repositories/organised-game.repository";
+import { TeamRepository } from "../teams/repositories/team.repository";
+import { VenueRepository } from "../venue/repositories/venue.repository";
+import { createLobbyController } from "./controllers/lobby.controller";
+import { LobbyRepository } from "./repositories/lobby.repository";
+import { PrismaLobbyRepository } from "./repositories/prisma-lobby.repository";
+import { createLobbyRoutes } from "./routes/lobby.routes";
+import { ConvertLobbyToOrganisedGame } from "./services/convert-to-organise";
+import {
+  ClearLooking,
+  CreateOpenGame,
+  JoinOpenGame,
+  KickOpenGame,
+  ListLobby,
+  ListMyProposals,
+  RespondToProposal,
+  SetLooking,
+} from "./services/lobby.service";
+
+export type CreateLobbyModuleParams = {
+  prisma: PrismaClient;
+  lobbyRepository?: LobbyRepository;
+  organisedGameRepository: OrganisedGameRepository;
+  venueRepository: VenueRepository;
+  friendshipRepository: FriendshipRepository;
+  teamRepository: TeamRepository;
+  friendProfileLookup: FriendProfileLookup;
+  lobbyNotifier?: LobbyNotifier;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type LobbyModule = {
+  router: Router;
+  lobbyRepository: LobbyRepository;
+};
+
+export function createLobbyModule({
+  prisma,
+  lobbyRepository: lobbyRepositoryOverride,
+  organisedGameRepository,
+  venueRepository,
+  friendshipRepository,
+  teamRepository,
+  friendProfileLookup,
+  lobbyNotifier,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreateLobbyModuleParams): LobbyModule {
+  const lobbyRepository =
+    lobbyRepositoryOverride ?? new PrismaLobbyRepository(prisma);
+  const converter = new ConvertLobbyToOrganisedGame(
+    organisedGameRepository,
+    venueRepository,
+  );
+
+  const controller = createLobbyController({
+    listLobby: new ListLobby(
+      lobbyRepository,
+      friendProfileLookup,
+      friendshipRepository,
+      teamRepository,
+    ),
+    setLooking: new SetLooking(
+      lobbyRepository,
+      friendProfileLookup,
+      lobbyNotifier,
+      converter,
+    ),
+    clearLooking: new ClearLooking(lobbyRepository),
+    createOpenGame: new CreateOpenGame(
+      lobbyRepository,
+      friendProfileLookup,
+      lobbyNotifier,
+    ),
+    joinOpenGame: new JoinOpenGame(
+      lobbyRepository,
+      friendProfileLookup,
+      lobbyNotifier,
+      converter,
+    ),
+    kickOpenGame: new KickOpenGame(lobbyRepository, friendProfileLookup),
+    listMyProposals: new ListMyProposals(lobbyRepository, friendProfileLookup),
+    respondToProposal: new RespondToProposal(
+      lobbyRepository,
+      friendProfileLookup,
+      lobbyNotifier,
+      converter,
+    ),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createLobbyRoutes(controller, { requireAuth }),
+    lobbyRepository,
+  };
+}
+
+export { createLobbyController } from "./controllers/lobby.controller";
+export { InMemoryLobbyRepository } from "./repositories/in-memory-lobby.repository";
+export { PrismaLobbyRepository } from "./repositories/prisma-lobby.repository";
+export type { LobbyRepository } from "./repositories/lobby.repository";
+export { LobbyLooking } from "./entities/lobby-looking";
+export { LobbyOpenGame } from "./entities/lobby-open-game";
+export { LobbyProposal } from "./entities/lobby-proposal";
+export { LobbySport, LOBBY_SPORTS } from "./entities/lobby-sport";
+export { ConvertLobbyToOrganisedGame } from "./services/convert-to-organise";
+export {
+  ClearLooking,
+  CreateOpenGame,
+  JoinOpenGame,
+  KickOpenGame,
+  ListLobby,
+  ListMyProposals,
+  RespondToProposal,
+  SetLooking,
+} from "./services/lobby.service";

--- a/src/modules/lobby/repositories/in-memory-lobby.repository.ts
+++ b/src/modules/lobby/repositories/in-memory-lobby.repository.ts
@@ -1,0 +1,150 @@
+import { LobbyLooking } from "../entities/lobby-looking";
+import { LobbyOpenGame } from "../entities/lobby-open-game";
+import { LobbyPersistenceError } from "../entities/lobby-persistence-error";
+import { LobbyProposal } from "../entities/lobby-proposal";
+import { LobbyListFilters, LobbyRepository } from "./lobby.repository";
+
+export class InMemoryLobbyRepository implements LobbyRepository {
+  private readonly lookings = new Map<string, LobbyLooking>();
+  private readonly openGames = new Map<string, LobbyOpenGame>();
+  private readonly proposals = new Map<string, LobbyProposal>();
+
+  async findLookingByUserId(userId: string): Promise<LobbyLooking | null> {
+    const id = userId.trim();
+    for (const looking of this.lookings.values()) {
+      if (looking.userId === id) return cloneLooking(looking);
+    }
+    return null;
+  }
+
+  async findLookingById(id: string): Promise<LobbyLooking | null> {
+    return cloneLooking(this.lookings.get(id) ?? null);
+  }
+
+  async upsertLooking(looking: LobbyLooking): Promise<LobbyLooking> {
+    for (const [id, existing] of this.lookings) {
+      if (existing.userId === looking.userId && existing.id !== looking.id) {
+        this.lookings.delete(id);
+      }
+    }
+    const stored = cloneLooking(looking)!;
+    this.lookings.set(stored.id, stored);
+    return cloneLooking(stored)!;
+  }
+
+  async deleteLookingByUserId(userId: string): Promise<boolean> {
+    const existing = await this.findLookingByUserId(userId);
+    if (!existing) return false;
+    this.lookings.delete(existing.id);
+    return true;
+  }
+
+  async listActiveLookings(filters: LobbyListFilters): Promise<LobbyLooking[]> {
+    const now = filters.now ?? new Date();
+    return [...this.lookings.values()]
+      .filter((looking) => looking.isActive(now))
+      .filter((looking) => matchesFilters(looking, filters))
+      .sort((a, b) => a.window.start.getTime() - b.window.start.getTime())
+      .map((looking) => cloneLooking(looking)!);
+  }
+
+  async findOpenGameById(id: string): Promise<LobbyOpenGame | null> {
+    return cloneOpenGame(this.openGames.get(id) ?? null);
+  }
+
+  async createOpenGame(game: LobbyOpenGame): Promise<LobbyOpenGame> {
+    const stored = cloneOpenGame(game)!;
+    this.openGames.set(stored.id, stored);
+    return cloneOpenGame(stored)!;
+  }
+
+  async persistOpenGame(game: LobbyOpenGame): Promise<LobbyOpenGame> {
+    if (!this.openGames.has(game.id)) {
+      throw new LobbyPersistenceError("Unable to save open game");
+    }
+    const stored = cloneOpenGame(game)!;
+    this.openGames.set(stored.id, stored);
+    return cloneOpenGame(stored)!;
+  }
+
+  async listActiveOpenGames(filters: LobbyListFilters): Promise<LobbyOpenGame[]> {
+    const now = filters.now ?? new Date();
+    return [...this.openGames.values()]
+      .filter((game) => game.status.isOpen && !game.isExpired(now))
+      .filter((game) => matchesFilters(game, filters))
+      .sort((a, b) => a.window.start.getTime() - b.window.start.getTime())
+      .map((game) => cloneOpenGame(game)!);
+  }
+
+  async listOpenGamesForUser(userId: string): Promise<LobbyOpenGame[]> {
+    const id = userId.trim();
+    return [...this.openGames.values()]
+      .filter((game) => game.memberOf(id))
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .map((game) => cloneOpenGame(game)!);
+  }
+
+  async findProposalById(id: string): Promise<LobbyProposal | null> {
+    return cloneProposal(this.proposals.get(id) ?? null);
+  }
+
+  async createProposal(proposal: LobbyProposal): Promise<LobbyProposal> {
+    const stored = cloneProposal(proposal)!;
+    this.proposals.set(stored.id, stored);
+    return cloneProposal(stored)!;
+  }
+
+  async persistProposal(proposal: LobbyProposal): Promise<LobbyProposal> {
+    if (!this.proposals.has(proposal.id)) {
+      throw new LobbyPersistenceError("Unable to save proposal");
+    }
+    const stored = cloneProposal(proposal)!;
+    this.proposals.set(stored.id, stored);
+    return cloneProposal(stored)!;
+  }
+
+  async listProposalsForUser(userId: string): Promise<LobbyProposal[]> {
+    const id = userId.trim();
+    return [...this.proposals.values()]
+      .filter((proposal) => proposal.isMember(id))
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .map((proposal) => cloneProposal(proposal)!);
+  }
+
+  async listPendingProposals(filters: LobbyListFilters): Promise<LobbyProposal[]> {
+    const now = filters.now ?? new Date();
+    return [...this.proposals.values()]
+      .filter(
+        (proposal) =>
+          proposal.status.isPending && proposal.window.end.getTime() > now.getTime(),
+      )
+      .filter((proposal) => matchesFilters(proposal, filters))
+      .map((proposal) => cloneProposal(proposal)!);
+  }
+}
+
+function matchesFilters(
+  item: { sport: { value: string }; city: { normalized: string } },
+  filters: LobbyListFilters,
+): boolean {
+  if (filters.sport && item.sport.value !== filters.sport) return false;
+  if (filters.city && item.city.normalized !== filters.city.trim().toLowerCase()) {
+    return false;
+  }
+  return true;
+}
+
+function cloneLooking(looking: LobbyLooking | null): LobbyLooking | null {
+  if (!looking) return null;
+  return LobbyLooking.fromSnapshot(looking.toSnapshot());
+}
+
+function cloneOpenGame(game: LobbyOpenGame | null): LobbyOpenGame | null {
+  if (!game) return null;
+  return LobbyOpenGame.fromSnapshot(game.toSnapshot());
+}
+
+function cloneProposal(proposal: LobbyProposal | null): LobbyProposal | null {
+  if (!proposal) return null;
+  return LobbyProposal.fromSnapshot(proposal.toSnapshot());
+}

--- a/src/modules/lobby/repositories/lobby.repository.ts
+++ b/src/modules/lobby/repositories/lobby.repository.ts
@@ -1,0 +1,30 @@
+import { LobbyLooking } from "../entities/lobby-looking";
+import { LobbyOpenGame } from "../entities/lobby-open-game";
+import { LobbyProposal } from "../entities/lobby-proposal";
+import { LobbySportValue } from "../entities/lobby-sport";
+
+export type LobbyListFilters = {
+  sport?: LobbySportValue;
+  city?: string;
+  now?: Date;
+};
+
+export interface LobbyRepository {
+  findLookingByUserId(userId: string): Promise<LobbyLooking | null>;
+  findLookingById(id: string): Promise<LobbyLooking | null>;
+  upsertLooking(looking: LobbyLooking): Promise<LobbyLooking>;
+  deleteLookingByUserId(userId: string): Promise<boolean>;
+  listActiveLookings(filters: LobbyListFilters): Promise<LobbyLooking[]>;
+
+  findOpenGameById(id: string): Promise<LobbyOpenGame | null>;
+  createOpenGame(game: LobbyOpenGame): Promise<LobbyOpenGame>;
+  persistOpenGame(game: LobbyOpenGame): Promise<LobbyOpenGame>;
+  listActiveOpenGames(filters: LobbyListFilters): Promise<LobbyOpenGame[]>;
+  listOpenGamesForUser(userId: string): Promise<LobbyOpenGame[]>;
+
+  findProposalById(id: string): Promise<LobbyProposal | null>;
+  createProposal(proposal: LobbyProposal): Promise<LobbyProposal>;
+  persistProposal(proposal: LobbyProposal): Promise<LobbyProposal>;
+  listProposalsForUser(userId: string): Promise<LobbyProposal[]>;
+  listPendingProposals(filters: LobbyListFilters): Promise<LobbyProposal[]>;
+}

--- a/src/modules/lobby/repositories/prisma-lobby.repository.ts
+++ b/src/modules/lobby/repositories/prisma-lobby.repository.ts
@@ -1,0 +1,502 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { Area } from "../entities/area";
+import { City } from "../entities/city";
+import { LobbyLooking } from "../entities/lobby-looking";
+import { LobbyOpenGame } from "../entities/lobby-open-game";
+import { LobbyOpenGameMember } from "../entities/lobby-open-game-member";
+import { LobbyOpenGameStatus } from "../entities/lobby-open-game-status";
+import { LobbyPersistenceError } from "../entities/lobby-persistence-error";
+import { LobbyProposal } from "../entities/lobby-proposal";
+import { LobbyProposalMember } from "../entities/lobby-proposal-member";
+import { LobbyProposalResponse } from "../entities/lobby-proposal-response";
+import { LobbyProposalStatus } from "../entities/lobby-proposal-status";
+import { LobbySkill } from "../entities/lobby-skill";
+import { LobbySport } from "../entities/lobby-sport";
+import { PartySize } from "../entities/party-size";
+import { TimeWindow } from "../entities/time-window";
+import { LobbyListFilters, LobbyRepository } from "./lobby.repository";
+
+type LookingRow = {
+  id: string;
+  userId: string;
+  sport: "padel" | "darts" | "golf";
+  windowStart: Date;
+  windowEnd: Date;
+  city: string;
+  area: string | null;
+  venueCmsId: string | null;
+  partySize: number;
+  skill: "casual" | "intermediate" | "competitive" | null;
+  expiresAt: Date;
+  createdAt: Date;
+};
+
+type OpenGameMemberRow = {
+  id: string;
+  userId: string;
+  partySize: number;
+  createdAt: Date;
+};
+
+type OpenGameRow = {
+  id: string;
+  hostUserId: string;
+  sport: "padel" | "darts" | "golf";
+  windowStart: Date;
+  windowEnd: Date;
+  city: string;
+  area: string | null;
+  venueCmsId: string | null;
+  slotsNeeded: number;
+  slotsFilled: number;
+  skill: "casual" | "intermediate" | "competitive" | null;
+  status: "open" | "filled" | "cancelled" | "expired";
+  organiseGameId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  members: OpenGameMemberRow[];
+};
+
+type ProposalMemberRow = {
+  id: string;
+  userId: string;
+  partySize: number;
+  response: "pending" | "accept" | "pass";
+  lookingId: string | null;
+  createdAt: Date;
+  respondedAt: Date | null;
+};
+
+type ProposalRow = {
+  id: string;
+  sport: "padel" | "darts" | "golf";
+  city: string;
+  area: string | null;
+  windowStart: Date;
+  windowEnd: Date;
+  venueCmsId: string | null;
+  skill: "casual" | "intermediate" | "competitive" | null;
+  status: "pending" | "accepted" | "expired" | "cancelled";
+  organiseGameId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  members: ProposalMemberRow[];
+};
+
+export class PrismaLobbyRepository implements LobbyRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findLookingByUserId(userId: string): Promise<LobbyLooking | null> {
+    try {
+      const row = await this.prisma.lobbyLooking.findUnique({
+        where: { userId: userId.trim() },
+      });
+      return row ? toLooking(row) : null;
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to load looking", { cause: error });
+    }
+  }
+
+  async findLookingById(id: string): Promise<LobbyLooking | null> {
+    try {
+      const row = await this.prisma.lobbyLooking.findUnique({ where: { id } });
+      return row ? toLooking(row) : null;
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to load looking", { cause: error });
+    }
+  }
+
+  async upsertLooking(looking: LobbyLooking): Promise<LobbyLooking> {
+    const snapshot = looking.toSnapshot();
+    try {
+      const row = await this.prisma.lobbyLooking.upsert({
+        where: { userId: snapshot.userId },
+        create: lookingWrite(looking),
+        update: {
+          id: snapshot.id,
+          sport: snapshot.sport,
+          windowStart: looking.window.start,
+          windowEnd: looking.window.end,
+          city: snapshot.city,
+          area: snapshot.area,
+          venueCmsId: snapshot.venueCmsId,
+          partySize: snapshot.partySize,
+          skill: snapshot.skill,
+          expiresAt: looking.expiresAt,
+          createdAt: looking.createdAt,
+        },
+      });
+      return toLooking(row);
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to save looking", { cause: error });
+    }
+  }
+
+  async deleteLookingByUserId(userId: string): Promise<boolean> {
+    try {
+      const result = await this.prisma.lobbyLooking.deleteMany({
+        where: { userId: userId.trim() },
+      });
+      return result.count > 0;
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to delete looking", {
+        cause: error,
+      });
+    }
+  }
+
+  async listActiveLookings(filters: LobbyListFilters): Promise<LobbyLooking[]> {
+    const now = filters.now ?? new Date();
+    try {
+      const rows = await this.prisma.lobbyLooking.findMany({
+        where: {
+          expiresAt: { gt: now },
+          ...(filters.sport ? { sport: filters.sport } : {}),
+          ...(filters.city
+            ? { city: { equals: filters.city.trim(), mode: "insensitive" } }
+            : {}),
+        },
+        orderBy: { windowStart: "asc" },
+      });
+      return rows.map(toLooking);
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to list lookings", {
+        cause: error,
+      });
+    }
+  }
+
+  async findOpenGameById(id: string): Promise<LobbyOpenGame | null> {
+    try {
+      const row = await this.prisma.lobbyOpenGame.findUnique({
+        where: { id },
+        include: { members: { orderBy: { createdAt: "asc" } } },
+      });
+      return row ? toOpenGame(row) : null;
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to load open game", {
+        cause: error,
+      });
+    }
+  }
+
+  async createOpenGame(game: LobbyOpenGame): Promise<LobbyOpenGame> {
+    const snapshot = game.toSnapshot();
+    try {
+      const row = await this.prisma.lobbyOpenGame.create({
+        data: {
+          id: snapshot.id,
+          hostUserId: snapshot.hostUserId,
+          sport: snapshot.sport,
+          windowStart: game.window.start,
+          windowEnd: game.window.end,
+          city: snapshot.city,
+          area: snapshot.area,
+          venueCmsId: snapshot.venueCmsId,
+          slotsNeeded: snapshot.slotsNeeded,
+          slotsFilled: snapshot.slotsFilled,
+          skill: snapshot.skill,
+          status: snapshot.status,
+          organiseGameId: snapshot.organiseGameId,
+          createdAt: game.createdAt,
+          updatedAt: game.updatedAt,
+          members: {
+            create: snapshot.members.map((member) => ({
+              id: member.id,
+              userId: member.userId,
+              partySize: member.partySize,
+              createdAt: new Date(member.createdAt),
+            })),
+          },
+        },
+        include: { members: { orderBy: { createdAt: "asc" } } },
+      });
+      return toOpenGame(row);
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to create open game", {
+        cause: error,
+      });
+    }
+  }
+
+  async persistOpenGame(game: LobbyOpenGame): Promise<LobbyOpenGame> {
+    const snapshot = game.toSnapshot();
+    try {
+      const row = await this.prisma.lobbyOpenGame.update({
+        where: { id: snapshot.id },
+        data: {
+          slotsFilled: snapshot.slotsFilled,
+          status: snapshot.status,
+          organiseGameId: snapshot.organiseGameId,
+          updatedAt: game.updatedAt,
+          members: {
+            deleteMany: {},
+            create: snapshot.members.map((member) => ({
+              id: member.id,
+              userId: member.userId,
+              partySize: member.partySize,
+              createdAt: new Date(member.createdAt),
+            })),
+          },
+        },
+        include: { members: { orderBy: { createdAt: "asc" } } },
+      });
+      return toOpenGame(row);
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to save open game", {
+        cause: error,
+      });
+    }
+  }
+
+  async listActiveOpenGames(filters: LobbyListFilters): Promise<LobbyOpenGame[]> {
+    const now = filters.now ?? new Date();
+    try {
+      const rows = await this.prisma.lobbyOpenGame.findMany({
+        where: {
+          status: "open",
+          windowEnd: { gt: now },
+          ...(filters.sport ? { sport: filters.sport } : {}),
+          ...(filters.city
+            ? { city: { equals: filters.city.trim(), mode: "insensitive" } }
+            : {}),
+        },
+        include: { members: { orderBy: { createdAt: "asc" } } },
+        orderBy: { windowStart: "asc" },
+      });
+      return rows.map(toOpenGame);
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to list open games", {
+        cause: error,
+      });
+    }
+  }
+
+  async listOpenGamesForUser(userId: string): Promise<LobbyOpenGame[]> {
+    try {
+      const rows = await this.prisma.lobbyOpenGame.findMany({
+        where: { members: { some: { userId: userId.trim() } } },
+        include: { members: { orderBy: { createdAt: "asc" } } },
+        orderBy: { createdAt: "desc" },
+      });
+      return rows.map(toOpenGame);
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to list open games", {
+        cause: error,
+      });
+    }
+  }
+
+  async findProposalById(id: string): Promise<LobbyProposal | null> {
+    try {
+      const row = await this.prisma.lobbyProposal.findUnique({
+        where: { id },
+        include: { members: { orderBy: { createdAt: "asc" } } },
+      });
+      return row ? toProposal(row) : null;
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to load proposal", {
+        cause: error,
+      });
+    }
+  }
+
+  async createProposal(proposal: LobbyProposal): Promise<LobbyProposal> {
+    const snapshot = proposal.toSnapshot();
+    try {
+      const row = await this.prisma.lobbyProposal.create({
+        data: {
+          id: snapshot.id,
+          sport: snapshot.sport,
+          city: snapshot.city,
+          area: snapshot.area,
+          windowStart: proposal.window.start,
+          windowEnd: proposal.window.end,
+          venueCmsId: snapshot.venueCmsId,
+          skill: snapshot.skill,
+          status: snapshot.status,
+          organiseGameId: snapshot.organiseGameId,
+          createdAt: proposal.createdAt,
+          updatedAt: proposal.updatedAt,
+          members: {
+            create: snapshot.members.map((member) => ({
+              id: member.id,
+              userId: member.userId,
+              partySize: member.partySize,
+              response: member.response,
+              lookingId: member.lookingId,
+              createdAt: new Date(member.createdAt),
+              respondedAt: member.respondedAt
+                ? new Date(member.respondedAt)
+                : null,
+            })),
+          },
+        },
+        include: { members: { orderBy: { createdAt: "asc" } } },
+      });
+      return toProposal(row);
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to create proposal", {
+        cause: error,
+      });
+    }
+  }
+
+  async persistProposal(proposal: LobbyProposal): Promise<LobbyProposal> {
+    const snapshot = proposal.toSnapshot();
+    try {
+      const row = await this.prisma.lobbyProposal.update({
+        where: { id: snapshot.id },
+        data: {
+          status: snapshot.status,
+          organiseGameId: snapshot.organiseGameId,
+          updatedAt: proposal.updatedAt,
+          members: {
+            deleteMany: {},
+            create: snapshot.members.map((member) => ({
+              id: member.id,
+              userId: member.userId,
+              partySize: member.partySize,
+              response: member.response,
+              lookingId: member.lookingId,
+              createdAt: new Date(member.createdAt),
+              respondedAt: member.respondedAt
+                ? new Date(member.respondedAt)
+                : null,
+            })),
+          },
+        },
+        include: { members: { orderBy: { createdAt: "asc" } } },
+      });
+      return toProposal(row);
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to save proposal", {
+        cause: error,
+      });
+    }
+  }
+
+  async listProposalsForUser(userId: string): Promise<LobbyProposal[]> {
+    try {
+      const rows = await this.prisma.lobbyProposal.findMany({
+        where: { members: { some: { userId: userId.trim() } } },
+        include: { members: { orderBy: { createdAt: "asc" } } },
+        orderBy: { createdAt: "desc" },
+      });
+      return rows.map(toProposal);
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to list proposals", {
+        cause: error,
+      });
+    }
+  }
+
+  async listPendingProposals(filters: LobbyListFilters): Promise<LobbyProposal[]> {
+    const now = filters.now ?? new Date();
+    try {
+      const rows = await this.prisma.lobbyProposal.findMany({
+        where: {
+          status: "pending",
+          windowEnd: { gt: now },
+          ...(filters.sport ? { sport: filters.sport } : {}),
+          ...(filters.city
+            ? { city: { equals: filters.city.trim(), mode: "insensitive" } }
+            : {}),
+        },
+        include: { members: { orderBy: { createdAt: "asc" } } },
+      });
+      return rows.map(toProposal);
+    } catch (error) {
+      throw new LobbyPersistenceError("Failed to list proposals", {
+        cause: error,
+      });
+    }
+  }
+}
+
+function lookingWrite(looking: LobbyLooking) {
+  const snapshot = looking.toSnapshot();
+  return {
+    id: snapshot.id,
+    userId: snapshot.userId,
+    sport: snapshot.sport,
+    windowStart: looking.window.start,
+    windowEnd: looking.window.end,
+    city: snapshot.city,
+    area: snapshot.area,
+    venueCmsId: snapshot.venueCmsId,
+    partySize: snapshot.partySize,
+    skill: snapshot.skill,
+    expiresAt: looking.expiresAt,
+    createdAt: looking.createdAt,
+  };
+}
+
+function toLooking(row: LookingRow): LobbyLooking {
+  return LobbyLooking.rehydrate({
+    id: row.id,
+    userId: row.userId,
+    sport: LobbySport.from(row.sport),
+    window: TimeWindow.from(row.windowStart, row.windowEnd),
+    city: City.from(row.city),
+    area: Area.from(row.area),
+    venueCmsId: row.venueCmsId,
+    partySize: PartySize.from(row.partySize),
+    skill: LobbySkill.from(row.skill),
+    expiresAt: row.expiresAt,
+    createdAt: row.createdAt,
+  });
+}
+
+function toOpenGame(row: OpenGameRow): LobbyOpenGame {
+  return LobbyOpenGame.rehydrate({
+    id: row.id,
+    hostUserId: row.hostUserId,
+    sport: LobbySport.from(row.sport),
+    window: TimeWindow.from(row.windowStart, row.windowEnd),
+    city: City.from(row.city),
+    area: Area.from(row.area),
+    venueCmsId: row.venueCmsId,
+    slotsNeeded: row.slotsNeeded,
+    skill: LobbySkill.from(row.skill),
+    status: LobbyOpenGameStatus.from(row.status),
+    organiseGameId: row.organiseGameId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    members: row.members.map((member) =>
+      LobbyOpenGameMember.rehydrate({
+        id: member.id,
+        userId: member.userId,
+        partySize: PartySize.from(member.partySize),
+        createdAt: member.createdAt,
+      }),
+    ),
+  });
+}
+
+function toProposal(row: ProposalRow): LobbyProposal {
+  return LobbyProposal.rehydrate({
+    id: row.id,
+    sport: LobbySport.from(row.sport),
+    city: City.from(row.city),
+    area: Area.from(row.area),
+    window: TimeWindow.from(row.windowStart, row.windowEnd),
+    venueCmsId: row.venueCmsId,
+    skill: LobbySkill.from(row.skill),
+    status: LobbyProposalStatus.from(row.status),
+    organiseGameId: row.organiseGameId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    members: row.members.map((member) =>
+      LobbyProposalMember.rehydrate({
+        id: member.id,
+        userId: member.userId,
+        partySize: PartySize.from(member.partySize),
+        response: LobbyProposalResponse.from(member.response),
+        lookingId: member.lookingId,
+        createdAt: member.createdAt,
+        respondedAt: member.respondedAt,
+      }),
+    ),
+  });
+}

--- a/src/modules/lobby/routes/lobby.routes.ts
+++ b/src/modules/lobby/routes/lobby.routes.ts
@@ -1,0 +1,70 @@
+import { NextFunction, Request, Response, Router } from "express";
+
+import { createLobbyController } from "../controllers/lobby.controller";
+
+export function createLobbyRoutes(
+  controller: ReturnType<typeof createLobbyController>,
+  options: {
+    requireAuth: (
+      req: Request,
+      res: Response,
+      next: NextFunction,
+    ) => void;
+  },
+) {
+  const router = Router();
+
+  router.get("/api/lobby", (req, res) => {
+    void controller.list(req, res);
+  });
+
+  router.post("/api/lobby/looking", options.requireAuth, (req, res) => {
+    void controller.setLooking(req, res);
+  });
+
+  router.delete("/api/lobby/looking", options.requireAuth, (req, res) => {
+    void controller.clearLooking(req, res);
+  });
+
+  router.post("/api/lobby/open-games", options.requireAuth, (req, res) => {
+    void controller.createOpenGame(req, res);
+  });
+
+  router.post(
+    "/api/lobby/open-games/:id/join",
+    options.requireAuth,
+    (req, res) => {
+      void controller.joinOpenGame(req, res);
+    },
+  );
+
+  router.post(
+    "/api/lobby/open-games/:id/kick",
+    options.requireAuth,
+    (req, res) => {
+      void controller.kickOpenGame(req, res);
+    },
+  );
+
+  router.get("/api/lobby/proposals", options.requireAuth, (req, res) => {
+    void controller.listProposals(req, res);
+  });
+
+  router.post(
+    "/api/lobby/proposals/:id/accept",
+    options.requireAuth,
+    (req, res) => {
+      void controller.acceptProposal(req, res);
+    },
+  );
+
+  router.post(
+    "/api/lobby/proposals/:id/pass",
+    options.requireAuth,
+    (req, res) => {
+      void controller.passProposal(req, res);
+    },
+  );
+
+  return router;
+}

--- a/src/modules/lobby/services/convert-to-organise.ts
+++ b/src/modules/lobby/services/convert-to-organise.ts
@@ -1,0 +1,73 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { OrganisedGame } from "../../organised-games/entities/organised-game";
+import { OrganisedGameCapacity } from "../../organised-games/entities/organised-game-capacity";
+import { OrganisedGameNotes } from "../../organised-games/entities/organised-game-notes";
+import { OrganisedGameRsvp } from "../../organised-games/entities/organised-game-rsvp";
+import { OrganisedGameSport } from "../../organised-games/entities/organised-game-sport";
+import { StartsAt } from "../../organised-games/entities/starts-at";
+import { OrganisedGameRepository } from "../../organised-games/repositories/organised-game.repository";
+import { LobbySport } from "../entities/lobby-sport";
+
+export type ConversionBlocked =
+  | "venue_required"
+  | "venue_not_found"
+  | "unsupported_sport";
+
+export type ConversionResult =
+  | { organiseGameId: string; source: "lobby" }
+  | { blocked: ConversionBlocked };
+
+export type ConvertLobbyToOrganisedInput = {
+  hostUserId: string;
+  inviteUserIds: string[];
+  sport: LobbySport;
+  venueCmsId: string | null;
+  startsAt: Date;
+  capacity: number;
+  notes: string;
+};
+
+export interface LobbyOrganiseConverter {
+  convert(input: ConvertLobbyToOrganisedInput): Promise<ConversionResult>;
+}
+
+export class ConvertLobbyToOrganisedGame implements LobbyOrganiseConverter {
+  constructor(
+    private readonly games: OrganisedGameRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async convert(input: ConvertLobbyToOrganisedInput): Promise<ConversionResult> {
+    if (!input.sport.canOrganise()) {
+      return { blocked: "unsupported_sport" };
+    }
+    if (!input.venueCmsId) {
+      return { blocked: "venue_required" };
+    }
+
+    const venueCmsId = CmsId.from(input.venueCmsId);
+    const venue = await this.venues.findByCmsId(venueCmsId);
+    if (!venue) {
+      return { blocked: "venue_not_found" };
+    }
+
+    const game = OrganisedGame.create({
+      hostUserId: input.hostUserId,
+      sport: OrganisedGameSport.from(input.sport.value),
+      venueCmsId,
+      startsAt: StartsAt.from(input.startsAt),
+      notes: OrganisedGameNotes.from(input.notes),
+      capacity: OrganisedGameCapacity.from(input.capacity, input.capacity),
+    });
+
+    for (const inviteeId of input.inviteUserIds) {
+      if (inviteeId === input.hostUserId) continue;
+      game.addInvitee(inviteeId);
+      game.rsvp(inviteeId, OrganisedGameRsvp.ACCEPTED);
+    }
+
+    const saved = await this.games.create(game);
+    return { organiseGameId: saved.id, source: "lobby" };
+  }
+}

--- a/src/modules/lobby/services/lobby.service.test.ts
+++ b/src/modules/lobby/services/lobby.service.test.ts
@@ -1,0 +1,391 @@
+import { InMemoryFriendProfileLookup } from "../../friends/repositories/in-memory-friend-profile.lookup";
+import { InMemoryFriendshipRepository } from "../../friends/repositories/in-memory-friendship.repository";
+import { InMemoryNotificationRepository } from "../../notifications/repositories/in-memory-notification.repository";
+import { NotifyLobby } from "../../notifications/services/notifications.service";
+import { InMemoryOrganisedGameRepository } from "../../organised-games/repositories/in-memory-organised-game.repository";
+import { InMemoryTeamRepository } from "../../teams/repositories/in-memory-team.repository";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { InMemoryLobbyRepository } from "../repositories/in-memory-lobby.repository";
+import { ConvertLobbyToOrganisedGame } from "./convert-to-organise";
+import {
+  ClearLooking,
+  CreateOpenGame,
+  JoinOpenGame,
+  KickOpenGame,
+  ListLobby,
+  RespondToProposal,
+  SetLooking,
+} from "./lobby.service";
+
+const NOW = new Date("2026-09-08T12:00:00.000Z");
+const WINDOW = {
+  windowStart: "2026-09-08T16:00:00.000Z",
+  windowEnd: "2026-09-08T18:00:00.000Z",
+};
+
+function seedProfiles(profiles: InMemoryFriendProfileLookup) {
+  profiles.seed({
+    userId: "user-a",
+    displayName: "Alex Smith",
+    handle: "alex",
+    avatarUrl: "https://cdn.example/alex.png",
+  });
+  profiles.seed({
+    userId: "user-b",
+    displayName: "Blake Jones",
+    handle: "blake",
+    avatarUrl: null,
+  });
+  profiles.seed({
+    userId: "user-c",
+    displayName: "Casey Lee",
+    handle: "casey",
+    avatarUrl: null,
+  });
+  profiles.seed({
+    userId: "user-d",
+    displayName: "Drew Patel",
+    handle: "drew",
+    avatarUrl: null,
+  });
+}
+
+async function setup() {
+  const lobby = new InMemoryLobbyRepository();
+  const profiles = new InMemoryFriendProfileLookup();
+  seedProfiles(profiles);
+  const friendships = new InMemoryFriendshipRepository();
+  const teams = new InMemoryTeamRepository();
+  const notifications = new InMemoryNotificationRepository();
+  const notifier = new NotifyLobby(notifications);
+  const venues = new InMemoryVenueRepository();
+  await venues.ensureFromCms(
+    Venue.registerFromCms(
+      CmsId.from("sanity-court-1"),
+      VenueName.from("Padel Club"),
+      Slug.from("padel-club"),
+    ),
+    { refreshDetails: false },
+  );
+  const organised = new InMemoryOrganisedGameRepository();
+  const converter = new ConvertLobbyToOrganisedGame(organised, venues);
+
+  return {
+    lobby,
+    profiles,
+    friendships,
+    teams,
+    notifications,
+    notifier,
+    organised,
+    converter,
+    list: new ListLobby(lobby, profiles, friendships, teams),
+    setLooking: new SetLooking(lobby, profiles, notifier, converter),
+    clearLooking: new ClearLooking(lobby),
+    createOpenGame: new CreateOpenGame(lobby, profiles, notifier),
+    join: new JoinOpenGame(lobby, profiles, notifier, converter),
+    kick: new KickOpenGame(lobby, profiles),
+    respond: new RespondToProposal(lobby, profiles, notifier, converter),
+  };
+}
+
+describe("lobby application", () => {
+  test("set looking replaces the previous row and caps TTL at windowEnd", async () => {
+    const ctx = await setup();
+    const first = await ctx.setLooking.execute({
+      userId: "user-a",
+      sport: "darts",
+      ...WINDOW,
+      city: "Cape Town",
+      partySizeWithMe: 1,
+      now: NOW,
+    });
+    const second = await ctx.setLooking.execute({
+      userId: "user-a",
+      sport: "padel",
+      ...WINDOW,
+      city: "Cape Town",
+      partySizeWithMe: 2,
+      now: NOW,
+    });
+
+    expect(first.looking.expiresAt).toBe(WINDOW.windowEnd);
+    expect(second.looking.sport).toBe("padel");
+    expect(second.looking.partySize).toBe(2);
+    expect(await ctx.lobby.findLookingById(first.looking.id)).toBeNull();
+  });
+
+  test("clear looking removes the seeker status", async () => {
+    const ctx = await setup();
+    await ctx.setLooking.execute({
+      userId: "user-a",
+      sport: "darts",
+      ...WINDOW,
+      city: "Cape Town",
+      now: NOW,
+    });
+    const cleared = await ctx.clearLooking.execute({
+      userId: "user-a",
+      now: NOW,
+    });
+    expect(cleared.cleared).toBe(true);
+    expect(await ctx.lobby.findLookingByUserId("user-a")).toBeNull();
+  });
+
+  test("two compatible darts lookings become a proposal", async () => {
+    const ctx = await setup();
+    await ctx.setLooking.execute({
+      userId: "user-a",
+      sport: "darts",
+      ...WINDOW,
+      city: "Cape Town",
+      now: NOW,
+    });
+    const second = await ctx.setLooking.execute({
+      userId: "user-b",
+      sport: "darts",
+      ...WINDOW,
+      city: "Cape Town",
+      now: NOW,
+    });
+
+    expect(second.proposals).toHaveLength(1);
+    expect(second.proposals[0].sport).toBe("darts");
+    expect(second.proposals[0].members).toHaveLength(2);
+
+    const inbox = await ctx.notifications.listPage({
+      recipientId: "user-b",
+      limit: 10,
+    });
+    expect(
+      inbox.items.some((n) => n.type.value === "lobby_proposal_ready"),
+    ).toBe(true);
+  });
+
+  test("proposal accept converts to Organise when venue is present", async () => {
+    const ctx = await setup();
+    await ctx.setLooking.execute({
+      userId: "user-a",
+      sport: "padel",
+      ...WINDOW,
+      city: "Cape Town",
+      venueCmsId: "sanity-court-1",
+      partySizeWithMe: 2,
+      now: NOW,
+    });
+    const second = await ctx.setLooking.execute({
+      userId: "user-b",
+      sport: "padel",
+      ...WINDOW,
+      city: "Cape Town",
+      partySizeWithMe: 2,
+      now: NOW,
+    });
+    const proposalId = second.proposals[0].id;
+
+    await ctx.respond.execute({
+      userId: "user-a",
+      proposalId,
+      decision: "accept",
+      now: NOW,
+    });
+    const accepted = await ctx.respond.execute({
+      userId: "user-b",
+      proposalId,
+      decision: "accept",
+      now: NOW,
+    });
+
+    expect(accepted.proposal.status).toBe("accepted");
+    expect(accepted.proposal.organiseGameId).toBeTruthy();
+    expect(accepted.proposal.source).toBe("lobby");
+    const organised = await ctx.organised.findById(
+      accepted.proposal.organiseGameId!,
+    );
+    expect(organised?.sport.value).toBe("padel");
+    expect(organised?.inviteOf("user-b")?.rsvp.isAccepted).toBe(true);
+  });
+
+  test("proposal pass cancels when remaining parties cannot fill", async () => {
+    const ctx = await setup();
+    await ctx.setLooking.execute({
+      userId: "user-a",
+      sport: "darts",
+      ...WINDOW,
+      city: "Cape Town",
+      now: NOW,
+    });
+    const second = await ctx.setLooking.execute({
+      userId: "user-b",
+      sport: "darts",
+      ...WINDOW,
+      city: "Cape Town",
+      now: NOW,
+    });
+
+    const passed = await ctx.respond.execute({
+      userId: "user-b",
+      proposalId: second.proposals[0].id,
+      decision: "pass",
+      now: NOW,
+    });
+    expect(passed.proposal.status).toBe("cancelled");
+    expect(passed.proposal.organiseGameId).toBeNull();
+  });
+
+  test("open game create/join/kick and fill converts to Organise", async () => {
+    const ctx = await setup();
+    const created = await ctx.createOpenGame.execute({
+      userId: "user-a",
+      sport: "padel",
+      ...WINDOW,
+      city: "Cape Town",
+      venueCmsId: "sanity-court-1",
+      slotsNeeded: 4,
+      partySizeWithMe: 1,
+      now: NOW,
+    });
+    expect(created.openGame.slotsRemaining).toBe(3);
+    expect(created.openGame.status).toBe("open");
+
+    const joined = await ctx.join.execute({
+      userId: "user-b",
+      openGameId: created.openGame.id,
+      partySizeWithMe: 1,
+      now: NOW,
+    });
+    expect(joined.openGame.slotsFilled).toBe(2);
+    expect(joined.openGame.status).toBe("open");
+
+    const kicked = await ctx.kick.execute({
+      userId: "user-a",
+      openGameId: created.openGame.id,
+      targetUserId: "user-b",
+      now: NOW,
+    });
+    expect(kicked.openGame.slotsFilled).toBe(1);
+
+    await ctx.join.execute({
+      userId: "user-b",
+      openGameId: created.openGame.id,
+      partySizeWithMe: 1,
+      now: NOW,
+    });
+    const filled = await ctx.join.execute({
+      userId: "user-c",
+      openGameId: created.openGame.id,
+      partySizeWithMe: 2,
+      now: NOW,
+    });
+
+    expect(filled.openGame.status).toBe("filled");
+    expect(filled.openGame.organiseGameId).toBeTruthy();
+    expect(filled.openGame.source).toBe("lobby");
+    expect(filled.openGame.slotsRemaining).toBe(0);
+  });
+
+  test("GET lobby privacy shape hides profile dump", async () => {
+    const ctx = await setup();
+    await ctx.setLooking.execute({
+      userId: "user-a",
+      sport: "golf",
+      ...WINDOW,
+      city: "Cape Town",
+      area: "Sea Point",
+      skill: "casual",
+      now: NOW,
+    });
+    await ctx.createOpenGame.execute({
+      userId: "user-b",
+      sport: "golf",
+      ...WINDOW,
+      city: "Cape Town",
+      area: "Camps Bay",
+      now: NOW,
+    });
+
+    const listed = await ctx.list.execute({
+      userId: "user-c",
+      city: "Cape Town",
+      now: NOW,
+    });
+
+    expect(listed.lookings).toEqual([
+      {
+        id: expect.any(String),
+        firstName: "Alex",
+        sport: "golf",
+        windowStart: WINDOW.windowStart,
+        windowEnd: WINDOW.windowEnd,
+        city: "Cape Town",
+        area: "Sea Point",
+      },
+    ]);
+    expect(listed.openGames[0]).toEqual({
+      id: expect.any(String),
+      firstName: "Blake",
+      sport: "golf",
+      windowStart: WINDOW.windowStart,
+      windowEnd: WINDOW.windowEnd,
+      city: "Cape Town",
+      area: "Camps Bay",
+      slotsNeeded: 4,
+      slotsFilled: 1,
+      slotsRemaining: 3,
+    });
+    expect(JSON.stringify(listed)).not.toContain("alex");
+    expect(JSON.stringify(listed)).not.toContain("Smith");
+    expect(JSON.stringify(listed)).not.toContain("cdn.example");
+    expect(JSON.stringify(listed.lookings)).not.toContain("user-a");
+  });
+
+  test("looking notifies when a compatible open game already exists", async () => {
+    const ctx = await setup();
+    await ctx.createOpenGame.execute({
+      userId: "user-a",
+      sport: "golf",
+      ...WINDOW,
+      city: "Cape Town",
+      now: NOW,
+    });
+    await ctx.setLooking.execute({
+      userId: "user-b",
+      sport: "golf",
+      ...WINDOW,
+      city: "Cape Town",
+      now: NOW,
+    });
+
+    const inbox = await ctx.notifications.listPage({
+      recipientId: "user-b",
+      limit: 10,
+    });
+    expect(
+      inbox.items.some((n) => n.type.value === "lobby_open_game_compatible"),
+    ).toBe(true);
+  });
+
+  test("darts fill is blocked from Organise conversion", async () => {
+    const ctx = await setup();
+    const created = await ctx.createOpenGame.execute({
+      userId: "user-a",
+      sport: "darts",
+      ...WINDOW,
+      city: "Cape Town",
+      venueCmsId: "sanity-court-1",
+      now: NOW,
+    });
+    const filled = await ctx.join.execute({
+      userId: "user-b",
+      openGameId: created.openGame.id,
+      now: NOW,
+    });
+    expect(filled.openGame.status).toBe("filled");
+    expect(filled.openGame.organiseGameId).toBeNull();
+    expect(filled.openGame.conversionBlocked).toBe("unsupported_sport");
+  });
+});

--- a/src/modules/lobby/services/lobby.service.ts
+++ b/src/modules/lobby/services/lobby.service.ts
@@ -1,0 +1,882 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import {
+  FriendProfile,
+  FriendProfileLookup,
+  FriendshipRepository,
+} from "../../friends/repositories/friendship.repository";
+import { LobbyNotifier } from "../../notifications/services/notifications.service";
+import { TeamRepository } from "../../teams/repositories/team.repository";
+import { Area } from "../entities/area";
+import { City } from "../entities/city";
+import { LobbyForbiddenError } from "../entities/lobby-forbidden-error";
+import { LobbyLooking } from "../entities/lobby-looking";
+import { LobbyNotFoundError } from "../entities/lobby-not-found-error";
+import { LobbyOpenGame } from "../entities/lobby-open-game";
+import { LobbyProposal } from "../entities/lobby-proposal";
+import { LobbySkill } from "../entities/lobby-skill";
+import { LobbySport } from "../entities/lobby-sport";
+import { PartySize } from "../entities/party-size";
+import { TimeWindow } from "../entities/time-window";
+import { LobbyRepository } from "../repositories/lobby.repository";
+import {
+  ConversionResult,
+  LobbyOrganiseConverter,
+} from "./convert-to-organise";
+
+export type PublicLobbyLooking = {
+  id: string;
+  firstName: string;
+  sport: "padel" | "darts" | "golf";
+  windowStart: string;
+  windowEnd: string;
+  city: string;
+  area: string | null;
+};
+
+export type PublicOwnLooking = PublicLobbyLooking & {
+  partySize: number;
+  skill: "casual" | "intermediate" | "competitive" | null;
+  venueCmsId: string | null;
+  expiresAt: string;
+};
+
+export type PublicLobbyOpenGame = {
+  id: string;
+  firstName: string;
+  sport: "padel" | "darts" | "golf";
+  windowStart: string;
+  windowEnd: string;
+  city: string;
+  area: string | null;
+  slotsNeeded: number;
+  slotsFilled: number;
+  slotsRemaining: number;
+};
+
+export type PublicOwnOpenGame = PublicLobbyOpenGame & {
+  status: "open" | "filled" | "cancelled" | "expired";
+  venueCmsId: string | null;
+  skill: "casual" | "intermediate" | "competitive" | null;
+  organiseGameId: string | null;
+  source: "lobby";
+  conversionBlocked: string | null;
+};
+
+export type PublicProposalMember = {
+  firstName: string;
+  partySize: number;
+  response: "pending" | "accept" | "pass";
+  isYou: boolean;
+};
+
+export type PublicProposal = {
+  id: string;
+  sport: "padel" | "darts" | "golf";
+  city: string;
+  area: string | null;
+  windowStart: string;
+  windowEnd: string;
+  status: "pending" | "accepted" | "expired" | "cancelled";
+  organiseGameId: string | null;
+  source: "lobby";
+  conversionBlocked: string | null;
+  members: PublicProposalMember[];
+};
+
+function firstNameOf(profile: FriendProfile | null): string {
+  const display = profile?.displayName?.trim() || "Player";
+  return display.split(/\s+/)[0] ?? "Player";
+}
+
+async function resolveFirstName(
+  lookup: FriendProfileLookup,
+  userId: string,
+): Promise<string> {
+  return firstNameOf(await lookup.findByUserId(userId));
+}
+
+function optionalVenue(raw: unknown): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") {
+    throw new DomainError("venueCmsId must be a string");
+  }
+  const value = raw.trim();
+  return value.length === 0 ? null : value;
+}
+
+function organiseNotes(kind: "openGame" | "proposal", id: string): string {
+  return `source=lobby ${kind}=${id}`;
+}
+
+export class ListLobby {
+  constructor(
+    private readonly lobby: LobbyRepository,
+    private readonly profiles: FriendProfileLookup,
+    private readonly friendships: FriendshipRepository,
+    private readonly teams: TeamRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string | null;
+    sport?: unknown;
+    city?: unknown;
+    now?: Date;
+  }) {
+    const now = input.now ?? new Date();
+    const sport =
+      input.sport == null || input.sport === ""
+        ? undefined
+        : LobbySport.from(input.sport).value;
+    const city =
+      input.city == null || input.city === ""
+        ? undefined
+        : City.from(input.city).value;
+
+    const [lookings, openGames] = await Promise.all([
+      this.lobby.listActiveLookings({ sport, city, now }),
+      this.lobby.listActiveOpenGames({ sport, city, now }),
+    ]);
+
+    const connected = input.userId
+      ? await this.connectedUserIds(input.userId)
+      : new Set<string>();
+
+    const publicLookings = await Promise.all(
+      lookings.map(async (looking) => ({
+        item: looking,
+        public: {
+          id: looking.id,
+          firstName: await resolveFirstName(this.profiles, looking.userId),
+          sport: looking.sport.value,
+          windowStart: looking.window.start.toISOString(),
+          windowEnd: looking.window.end.toISOString(),
+          city: looking.city.value,
+          area: looking.area?.value ?? null,
+        } satisfies PublicLobbyLooking,
+      })),
+    );
+
+    const publicOpenGames = await Promise.all(
+      openGames.map(async (game) => ({
+        item: game,
+        public: {
+          id: game.id,
+          firstName: await resolveFirstName(this.profiles, game.hostUserId),
+          sport: game.sport.value,
+          windowStart: game.window.start.toISOString(),
+          windowEnd: game.window.end.toISOString(),
+          city: game.city.value,
+          area: game.area?.value ?? null,
+          slotsNeeded: game.slotsNeeded,
+          slotsFilled: game.slotsFilled(),
+          slotsRemaining: game.remainingSlots(),
+        } satisfies PublicLobbyOpenGame,
+      })),
+    );
+
+    publicLookings.sort((a, b) =>
+      compareAffinity(
+        connected.has(a.item.userId),
+        connected.has(b.item.userId),
+        a.item.window.start,
+        b.item.window.start,
+      ),
+    );
+    publicOpenGames.sort((a, b) =>
+      compareAffinity(
+        connected.has(a.item.hostUserId),
+        connected.has(b.item.hostUserId),
+        a.item.window.start,
+        b.item.window.start,
+      ),
+    );
+
+    let viewerLooking: PublicOwnLooking | null = null;
+    if (input.userId) {
+      const own = await this.lobby.findLookingByUserId(input.userId);
+      if (own && own.isActive(now)) {
+        viewerLooking = {
+          id: own.id,
+          firstName: await resolveFirstName(this.profiles, own.userId),
+          sport: own.sport.value,
+          windowStart: own.window.start.toISOString(),
+          windowEnd: own.window.end.toISOString(),
+          city: own.city.value,
+          area: own.area?.value ?? null,
+          partySize: own.partySize.value,
+          skill: own.skill?.value ?? null,
+          venueCmsId: own.venueCmsId,
+          expiresAt: own.expiresAt.toISOString(),
+        };
+      }
+    }
+
+    return {
+      lookings: publicLookings.map((row) => row.public),
+      openGames: publicOpenGames.map((row) => row.public),
+      viewer: { looking: viewerLooking },
+    };
+  }
+
+  private async connectedUserIds(userId: string): Promise<Set<string>> {
+    const ids = new Set<string>();
+    const friendships = await this.friendships.listForUser(userId);
+    for (const row of friendships) {
+      if (row.status !== "accepted") continue;
+      ids.add(row.requesterId === userId ? row.addresseeId : row.requesterId);
+    }
+    const teams = await this.teams.listForUser(userId);
+    for (const team of teams) {
+      for (const member of team.members) {
+        if (member.status.isActive && member.userId !== userId) {
+          ids.add(member.userId);
+        }
+      }
+    }
+    return ids;
+  }
+}
+
+function compareAffinity(
+  aConnected: boolean,
+  bConnected: boolean,
+  aStart: Date,
+  bStart: Date,
+): number {
+  if (aConnected !== bConnected) return aConnected ? -1 : 1;
+  return aStart.getTime() - bStart.getTime();
+}
+
+export class SetLooking {
+  constructor(
+    private readonly lobby: LobbyRepository,
+    private readonly profiles: FriendProfileLookup,
+    private readonly notifier: LobbyNotifier | undefined,
+    private readonly converter: LobbyOrganiseConverter,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    sport: unknown;
+    windowStart: unknown;
+    windowEnd: unknown;
+    city: unknown;
+    area?: unknown;
+    venueCmsId?: unknown;
+    partySizeWithMe?: unknown;
+    skill?: unknown;
+    now?: Date;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const now = input.now ?? new Date();
+    const looking = LobbyLooking.create({
+      userId,
+      sport: LobbySport.from(input.sport),
+      window: TimeWindow.from(input.windowStart, input.windowEnd),
+      city: City.from(input.city),
+      area: Area.from(input.area),
+      venueCmsId: optionalVenue(input.venueCmsId),
+      partySize: PartySize.from(input.partySizeWithMe),
+      skill: LobbySkill.from(input.skill),
+      now,
+    });
+
+    await cancelPendingProposalsForUser(this.lobby, userId, now);
+    const saved = await this.lobby.upsertLooking(looking);
+    await notifyCompatibleOpenGames(this.lobby, this.notifier, saved, now);
+    const proposals = await evaluateLookingProposals(
+      this.lobby,
+      this.notifier,
+      this.profiles,
+      saved,
+      now,
+    );
+
+    return {
+      looking: await toOwnLooking(saved, this.profiles),
+      proposals: await Promise.all(
+        proposals.map((proposal) =>
+          toPublicProposal(proposal, this.profiles, userId),
+        ),
+      ),
+    };
+  }
+}
+
+export class ClearLooking {
+  constructor(private readonly lobby: LobbyRepository) {}
+
+  async execute(input: { userId: string; now?: Date }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const now = input.now ?? new Date();
+    await cancelPendingProposalsForUser(this.lobby, userId, now);
+    const deleted = await this.lobby.deleteLookingByUserId(userId);
+    return { ok: true as const, cleared: deleted };
+  }
+}
+
+export class CreateOpenGame {
+  constructor(
+    private readonly lobby: LobbyRepository,
+    private readonly profiles: FriendProfileLookup,
+    private readonly notifier: LobbyNotifier | undefined,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    sport: unknown;
+    windowStart: unknown;
+    windowEnd: unknown;
+    city: unknown;
+    area?: unknown;
+    venueCmsId?: unknown;
+    slotsNeeded?: unknown;
+    partySizeWithMe?: unknown;
+    skill?: unknown;
+    now?: Date;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const now = input.now ?? new Date();
+    const game = LobbyOpenGame.create({
+      hostUserId: userId,
+      sport: LobbySport.from(input.sport),
+      window: TimeWindow.from(input.windowStart, input.windowEnd),
+      city: City.from(input.city),
+      area: Area.from(input.area),
+      venueCmsId: optionalVenue(input.venueCmsId),
+      slotsNeeded:
+        input.slotsNeeded == null ? undefined : Number(input.slotsNeeded),
+      hostPartySize: PartySize.from(input.partySizeWithMe),
+      skill: LobbySkill.from(input.skill),
+      now,
+    });
+
+    const saved = await this.lobby.createOpenGame(game);
+    await notifyCompatibleLookings(this.lobby, this.notifier, saved, now);
+    return { openGame: await toOwnOpenGame(saved, this.profiles) };
+  }
+}
+
+export class JoinOpenGame {
+  constructor(
+    private readonly lobby: LobbyRepository,
+    private readonly profiles: FriendProfileLookup,
+    private readonly notifier: LobbyNotifier | undefined,
+    private readonly converter: LobbyOrganiseConverter,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    openGameId: string;
+    partySizeWithMe?: unknown;
+    now?: Date;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const now = input.now ?? new Date();
+    const game = await this.lobby.findOpenGameById(input.openGameId.trim());
+    if (!game) throw new LobbyNotFoundError("Open game not found");
+
+    game.join(userId, PartySize.from(input.partySizeWithMe), now);
+    let conversionBlocked: string | null = null;
+    if (game.status.isFilled) {
+      const result = await convertOpenGame(this.converter, game);
+      conversionBlocked = applyConversion(game, result);
+    }
+
+    const saved = await this.lobby.persistOpenGame(game);
+    await this.notifier?.notify({
+      recipientId: saved.hostUserId,
+      actorId: userId,
+      type: "lobby_open_game_joined",
+      resourceId: `${saved.id}:${userId}`,
+      sport: saved.sport.value,
+      city: saved.city.value,
+      windowStart: saved.window.start.toISOString(),
+      windowEnd: saved.window.end.toISOString(),
+      openGameId: saved.id,
+      organiseGameId: saved.organiseGameId,
+    });
+    if (saved.status.isFilled) {
+      await notifyFilled(this.notifier, saved, userId);
+    }
+
+    return {
+      openGame: await toOwnOpenGame(saved, this.profiles, conversionBlocked),
+    };
+  }
+}
+
+export class KickOpenGame {
+  constructor(
+    private readonly lobby: LobbyRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    openGameId: string;
+    targetUserId: unknown;
+    now?: Date;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const now = input.now ?? new Date();
+    const game = await this.lobby.findOpenGameById(input.openGameId.trim());
+    if (!game) throw new LobbyNotFoundError("Open game not found");
+    game.kick(userId, requiredTrimmed(input.targetUserId, "userId"), now);
+    const saved = await this.lobby.persistOpenGame(game);
+    return { openGame: await toOwnOpenGame(saved, this.profiles) };
+  }
+}
+
+export class ListMyProposals {
+  constructor(
+    private readonly lobby: LobbyRepository,
+    private readonly profiles: FriendProfileLookup,
+  ) {}
+
+  async execute(input: { userId: string }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const proposals = await this.lobby.listProposalsForUser(userId);
+    return {
+      proposals: await Promise.all(
+        proposals.map((proposal) =>
+          toPublicProposal(proposal, this.profiles, userId),
+        ),
+      ),
+    };
+  }
+}
+
+export class RespondToProposal {
+  constructor(
+    private readonly lobby: LobbyRepository,
+    private readonly profiles: FriendProfileLookup,
+    private readonly notifier: LobbyNotifier | undefined,
+    private readonly converter: LobbyOrganiseConverter,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    proposalId: string;
+    decision: "accept" | "pass";
+    now?: Date;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const now = input.now ?? new Date();
+    const proposal = await this.lobby.findProposalById(input.proposalId.trim());
+    if (!proposal) throw new LobbyNotFoundError("Proposal not found");
+    if (!proposal.isMember(userId)) {
+      throw new LobbyForbiddenError("Only a proposal member can respond");
+    }
+
+    if (input.decision === "accept") proposal.accept(userId, now);
+    else proposal.pass(userId, now);
+
+    let conversionBlocked: string | null = null;
+    if (proposal.isReadyToConvert() || proposal.status.isAccepted) {
+      const result = await convertProposal(this.converter, proposal);
+      conversionBlocked = applyProposalConversion(proposal, result);
+      if (proposal.organiseGameId) {
+        await notifyProposalConverted(this.notifier, proposal, userId);
+        await clearLookingsForProposal(this.lobby, proposal);
+      }
+    }
+
+    const saved = await this.lobby.persistProposal(proposal);
+    return {
+      proposal: await toPublicProposal(
+        saved,
+        this.profiles,
+        userId,
+        conversionBlocked,
+      ),
+    };
+  }
+}
+
+async function toOwnLooking(
+  looking: LobbyLooking,
+  profiles: FriendProfileLookup,
+): Promise<PublicOwnLooking> {
+  return {
+    id: looking.id,
+    firstName: await resolveFirstName(profiles, looking.userId),
+    sport: looking.sport.value,
+    windowStart: looking.window.start.toISOString(),
+    windowEnd: looking.window.end.toISOString(),
+    city: looking.city.value,
+    area: looking.area?.value ?? null,
+    partySize: looking.partySize.value,
+    skill: looking.skill?.value ?? null,
+    venueCmsId: looking.venueCmsId,
+    expiresAt: looking.expiresAt.toISOString(),
+  };
+}
+
+async function toOwnOpenGame(
+  game: LobbyOpenGame,
+  profiles: FriendProfileLookup,
+  conversionBlocked: string | null = null,
+): Promise<PublicOwnOpenGame> {
+  return {
+    id: game.id,
+    firstName: await resolveFirstName(profiles, game.hostUserId),
+    sport: game.sport.value,
+    windowStart: game.window.start.toISOString(),
+    windowEnd: game.window.end.toISOString(),
+    city: game.city.value,
+    area: game.area?.value ?? null,
+    slotsNeeded: game.slotsNeeded,
+    slotsFilled: game.slotsFilled(),
+    slotsRemaining: game.remainingSlots(),
+    status: game.status.value,
+    venueCmsId: game.venueCmsId,
+    skill: game.skill?.value ?? null,
+    organiseGameId: game.organiseGameId,
+    source: "lobby",
+    conversionBlocked,
+  };
+}
+
+async function toPublicProposal(
+  proposal: LobbyProposal,
+  profiles: FriendProfileLookup,
+  viewerUserId: string,
+  conversionBlocked: string | null = null,
+): Promise<PublicProposal> {
+  const members: PublicProposalMember[] = [];
+  for (const member of proposal.members) {
+    members.push({
+      firstName: await resolveFirstName(profiles, member.userId),
+      partySize: member.partySize.value,
+      response: member.response.value,
+      isYou: member.userId === viewerUserId,
+    });
+  }
+  return {
+    id: proposal.id,
+    sport: proposal.sport.value,
+    city: proposal.city.value,
+    area: proposal.area?.value ?? null,
+    windowStart: proposal.window.start.toISOString(),
+    windowEnd: proposal.window.end.toISOString(),
+    status: proposal.status.value,
+    organiseGameId: proposal.organiseGameId,
+    source: "lobby",
+    conversionBlocked,
+    members,
+  };
+}
+
+async function cancelPendingProposalsForUser(
+  lobby: LobbyRepository,
+  userId: string,
+  now: Date,
+): Promise<void> {
+  const proposals = await lobby.listProposalsForUser(userId);
+  for (const proposal of proposals) {
+    if (!proposal.status.isPending) continue;
+    proposal.cancel(now);
+    await lobby.persistProposal(proposal);
+  }
+}
+
+async function notifyCompatibleOpenGames(
+  lobby: LobbyRepository,
+  notifier: LobbyNotifier | undefined,
+  looking: LobbyLooking,
+  now: Date,
+): Promise<void> {
+  if (!notifier) return;
+  const games = await lobby.listActiveOpenGames({
+    sport: looking.sport.value,
+    city: looking.city.value,
+    now,
+  });
+  for (const game of games) {
+    if (!game.window.overlaps(looking.window)) continue;
+    if (game.remainingSlots() < looking.partySize.value) continue;
+    if (game.memberOf(looking.userId)) continue;
+    await notifier.notify({
+      recipientId: looking.userId,
+      actorId: game.hostUserId,
+      type: "lobby_open_game_compatible",
+      resourceId: game.id,
+      sport: game.sport.value,
+      city: game.city.value,
+      windowStart: game.window.start.toISOString(),
+      windowEnd: game.window.end.toISOString(),
+      openGameId: game.id,
+    });
+  }
+}
+
+async function notifyCompatibleLookings(
+  lobby: LobbyRepository,
+  notifier: LobbyNotifier | undefined,
+  game: LobbyOpenGame,
+  now: Date,
+): Promise<void> {
+  if (!notifier) return;
+  const lookings = await lobby.listActiveLookings({
+    sport: game.sport.value,
+    city: game.city.value,
+    now,
+  });
+  for (const looking of lookings) {
+    if (!game.window.overlaps(looking.window)) continue;
+    if (game.remainingSlots() < looking.partySize.value) continue;
+    if (game.memberOf(looking.userId)) continue;
+    await notifier.notify({
+      recipientId: looking.userId,
+      actorId: game.hostUserId,
+      type: "lobby_open_game_compatible",
+      resourceId: game.id,
+      sport: game.sport.value,
+      city: game.city.value,
+      windowStart: game.window.start.toISOString(),
+      windowEnd: game.window.end.toISOString(),
+      openGameId: game.id,
+    });
+  }
+}
+
+async function notifyFilled(
+  notifier: LobbyNotifier | undefined,
+  game: LobbyOpenGame,
+  actorId: string,
+): Promise<void> {
+  if (!notifier) return;
+  for (const member of game.members) {
+    await notifier.notify({
+      recipientId: member.userId,
+      actorId,
+      type: "lobby_open_game_filled",
+      resourceId: game.id,
+      sport: game.sport.value,
+      city: game.city.value,
+      windowStart: game.window.start.toISOString(),
+      windowEnd: game.window.end.toISOString(),
+      openGameId: game.id,
+      organiseGameId: game.organiseGameId,
+    });
+  }
+}
+
+async function notifyProposalReady(
+  notifier: LobbyNotifier | undefined,
+  proposal: LobbyProposal,
+): Promise<void> {
+  if (!notifier) return;
+  const actorId = proposal.organizerUserId();
+  for (const member of proposal.members) {
+    await notifier.notify({
+      recipientId: member.userId,
+      actorId,
+      type: "lobby_proposal_ready",
+      resourceId: proposal.id,
+      sport: proposal.sport.value,
+      city: proposal.city.value,
+      windowStart: proposal.window.start.toISOString(),
+      windowEnd: proposal.window.end.toISOString(),
+      proposalId: proposal.id,
+    });
+  }
+}
+
+async function notifyProposalConverted(
+  notifier: LobbyNotifier | undefined,
+  proposal: LobbyProposal,
+  actorId: string,
+): Promise<void> {
+  if (!notifier) return;
+  for (const member of proposal.members) {
+    if (!member.response.isAccept) continue;
+    await notifier.notify({
+      recipientId: member.userId,
+      actorId,
+      type: "lobby_proposal_ready",
+      resourceId: `${proposal.id}:converted`,
+      sport: proposal.sport.value,
+      city: proposal.city.value,
+      windowStart: proposal.window.start.toISOString(),
+      windowEnd: proposal.window.end.toISOString(),
+      proposalId: proposal.id,
+      organiseGameId: proposal.organiseGameId,
+    });
+  }
+}
+
+async function evaluateLookingProposals(
+  lobby: LobbyRepository,
+  notifier: LobbyNotifier | undefined,
+  _profiles: FriendProfileLookup,
+  seed: LobbyLooking,
+  now: Date,
+): Promise<LobbyProposal[]> {
+  const created: LobbyProposal[] = [];
+  const lookings = await lobby.listActiveLookings({
+    sport: seed.sport.value,
+    city: seed.city.value,
+    now,
+  });
+  const pending = await lobby.listPendingProposals({
+    sport: seed.sport.value,
+    city: seed.city.value,
+    now,
+  });
+  const busy = new Set<string>();
+  for (const proposal of pending) {
+    for (const member of proposal.members) busy.add(member.userId);
+  }
+  const openGames = await lobby.listActiveOpenGames({
+    sport: seed.sport.value,
+    now,
+  });
+  for (const game of openGames) {
+    for (const member of game.members) busy.add(member.userId);
+  }
+
+  const available = lookings.filter((looking) => !busy.has(looking.userId));
+  const unused = [...available].sort(
+    (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+  );
+
+  while (unused.length >= 2) {
+    const pack = takePack(unused, seed.sport);
+    if (!pack) {
+      unused.shift();
+      continue;
+    }
+    const window = intersectionOf(pack.map((item) => item.window));
+    if (!window) {
+      unused.shift();
+      continue;
+    }
+    const venueCmsId =
+      pack.find((item) => item.venueCmsId)?.venueCmsId ?? null;
+    const proposal = LobbyProposal.create({
+      sport: seed.sport,
+      city: seed.city,
+      area: pack.find((item) => item.area)?.area ?? null,
+      window,
+      venueCmsId,
+      skill: pack.find((item) => item.skill)?.skill ?? null,
+      members: pack.map((item) => ({
+        userId: item.userId,
+        partySize: item.partySize,
+        lookingId: item.id,
+      })),
+      now,
+    });
+    const saved = await lobby.createProposal(proposal);
+    await notifyProposalReady(notifier, saved);
+    created.push(saved);
+    const packedIds = new Set(pack.map((item) => item.id));
+    for (let i = unused.length - 1; i >= 0; i -= 1) {
+      if (packedIds.has(unused[i].id)) unused.splice(i, 1);
+    }
+  }
+
+  return created;
+}
+
+function takePack(
+  unused: LobbyLooking[],
+  sport: LobbySport,
+): LobbyLooking[] | null {
+  if (unused.length === 0) return null;
+  const seed = unused[0];
+  const pack = [seed];
+  let slots = seed.partySize.value;
+  for (let i = 1; i < unused.length; i += 1) {
+    const candidate = unused[i];
+    const next = slots + candidate.partySize.value;
+    if (next > sport.maxSlots()) continue;
+    const window = intersectionOf([...pack, candidate].map((item) => item.window));
+    if (!window) continue;
+    pack.push(candidate);
+    slots = next;
+    if (slots === sport.maxSlots()) break;
+  }
+  if (slots < sport.minSlots()) return null;
+  return pack;
+}
+
+function intersectionOf(windows: TimeWindow[]): TimeWindow | null {
+  let current: TimeWindow | null = windows[0] ?? null;
+  for (let i = 1; i < windows.length; i += 1) {
+    if (!current) return null;
+    current = current.intersection(windows[i]);
+  }
+  return current;
+}
+
+async function convertOpenGame(
+  converter: LobbyOrganiseConverter,
+  game: LobbyOpenGame,
+): Promise<ConversionResult> {
+  const inviteUserIds = game.members
+    .filter((member) => member.userId !== game.hostUserId)
+    .map((member) => member.userId);
+  return converter.convert({
+    hostUserId: game.hostUserId,
+    inviteUserIds,
+    sport: game.sport,
+    venueCmsId: game.venueCmsId,
+    startsAt: game.window.start,
+    capacity: game.slotsNeeded,
+    notes: organiseNotes("openGame", game.id),
+  });
+}
+
+async function convertProposal(
+  converter: LobbyOrganiseConverter,
+  proposal: LobbyProposal,
+): Promise<ConversionResult> {
+  const accepted = proposal.members.filter((member) => member.response.isAccept);
+  const hostUserId = accepted[0]?.userId ?? proposal.organizerUserId();
+  return converter.convert({
+    hostUserId,
+    inviteUserIds: accepted
+      .map((member) => member.userId)
+      .filter((id) => id !== hostUserId),
+    sport: proposal.sport,
+    venueCmsId: proposal.venueCmsId,
+    startsAt: proposal.window.start,
+    capacity: Math.max(proposal.acceptedSlots(), proposal.sport.minSlots()),
+    notes: organiseNotes("proposal", proposal.id),
+  });
+}
+
+function applyConversion(
+  game: LobbyOpenGame,
+  result: ConversionResult,
+): string | null {
+  if ("organiseGameId" in result) {
+    game.linkOrganisedGame(result.organiseGameId);
+    return null;
+  }
+  return result.blocked;
+}
+
+function applyProposalConversion(
+  proposal: LobbyProposal,
+  result: ConversionResult,
+): string | null {
+  if ("organiseGameId" in result) {
+    proposal.linkOrganisedGame(result.organiseGameId);
+    return null;
+  }
+  return result.blocked;
+}
+
+async function clearLookingsForProposal(
+  lobby: LobbyRepository,
+  proposal: LobbyProposal,
+): Promise<void> {
+  for (const member of proposal.members) {
+    if (!member.response.isAccept) continue;
+    await lobby.deleteLookingByUserId(member.userId);
+  }
+}

--- a/src/modules/notifications/entities/lobby-notification-payload.ts
+++ b/src/modules/notifications/entities/lobby-notification-payload.ts
@@ -1,0 +1,97 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const SPORTS = ["padel", "darts", "golf"] as const;
+export type LobbyNotificationSport = (typeof SPORTS)[number];
+
+export type LobbyNotificationPayloadSnapshot = {
+  source: "lobby";
+  sport: LobbyNotificationSport;
+  city: string;
+  windowStart: string;
+  windowEnd: string;
+  openGameId: string | null;
+  proposalId: string | null;
+  organiseGameId: string | null;
+};
+
+export class LobbyNotificationPayload {
+  private constructor(
+    readonly sport: LobbyNotificationSport,
+    readonly city: string,
+    readonly windowStart: Date,
+    readonly windowEnd: Date,
+    readonly openGameId: string | null,
+    readonly proposalId: string | null,
+    readonly organiseGameId: string | null,
+  ) {}
+
+  static from(raw: unknown): LobbyNotificationPayload {
+    if (!raw || typeof raw !== "object") {
+      throw new DomainError("notification payload is required");
+    }
+
+    const record = raw as Record<string, unknown>;
+    const sport = parseSport(record.sport);
+    const city = requiredTrimmed(record.city, "city");
+    const windowStart = parseDate(record.windowStart, "windowStart");
+    const windowEnd = parseDate(record.windowEnd, "windowEnd");
+
+    return new LobbyNotificationPayload(
+      sport,
+      city,
+      windowStart,
+      windowEnd,
+      parseOptionalId(record.openGameId, "openGameId"),
+      parseOptionalId(record.proposalId, "proposalId"),
+      parseOptionalId(record.organiseGameId, "organiseGameId"),
+    );
+  }
+
+  toSnapshot(): LobbyNotificationPayloadSnapshot {
+    return {
+      source: "lobby",
+      sport: this.sport,
+      city: this.city,
+      windowStart: this.windowStart.toISOString(),
+      windowEnd: this.windowEnd.toISOString(),
+      openGameId: this.openGameId,
+      proposalId: this.proposalId,
+      organiseGameId: this.organiseGameId,
+    };
+  }
+}
+
+function parseSport(raw: unknown): LobbyNotificationSport {
+  if (typeof raw !== "string") {
+    throw new DomainError("sport must be padel, darts, or golf");
+  }
+  const sport = raw.trim().toLowerCase();
+  if (sport === "padel" || sport === "darts" || sport === "golf") return sport;
+  throw new DomainError("sport must be padel, darts, or golf");
+}
+
+function parseDate(raw: unknown, field: string): Date {
+  if (raw instanceof Date) {
+    if (Number.isNaN(raw.getTime())) {
+      throw new DomainError(`${field} must be a valid date`);
+    }
+    return raw;
+  }
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new DomainError(`${field} is required`);
+  }
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new DomainError(`${field} must be a valid date`);
+  }
+  return parsed;
+}
+
+function parseOptionalId(raw: unknown, field: string): string | null {
+  if (raw == null) return null;
+  if (typeof raw !== "string") {
+    throw new DomainError(`${field} must be a string`);
+  }
+  const value = raw.trim();
+  return value.length === 0 ? null : value;
+}

--- a/src/modules/notifications/entities/notification-type.ts
+++ b/src/modules/notifications/entities/notification-type.ts
@@ -1,11 +1,29 @@
 import { DomainError } from "../../../lib/domain-error";
 
-export const NOTIFICATION_TYPES = ["organised_game_invite"] as const;
+export const NOTIFICATION_TYPES = [
+  "organised_game_invite",
+  "lobby_open_game_compatible",
+  "lobby_proposal_ready",
+  "lobby_open_game_joined",
+  "lobby_open_game_filled",
+] as const;
 export type NotificationTypeValue = (typeof NOTIFICATION_TYPES)[number];
 
 export class NotificationType {
   static readonly ORGANISED_GAME_INVITE = new NotificationType(
     "organised_game_invite",
+  );
+  static readonly LOBBY_OPEN_GAME_COMPATIBLE = new NotificationType(
+    "lobby_open_game_compatible",
+  );
+  static readonly LOBBY_PROPOSAL_READY = new NotificationType(
+    "lobby_proposal_ready",
+  );
+  static readonly LOBBY_OPEN_GAME_JOINED = new NotificationType(
+    "lobby_open_game_joined",
+  );
+  static readonly LOBBY_OPEN_GAME_FILLED = new NotificationType(
+    "lobby_open_game_filled",
   );
 
   private constructor(readonly value: NotificationTypeValue) {}
@@ -16,15 +34,28 @@ export class NotificationType {
     }
 
     const type = raw.trim().toLowerCase();
-    if (type === "organised_game_invite") {
-      return NotificationType.ORGANISED_GAME_INVITE;
+    switch (type) {
+      case "organised_game_invite":
+        return NotificationType.ORGANISED_GAME_INVITE;
+      case "lobby_open_game_compatible":
+        return NotificationType.LOBBY_OPEN_GAME_COMPATIBLE;
+      case "lobby_proposal_ready":
+        return NotificationType.LOBBY_PROPOSAL_READY;
+      case "lobby_open_game_joined":
+        return NotificationType.LOBBY_OPEN_GAME_JOINED;
+      case "lobby_open_game_filled":
+        return NotificationType.LOBBY_OPEN_GAME_FILLED;
+      default:
+        throw new DomainError("Unknown notification type");
     }
-
-    throw new DomainError("Unknown notification type");
   }
 
   get isOrganisedGameInvite(): boolean {
     return this.value === "organised_game_invite";
+  }
+
+  get isLobby(): boolean {
+    return this.value.startsWith("lobby_");
   }
 
   equals(other: NotificationType): boolean {

--- a/src/modules/notifications/entities/notification.test.ts
+++ b/src/modules/notifications/entities/notification.test.ts
@@ -1,4 +1,5 @@
 import { Notification } from "./notification";
+import { NotificationType } from "./notification-type";
 import { OrganisedGameInvitePayload } from "./organised-game-invite-payload";
 
 describe("Notification", () => {
@@ -50,6 +51,35 @@ describe("Notification", () => {
 
     const restored = Notification.fromSnapshot(notification.toSnapshot());
     expect(restored.toSnapshot()).toEqual(notification.toSnapshot());
+  });
+
+  test("lobby notice round-trips and cannot notify the actor", () => {
+    const notification = Notification.lobby({
+      recipientId: "seeker-1",
+      actorId: "host-1",
+      type: NotificationType.LOBBY_PROPOSAL_READY,
+      resourceId: "proposal-1",
+      sport: "darts",
+      city: "Cape Town",
+      windowStart: "2026-09-08T16:00:00.000Z",
+      windowEnd: "2026-09-08T18:00:00.000Z",
+      proposalId: "proposal-1",
+    });
+
+    expect(notification.type.value).toBe("lobby_proposal_ready");
+    expect(notification.toSnapshot().payload).toEqual({
+      source: "lobby",
+      sport: "darts",
+      city: "Cape Town",
+      windowStart: "2026-09-08T16:00:00.000Z",
+      windowEnd: "2026-09-08T18:00:00.000Z",
+      openGameId: null,
+      proposalId: "proposal-1",
+      organiseGameId: null,
+    });
+    expect(
+      Notification.fromSnapshot(notification.toSnapshot()).toSnapshot(),
+    ).toEqual(notification.toSnapshot());
   });
 
   test("payload rejects unknown sport", () => {

--- a/src/modules/notifications/entities/notification.ts
+++ b/src/modules/notifications/entities/notification.ts
@@ -2,18 +2,28 @@ import { randomUUID } from "node:crypto";
 
 import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
 import {
+  LobbyNotificationPayload,
+  LobbyNotificationPayloadSnapshot,
+} from "./lobby-notification-payload";
+import {
   OrganisedGameInvitePayload,
   OrganisedGameInvitePayloadSnapshot,
 } from "./organised-game-invite-payload";
-import { NotificationType } from "./notification-type";
+import { NotificationType, NotificationTypeValue } from "./notification-type";
+
+export type NotificationPayload =
+  | OrganisedGameInvitePayload
+  | LobbyNotificationPayload;
 
 export type NotificationSnapshot = {
   id: string;
   recipientId: string;
   actorId: string;
-  type: "organised_game_invite";
+  type: NotificationTypeValue;
   resourceId: string;
-  payload: OrganisedGameInvitePayloadSnapshot;
+  payload:
+    | OrganisedGameInvitePayloadSnapshot
+    | LobbyNotificationPayloadSnapshot;
   readAt: string | null;
   createdAt: string;
 };
@@ -27,6 +37,20 @@ export type CreateOrganisedGameInviteNotificationProps = {
   venueCmsId?: unknown;
 };
 
+export type CreateLobbyNotificationProps = {
+  recipientId: string;
+  actorId: string;
+  type: NotificationType;
+  resourceId: string;
+  sport: unknown;
+  city: unknown;
+  windowStart: unknown;
+  windowEnd: unknown;
+  openGameId?: unknown;
+  proposalId?: unknown;
+  organiseGameId?: unknown;
+};
+
 export class Notification {
   private constructor(
     readonly id: string,
@@ -34,7 +58,7 @@ export class Notification {
     readonly actorId: string,
     readonly type: NotificationType,
     readonly resourceId: string,
-    readonly payload: OrganisedGameInvitePayload,
+    readonly payload: NotificationPayload,
     readonly createdAt: Date,
     private readAtValue: Date | null,
   ) {}
@@ -67,13 +91,46 @@ export class Notification {
     );
   }
 
+  static lobby(props: CreateLobbyNotificationProps): Notification {
+    const recipientId = requiredTrimmed(props.recipientId, "recipientId");
+    const actorId = requiredTrimmed(props.actorId, "actorId");
+    if (recipientId === actorId) {
+      throw new DomainError("Cannot notify the actor");
+    }
+    if (!props.type.isLobby) {
+      throw new DomainError("notification type must be a lobby type");
+    }
+
+    const payload = LobbyNotificationPayload.from({
+      source: "lobby",
+      sport: props.sport,
+      city: props.city,
+      windowStart: props.windowStart,
+      windowEnd: props.windowEnd,
+      openGameId: props.openGameId,
+      proposalId: props.proposalId,
+      organiseGameId: props.organiseGameId,
+    });
+
+    return new Notification(
+      randomUUID(),
+      recipientId,
+      actorId,
+      props.type,
+      requiredTrimmed(props.resourceId, "resourceId"),
+      payload,
+      new Date(),
+      null,
+    );
+  }
+
   static rehydrate(props: {
     id: string;
     recipientId: string;
     actorId: string;
     type: NotificationType;
     resourceId: string;
-    payload: OrganisedGameInvitePayload;
+    payload: NotificationPayload;
     createdAt: Date;
     readAt: Date | null;
   }): Notification {
@@ -90,13 +147,14 @@ export class Notification {
   }
 
   static fromSnapshot(snapshot: NotificationSnapshot): Notification {
+    const type = NotificationType.from(snapshot.type);
     return Notification.rehydrate({
       id: snapshot.id,
       recipientId: snapshot.recipientId,
       actorId: snapshot.actorId,
-      type: NotificationType.from(snapshot.type),
+      type,
       resourceId: snapshot.resourceId,
-      payload: OrganisedGameInvitePayload.from(snapshot.payload),
+      payload: payloadFromSnapshot(type, snapshot.payload),
       createdAt: new Date(snapshot.createdAt),
       readAt: snapshot.readAt ? new Date(snapshot.readAt) : null,
     });
@@ -127,4 +185,14 @@ export class Notification {
       createdAt: this.createdAt.toISOString(),
     };
   }
+}
+
+export function payloadFromSnapshot(
+  type: NotificationType,
+  raw: unknown,
+): NotificationPayload {
+  if (type.isOrganisedGameInvite) {
+    return OrganisedGameInvitePayload.from(raw);
+  }
+  return LobbyNotificationPayload.from(raw);
 }

--- a/src/modules/notifications/index.ts
+++ b/src/modules/notifications/index.ts
@@ -13,8 +13,10 @@ import { PrismaNotificationRepository } from "./repositories/prisma-notification
 import { createNotificationsRoutes } from "./routes/notifications.routes";
 import {
   ListMyNotifications,
+  LobbyNotifier,
   MarkAllNotificationsRead,
   MarkNotificationRead,
+  NotifyLobby,
   NotifyOrganisedGameInvite,
   OrganisedGameInviteNotifier,
 } from "./services/notifications.service";
@@ -31,6 +33,7 @@ export type NotificationsModule = {
   router: Router;
   notificationRepository: NotificationRepository;
   organisedGameInviteNotifier: OrganisedGameInviteNotifier;
+  lobbyNotifier: LobbyNotifier;
 };
 
 export function createNotificationsModule({
@@ -46,6 +49,7 @@ export function createNotificationsModule({
   const organisedGameInviteNotifier = new NotifyOrganisedGameInvite(
     notificationRepository,
   );
+  const lobbyNotifier = new NotifyLobby(notificationRepository);
 
   const controller = createNotificationsController({
     listMyNotifications: new ListMyNotifications(
@@ -66,6 +70,7 @@ export function createNotificationsModule({
     router: createNotificationsRoutes(controller, { requireAuth }),
     notificationRepository,
     organisedGameInviteNotifier,
+    lobbyNotifier,
   };
 }
 
@@ -76,17 +81,22 @@ export type { NotificationRepository } from "./repositories/notification.reposit
 export { Notification } from "./entities/notification";
 export { NotificationType } from "./entities/notification-type";
 export { OrganisedGameInvitePayload } from "./entities/organised-game-invite-payload";
+export { LobbyNotificationPayload } from "./entities/lobby-notification-payload";
 export { NotificationNotFoundError } from "./entities/notification-not-found-error";
 export { NotificationPersistenceError } from "./entities/notification-persistence-error";
 export {
   ListMyNotifications,
   MarkAllNotificationsRead,
   MarkNotificationRead,
+  NotifyLobby,
   NotifyOrganisedGameInvite,
 } from "./services/notifications.service";
 export type {
+  LobbyNotice,
+  LobbyNotifier,
   OrganisedGameInviteNotice,
   OrganisedGameInviteNotifier,
+  PublicLobbyNotificationPayload,
   PublicNotification,
   PublicNotificationActor,
   PublicOrganisedGameInvitePayload,

--- a/src/modules/notifications/repositories/prisma-notification.repository.ts
+++ b/src/modules/notifications/repositories/prisma-notification.repository.ts
@@ -1,8 +1,10 @@
 import { Prisma, PrismaClient } from "../../../generated/prisma/client";
-import { Notification } from "../entities/notification";
+import { Notification, payloadFromSnapshot } from "../entities/notification";
 import { NotificationPersistenceError } from "../entities/notification-persistence-error";
-import { NotificationType } from "../entities/notification-type";
-import { OrganisedGameInvitePayload } from "../entities/organised-game-invite-payload";
+import {
+  NotificationType,
+  NotificationTypeValue,
+} from "../entities/notification-type";
 import {
   NotificationListPage,
   NotificationListQuery,
@@ -13,7 +15,7 @@ type NotificationRow = {
   id: string;
   recipientId: string;
   actorId: string;
-  type: "organised_game_invite";
+  type: NotificationTypeValue;
   resourceId: string;
   payload: Prisma.JsonValue;
   readAt: Date | null;
@@ -34,7 +36,7 @@ function toDomain(row: NotificationRow): Notification {
     actorId: row.actorId,
     type: NotificationType.from(row.type),
     resourceId: row.resourceId,
-    payload: OrganisedGameInvitePayload.from(row.payload),
+    payload: payloadFromSnapshot(NotificationType.from(row.type), row.payload),
     createdAt: row.createdAt,
     readAt: row.readAt,
   });
@@ -192,7 +194,7 @@ export class PrismaNotificationRepository implements NotificationRepository {
 
   private async findByUnique(
     recipientId: string,
-    type: "organised_game_invite",
+    type: NotificationTypeValue,
     resourceId: string,
   ): Promise<Notification | null> {
     const row = await this.prisma.notification.findUnique({

--- a/src/modules/notifications/services/notifications.service.test.ts
+++ b/src/modules/notifications/services/notifications.service.test.ts
@@ -141,9 +141,11 @@ describe("notifications application", () => {
 
     const firstPage = await list.execute({ userId: "friend-a", limit: 2 });
     expect(firstPage.unreadCount).toBe(2);
-    expect(firstPage.notifications.map((row) => row.payload.organisedGameId)).toEqual(
-      ["game-mid", "game-new"],
-    );
+    expect(
+      firstPage.notifications.map((row) =>
+        "organisedGameId" in row.payload ? row.payload.organisedGameId : null,
+      ),
+    ).toEqual(["game-mid", "game-new"]);
     expect(firstPage.notifications.every((row) => row.readAt == null)).toBe(true);
     expect(firstPage.nextCursor).toEqual(expect.any(String));
 

--- a/src/modules/notifications/services/notifications.service.ts
+++ b/src/modules/notifications/services/notifications.service.ts
@@ -25,11 +25,27 @@ export type PublicOrganisedGameInvitePayload = {
   venueCmsId: string | null;
 };
 
+export type PublicLobbyNotificationPayload = {
+  source: "lobby";
+  sport: "padel" | "darts" | "golf";
+  city: string;
+  windowStart: string;
+  windowEnd: string;
+  openGameId: string | null;
+  proposalId: string | null;
+  organiseGameId: string | null;
+};
+
 export type PublicNotification = {
   id: string;
-  type: "organised_game_invite";
+  type:
+    | "organised_game_invite"
+    | "lobby_open_game_compatible"
+    | "lobby_proposal_ready"
+    | "lobby_open_game_joined"
+    | "lobby_open_game_filled";
   actor: PublicNotificationActor;
-  payload: PublicOrganisedGameInvitePayload;
+  payload: PublicOrganisedGameInvitePayload | PublicLobbyNotificationPayload;
   readAt: string | null;
   createdAt: string;
 };
@@ -49,6 +65,28 @@ export interface OrganisedGameInviteNotifier {
     recipientId: string;
     organisedGameId: string;
   }): Promise<void>;
+}
+
+export type LobbyNotice = {
+  recipientId: string;
+  actorId: string;
+  type:
+    | "lobby_open_game_compatible"
+    | "lobby_proposal_ready"
+    | "lobby_open_game_joined"
+    | "lobby_open_game_filled";
+  resourceId: string;
+  sport: "padel" | "darts" | "golf";
+  city: string;
+  windowStart: string;
+  windowEnd: string;
+  openGameId?: string | null;
+  proposalId?: string | null;
+  organiseGameId?: string | null;
+};
+
+export interface LobbyNotifier {
+  notify(input: LobbyNotice): Promise<void>;
 }
 
 const DEFAULT_LIST_LIMIT = 20;
@@ -127,6 +165,29 @@ async function toPublic(
     readAt: snapshot.readAt,
     createdAt: snapshot.createdAt,
   };
+}
+
+export class NotifyLobby implements LobbyNotifier {
+  constructor(private readonly notifications: NotificationRepository) {}
+
+  async notify(input: LobbyNotice): Promise<void> {
+    if (input.recipientId === input.actorId) return;
+    await this.notifications.create(
+      Notification.lobby({
+        recipientId: input.recipientId,
+        actorId: input.actorId,
+        type: NotificationType.from(input.type),
+        resourceId: input.resourceId,
+        sport: input.sport,
+        city: input.city,
+        windowStart: input.windowStart,
+        windowEnd: input.windowEnd,
+        openGameId: input.openGameId,
+        proposalId: input.proposalId,
+        organiseGameId: input.organiseGameId,
+      }),
+    );
+  }
 }
 
 export class NotifyOrganisedGameInvite implements OrganisedGameInviteNotifier {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #52

Hybrid matchmaking lobby (community on-ramp). **Not booking.** Seekers set Looking, hosts post open games, compatible lookings become Accept/Pass proposals. Filled open games and accepted proposals convert through existing Organise create (no parallel match engine).

## Migration
`20260908200000_lobby`

## API
| Method | Path | Auth |
| --- | --- | --- |
| GET | `/api/lobby?sport=&city=` | optional |
| POST | `/api/lobby/looking` | required |
| DELETE | `/api/lobby/looking` | required |
| POST | `/api/lobby/open-games` | required |
| POST | `/api/lobby/open-games/:id/join` | required |
| POST | `/api/lobby/open-games/:id/kick` | required (host) |
| GET | `/api/lobby/proposals` | required |
| POST | `/api/lobby/proposals/:id/accept` | required |
| POST | `/api/lobby/proposals/:id/pass` | required |

Public list fields: `firstName`, `sport`, `windowStart`, `windowEnd`, `city`, `area` (+ slot counts on open games). `source: "lobby"` and `organiseGameId` on converted items.

## Organise conversion
On fill / unanimous accept, lobby creates an `OrganisedGame` (auto-accepted invitees) and sets `organiseGameId`. Host starts via existing Start API. Blocked without a registered venue or for darts (`conversionBlocked`).

Propose evaluation is request-time (no worker). See `src/modules/lobby/README.md`.

Do not merge until review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-614236d6-7283-4c56-bef5-3109c4156a16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-614236d6-7283-4c56-bef5-3109c4156a16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

