### PR TITLE
feat: Golf tour / camp event v1

### DIFF
--- a/prisma/migrations/20260909120000_golf_tour/migration.sql
+++ b/prisma/migrations/20260909120000_golf_tour/migration.sql
@@ -1,0 +1,141 @@
+-- CreateEnum
+CREATE TYPE "GolfTourStatus" AS ENUM ('draft', 'active', 'completed');
+
+-- CreateEnum
+CREATE TYPE "GolfTourFormat" AS ENUM ('stroke');
+
+-- CreateEnum
+CREATE TYPE "GolfTourFourballStatus" AS ENUM ('pending', 'live', 'locked', 'cancelled');
+
+-- CreateTable
+CREATE TABLE "GolfTour" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "startDate" DATE NOT NULL,
+    "endDate" DATE NOT NULL,
+    "status" "GolfTourStatus" NOT NULL DEFAULT 'draft',
+    "hostUserId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GolfTour_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GolfTourCamp" (
+    "id" TEXT NOT NULL,
+    "tourId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "color" TEXT,
+    "sortOrder" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GolfTourCamp_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GolfTourRound" (
+    "id" TEXT NOT NULL,
+    "tourId" TEXT NOT NULL,
+    "date" DATE NOT NULL,
+    "venueCmsId" TEXT NOT NULL,
+    "label" TEXT,
+    "format" "GolfTourFormat" NOT NULL DEFAULT 'stroke',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GolfTourRound_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GolfTourFourball" (
+    "id" TEXT NOT NULL,
+    "tourId" TEXT NOT NULL,
+    "roundId" TEXT NOT NULL,
+    "campId" TEXT NOT NULL,
+    "golfRoundId" TEXT,
+    "status" "GolfTourFourballStatus" NOT NULL DEFAULT 'pending',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GolfTourFourball_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GolfTourFourballPlayer" (
+    "id" TEXT NOT NULL,
+    "fourballId" TEXT NOT NULL,
+    "slot" INTEGER NOT NULL,
+    "userId" TEXT,
+    "displayName" TEXT NOT NULL,
+    "isGuest" BOOLEAN NOT NULL,
+
+    CONSTRAINT "GolfTourFourballPlayer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "GolfTour_hostUserId_idx" ON "GolfTour"("hostUserId");
+
+-- CreateIndex
+CREATE INDEX "GolfTour_status_startDate_idx" ON "GolfTour"("status", "startDate");
+
+-- CreateIndex
+CREATE INDEX "GolfTour_hostUserId_status_idx" ON "GolfTour"("hostUserId", "status");
+
+-- CreateIndex
+CREATE INDEX "GolfTourCamp_tourId_idx" ON "GolfTourCamp"("tourId");
+
+-- CreateIndex
+CREATE INDEX "GolfTourRound_tourId_idx" ON "GolfTourRound"("tourId");
+
+-- CreateIndex
+CREATE INDEX "GolfTourRound_venueCmsId_idx" ON "GolfTourRound"("venueCmsId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GolfTourFourball_golfRoundId_key" ON "GolfTourFourball"("golfRoundId");
+
+-- CreateIndex
+CREATE INDEX "GolfTourFourball_tourId_idx" ON "GolfTourFourball"("tourId");
+
+-- CreateIndex
+CREATE INDEX "GolfTourFourball_roundId_idx" ON "GolfTourFourball"("roundId");
+
+-- CreateIndex
+CREATE INDEX "GolfTourFourball_campId_idx" ON "GolfTourFourball"("campId");
+
+-- CreateIndex
+CREATE INDEX "GolfTourFourball_golfRoundId_idx" ON "GolfTourFourball"("golfRoundId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GolfTourFourballPlayer_fourballId_slot_key" ON "GolfTourFourballPlayer"("fourballId", "slot");
+
+-- CreateIndex
+CREATE INDEX "GolfTourFourballPlayer_userId_idx" ON "GolfTourFourballPlayer"("userId");
+
+-- CreateIndex
+CREATE INDEX "GolfTourFourballPlayer_fourballId_idx" ON "GolfTourFourballPlayer"("fourballId");
+
+-- AddForeignKey
+ALTER TABLE "GolfTourCamp" ADD CONSTRAINT "GolfTourCamp_tourId_fkey" FOREIGN KEY ("tourId") REFERENCES "GolfTour"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GolfTourRound" ADD CONSTRAINT "GolfTourRound_tourId_fkey" FOREIGN KEY ("tourId") REFERENCES "GolfTour"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GolfTourRound" ADD CONSTRAINT "GolfTourRound_venueCmsId_fkey" FOREIGN KEY ("venueCmsId") REFERENCES "Venue"("cmsId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GolfTourFourball" ADD CONSTRAINT "GolfTourFourball_tourId_fkey" FOREIGN KEY ("tourId") REFERENCES "GolfTour"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GolfTourFourball" ADD CONSTRAINT "GolfTourFourball_roundId_fkey" FOREIGN KEY ("roundId") REFERENCES "GolfTourRound"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GolfTourFourball" ADD CONSTRAINT "GolfTourFourball_campId_fkey" FOREIGN KEY ("campId") REFERENCES "GolfTourCamp"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GolfTourFourball" ADD CONSTRAINT "GolfTourFourball_golfRoundId_fkey" FOREIGN KEY ("golfRoundId") REFERENCES "GolfRound"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GolfTourFourballPlayer" ADD CONSTRAINT "GolfTourFourballPlayer_fourballId_fkey" FOREIGN KEY ("fourballId") REFERENCES "GolfTourFourball"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,7 @@ model Venue {
   dartsMatches    DartsMatch[]
   follows         VenueFollow[]
   organisedGames  OrganisedGame[]
+  golfTourRounds  GolfTourRound[]
 }
 
 model VenueFollow {
@@ -615,6 +616,7 @@ model GolfRound {
   lockedByUserId String?
   createdAt    DateTime        @default(now())
   players      GolfRoundPlayer[]
+  tourFourball GolfTourFourball?
 
   @@index([venueCmsId])
   @@index([status, startsAt])
@@ -911,4 +913,108 @@ model LobbyProposalMember {
   @@unique([proposalId, userId])
   @@index([userId])
   @@index([proposalId])
+}
+
+enum GolfTourStatus {
+  draft
+  active
+  completed
+}
+
+enum GolfTourFormat {
+  stroke
+}
+
+enum GolfTourFourballStatus {
+  pending
+  live
+  locked
+  cancelled
+}
+
+// Multi-day multi-course friend golf event (Tour + Camp). Not a Tournament.
+// No User FK — same as Team / OrganisedGame. Fourballs link to GolfRound
+// (existing scorecard). format is pluggable; v1 is stroke only.
+model GolfTour {
+  id         String         @id @default(uuid())
+  name       String
+  startDate  DateTime       @db.Date
+  endDate    DateTime       @db.Date
+  status     GolfTourStatus @default(draft)
+  hostUserId String
+  createdAt  DateTime       @default(now())
+  updatedAt  DateTime       @updatedAt
+  camps      GolfTourCamp[]
+  rounds     GolfTourRound[]
+  fourballs  GolfTourFourball[]
+
+  @@index([hostUserId])
+  @@index([status, startDate])
+  @@index([hostUserId, status])
+}
+
+model GolfTourCamp {
+  id        String   @id @default(uuid())
+  tourId    String
+  name      String
+  color     String?
+  sortOrder Int
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  tour      GolfTour @relation(fields: [tourId], references: [id], onDelete: Cascade)
+  fourballs GolfTourFourball[]
+
+  @@index([tourId])
+}
+
+model GolfTourRound {
+  id         String         @id @default(uuid())
+  tourId     String
+  date       DateTime       @db.Date
+  venueCmsId String
+  venue      Venue          @relation(fields: [venueCmsId], references: [cmsId])
+  label      String?
+  format     GolfTourFormat @default(stroke)
+  createdAt  DateTime       @default(now())
+  updatedAt  DateTime       @updatedAt
+  tour       GolfTour       @relation(fields: [tourId], references: [id], onDelete: Cascade)
+  fourballs  GolfTourFourball[]
+
+  @@index([tourId])
+  @@index([venueCmsId])
+}
+
+model GolfTourFourball {
+  id          String                 @id @default(uuid())
+  tourId      String
+  roundId     String
+  campId      String
+  golfRoundId String?                @unique
+  status      GolfTourFourballStatus @default(pending)
+  createdAt   DateTime               @default(now())
+  updatedAt   DateTime               @updatedAt
+  tour        GolfTour               @relation(fields: [tourId], references: [id], onDelete: Cascade)
+  round       GolfTourRound          @relation(fields: [roundId], references: [id], onDelete: Cascade)
+  camp        GolfTourCamp           @relation(fields: [campId], references: [id], onDelete: Cascade)
+  golfRound   GolfRound?             @relation(fields: [golfRoundId], references: [id])
+  players     GolfTourFourballPlayer[]
+
+  @@index([tourId])
+  @@index([roundId])
+  @@index([campId])
+  @@index([golfRoundId])
+}
+
+model GolfTourFourballPlayer {
+  id          String           @id @default(uuid())
+  fourballId  String
+  slot        Int
+  userId      String?
+  displayName String
+  isGuest     Boolean
+  fourball    GolfTourFourball @relation(fields: [fourballId], references: [id], onDelete: Cascade)
+
+  @@unique([fourballId, slot])
+  @@index([userId])
+  @@index([fourballId])
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -90,6 +90,12 @@ import {
   createLobbyModule,
   LobbyRepository,
 } from "./modules/lobby";
+import {
+  createGolfToursModule,
+  GolfTourRepository,
+} from "./modules/golf-tours";
+import { PrismaGolfTourRepository } from "./modules/golf-tours/repositories/prisma-golf-tour.repository";
+import { LockGolfTourFourballOnScorecardLock } from "./modules/golf-tours/services/lock-fourball-on-scorecard-lock";
 
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
@@ -116,6 +122,7 @@ export type CreateAppDependencies = {
   coverageIntentRepository?: CoverageIntentRepository;
   coverageRateLimiter?: CoverageRateLimiter;
   lobbyRepository?: LobbyRepository;
+  golfTourRepository?: GolfTourRepository;
 };
 
 export async function createApp(
@@ -165,8 +172,16 @@ export async function createApp(
     teamMatchRepository,
     onTeamMatchCompleted,
   );
-  const onScorecardLocked = (event: ScorecardLockedEvent) =>
-    completeOnLock.execute(event);
+  const golfTourRepository =
+    dependencies.golfTourRepository ??
+    new PrismaGolfTourRepository(prisma);
+  const lockFourballOnScorecardLock = new LockGolfTourFourballOnScorecardLock(
+    golfTourRepository,
+  );
+  const onScorecardLocked = async (event: ScorecardLockedEvent) => {
+    await completeOnLock.execute(event);
+    await lockFourballOnScorecardLock.execute(event);
+  };
 
   const match = createMatchModule({
     prisma,
@@ -313,6 +328,14 @@ export async function createApp(
     tryGetSessionUserId: identity.tryGetSessionUserId,
     requireAuth: identity.authorizationMiddleware,
   });
+  const golfTours = createGolfToursModule({
+    prisma,
+    venueRepository: venue.venueRepository,
+    golfRoundRepository: golfRound.golfRoundRepository,
+    golfTourRepository,
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
 
   app.use(identity.router);
   app.use(venue.router);
@@ -334,6 +357,7 @@ export async function createApp(
   app.use(roadmap.router);
   app.use(intents.router);
   app.use(lobby.router);
+  app.use(golfTours.router);
 
   app.use(
     (

--- a/src/modules/golf-tours/README.md
+++ b/src/modules/golf-tours/README.md
@@ -1,0 +1,165 @@
+# Golf tour / camp event v1
+
+Multi-day, multi-course friend golf event. Naming is **Tour** + **Camp** (N≥2). This is **not** a single-elim Tournament.
+
+Fourballs reuse the **existing golf scorecard** (`POST /api/golf-rounds`). Each fourball has its own golf round id so groups can score on different devices. Handicaps and scramble are **v1.1** — `format` is stored and pluggable; v1 accepts **`stroke` only**.
+
+## Migration
+
+`20260909120000_golf_tour`
+
+Applied on merge via Railway `preDeployCommand` (`prisma migrate deploy`). **Do not merge until ready to migrate.**
+
+## Complete behavior
+
+- **Host** `POST /api/golf-tours/:id/complete` may complete a draft or active tour at any time (including while fourballs are still pending). Idempotent if already completed.
+- **Auto-complete** runs when a fourball is locked from its golf scorecard (`POST /api/golf-rounds/:id/lock`) **and** every non-cancelled fourball on the tour is `locked`. Cancelled fourballs are ignored. An empty tour (no fourballs) is **not** auto-completed.
+
+Starting the first fourball moves the tour from `draft` → `active`. A completed tour cannot be mutated.
+
+## Scoring / leaderboard
+
+`GET /api/golf-tours/:id/leaderboard` is **gross stroke average per player-round**. Only **locked** fourballs whose linked golf round is also **locked** count.
+
+For each player in a camp, across those locked cards:
+
+```
+avgGross = totalGrossStrokes / playerRoundsCounted
+```
+
+- `totalGrossStrokes` = sum of hole strokes on that player’s scorecard slot.
+- `playerRoundsCounted` = number of locked fourballs in that camp the player was seated in.
+- Sort: `avgGross` ascending, then `totalStrokes` ascending, then `displayName`.
+- Live / pending / cancelled fourballs are ignored, even if a live card has hole scores.
+
+### Guest identity
+
+Guests have no `userId`. Leaderboard key:
+
+| Player | `playerKey` |
+| --- | --- |
+| Registered | `user:{userId}` |
+| Guest | `guest:{trimmed lowercased displayName}` |
+
+The same guest display name in two locked fourballs of **one camp** aggregates as one person. Different camps do not merge. Hosts should keep guest names stable (or unique) within a camp.
+
+## Format enum (v1.1)
+
+Prisma `GolfTourFormat` is currently `{ stroke }`. Round create/edit rejects `scramble` with a 400. When scramble / handicap nets ship, extend the enum and plug a scorer behind `format` — do not fork the tour aggregate.
+
+## Auth
+
+Session cookie + `requireAuth` on every route.
+
+- **Host** mutates (CRUD tour, camps, rounds, fourballs, complete).
+- **Host or seated registered player** may start a fourball (so the group can open the card on their device).
+- **Host or seated registered player** may `GET` the tour and leaderboard. Outsiders get `404`.
+
+## Frontend contract
+
+All mutate/read routes need the session cookie. Dates are `YYYY-MM-DD`. Nested writes return `{ tour }`. Start returns the live card path for the existing golf UI.
+
+| Method | Path | Body | Response |
+| --- | --- | --- | --- |
+| `POST` | `/api/golf-tours` | `{ name, startDate, endDate, campNames? }` | `201 { tour }` — default **2** camps (`Camp A`, `Camp B`) if `campNames` omitted. `campNames` must have N≥2. |
+| `GET` | `/api/golf-tours/mine` | | `200 { tours }` hosting **or** seated as a registered player |
+| `GET` | `/api/golf-tours/:id` | | `200 { tour }` |
+| `PATCH` | `/api/golf-tours/:id` | `{ name?, startDate?, endDate? }` | `200 { tour }` |
+| `POST` | `/api/golf-tours/:id/complete` | | `200 { tour }` |
+| `POST` | `/api/golf-tours/:id/camps` | `{ name, color? }` | `201 { tour }` |
+| `PATCH` | `/api/golf-tours/:id/camps/:campId` | `{ name?, color? }` | `200 { tour }` |
+| `POST` | `/api/golf-tours/:id/rounds` | `{ date, venueCmsId, label?, format? }` | `201 { tour }` — `format` defaults to `stroke` |
+| `PATCH` | `/api/golf-tours/:id/rounds/:roundId` | `{ date?, venueCmsId?, label?, format? }` | `200 { tour }` |
+| `POST` | `/api/golf-tours/:id/rounds/:roundId/fourballs` | `{ campId, players? }` | `201 { tour, fourball }` |
+| `PATCH` | `/api/golf-tours/:id/fourballs/:fourballId` | `{ players?, campId?, status? }` | `200 { tour }` — `status` may only be `cancelled` (pending only) |
+| `POST` | `/api/golf-tours/:id/fourballs/:fourballId/start` | `{ teeName, holesPlayed?, startingHole?, course?, players? }` | `201 { tour, fourball, golfRoundId, path }` |
+| `GET` | `/api/golf-tours/:id/leaderboard` | | `200 { leaderboard }` |
+
+### `tour` shape
+
+```json
+{
+  "id": "…",
+  "name": "Friends Cup",
+  "startDate": "2026-09-12",
+  "endDate": "2026-09-14",
+  "status": "draft",
+  "hostUserId": "…",
+  "viewer": { "role": "host" },
+  "camps": [{ "id": "…", "name": "Camp A", "color": null, "sortOrder": 0 }],
+  "rounds": [{
+    "id": "…",
+    "date": "2026-09-12",
+    "venueCmsId": "sanity-course-1",
+    "label": "Saturday AM",
+    "format": "stroke"
+  }],
+  "fourballs": [{
+    "id": "…",
+    "roundId": "…",
+    "campId": "…",
+    "status": "pending",
+    "golfRoundId": null,
+    "path": null,
+    "players": [
+      { "slot": 1, "userId": "…", "displayName": "Alex", "isGuest": false },
+      { "slot": 2, "userId": null, "displayName": "Pat", "isGuest": true }
+    ]
+  }],
+  "createdAt": "…",
+  "updatedAt": "…"
+}
+```
+
+`viewer.role` is `"host"` or `"player"`. `status` is `draft` \| `active` \| `completed`. Fourball `status` is `pending` \| `live` \| `locked` \| `cancelled`.
+
+### Start fourball
+
+Wires **venue from the tour round** and **tees/course like organise→golf start**:
+
+- `teeName` is required (same as golf round create).
+- Default `holesPlayed` is `9` with the default 9-hole par-4 course when `course` is omitted.
+- Seated fourball players are copied onto the golf card (override with `players` if needed).
+- Returns `{ golfRoundId, path }` where `path` is `/golf/{golfRoundId}` — open the existing golf scorecard UI.
+- Idempotent if the fourball is already `live` or `locked`.
+
+Locking that card (`POST /api/golf-rounds/:id/lock`) marks the fourball `locked` and may auto-complete the tour.
+
+### Leaderboard shape
+
+```json
+{
+  "leaderboard": {
+    "tourId": "…",
+    "status": "active",
+    "camps": [{
+      "campId": "…",
+      "name": "Camp A",
+      "color": null,
+      "players": [{
+        "playerKey": "user:…",
+        "userId": "…",
+        "displayName": "Alex",
+        "isGuest": false,
+        "avgGross": 36,
+        "playerRoundsCounted": 1,
+        "totalStrokes": 36
+      }]
+    }]
+  }
+}
+```
+
+Players with zero locked rounds in that camp are omitted.
+
+## Out of scope
+
+Scramble engine, handicaps, booking/payments, Frontend, SEO. In-app notifications for “fourball ready” / “tour completed” are a nice-to-have and not in this v1.
+
+## Link to golf rounds
+
+| Golf tour | Golf rounds API |
+| --- | --- |
+| Start fourball | `POST /api/golf-rounds` (create live card) |
+| Play / lock | existing golf UI + `POST /api/golf-rounds/:id/lock` |
+| Leaderboard | locked cards only (`GolfRound.status = locked`) |

--- a/src/modules/golf-tours/controllers/golf-tours.controller.ts
+++ b/src/modules/golf-tours/controllers/golf-tours.controller.ts
@@ -1,0 +1,390 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { GolfRoundPersistenceError } from "../../golf-round/entities/golf-round-persistence-error";
+import { GolfRoundVenueNotFoundError } from "../../golf-round/entities/golf-round-venue-not-found-error";
+import { GolfTourCampNotFoundError } from "../entities/golf-tour-camp-not-found-error";
+import { GolfTourForbiddenError } from "../entities/golf-tour-forbidden-error";
+import { GolfTourFourballNotFoundError } from "../entities/golf-tour-fourball-not-found-error";
+import { GolfTourNotFoundError } from "../entities/golf-tour-not-found-error";
+import { GolfTourNotReadyError } from "../entities/golf-tour-not-ready-error";
+import { GolfTourPersistenceError } from "../entities/golf-tour-persistence-error";
+import { GolfTourRoundNotFoundError } from "../entities/golf-tour-round-not-found-error";
+import { GolfTourVenueNotFoundError } from "../entities/golf-tour-venue-not-found-error";
+import {
+  AddGolfTourCamp,
+  AddGolfTourFourball,
+  AddGolfTourRound,
+  CompleteGolfTour,
+  CreateGolfTour,
+  GetGolfTour,
+  GetGolfTourLeaderboard,
+  ListMyGolfTours,
+  StartGolfTourFourball,
+  UpdateGolfTour,
+  UpdateGolfTourCamp,
+  UpdateGolfTourFourball,
+  UpdateGolfTourRound,
+} from "../services/golf-tours.service";
+
+const playerSchema = z.object({
+  slot: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
+  userId: z.string().nullable().optional(),
+  displayName: z.string(),
+  isGuest: z.boolean(),
+});
+
+const courseHoleSchema = z.object({
+  number: z.number(),
+  par: z.number(),
+  strokeIndex: z.number(),
+});
+
+const createBodySchema = z.object({
+  name: z.string(),
+  startDate: z.string(),
+  endDate: z.string(),
+  campNames: z.array(z.string()).optional(),
+});
+
+const updateBodySchema = z
+  .object({
+    name: z.string().optional(),
+    startDate: z.string().optional(),
+    endDate: z.string().optional(),
+  })
+  .refine(
+    (body) =>
+      body.name !== undefined ||
+      body.startDate !== undefined ||
+      body.endDate !== undefined,
+    { message: "At least one field is required" },
+  );
+
+const idParamSchema = z.object({
+  id: z.string(),
+});
+
+const campParamSchema = z.object({
+  id: z.string(),
+  campId: z.string(),
+});
+
+const roundParamSchema = z.object({
+  id: z.string(),
+  roundId: z.string(),
+});
+
+const fourballParamSchema = z.object({
+  id: z.string(),
+  fourballId: z.string(),
+});
+
+const campBodySchema = z.object({
+  name: z.string(),
+  color: z.string().nullable().optional(),
+});
+
+const updateCampBodySchema = z.object({
+  name: z.string().optional(),
+  color: z.string().nullable().optional(),
+});
+
+const roundBodySchema = z.object({
+  date: z.string(),
+  venueCmsId: z.string(),
+  label: z.string().nullable().optional(),
+  format: z.string().optional(),
+});
+
+const updateRoundBodySchema = z.object({
+  date: z.string().optional(),
+  venueCmsId: z.string().optional(),
+  label: z.string().nullable().optional(),
+  format: z.string().optional(),
+});
+
+const createFourballBodySchema = z.object({
+  campId: z.string(),
+  players: z.array(playerSchema).max(4).optional(),
+});
+
+const updateFourballBodySchema = z.object({
+  campId: z.string().optional(),
+  players: z.array(playerSchema).max(4).optional(),
+  status: z.string().optional(),
+});
+
+const startFourballBodySchema = z.object({
+  teeName: z.string().optional(),
+  holesPlayed: z.union([z.literal(9), z.literal(18)]).optional(),
+  startingHole: z.number().optional(),
+  course: z
+    .object({
+      name: z.string().nullable().optional(),
+      holes: z.array(courseHoleSchema).min(1),
+    })
+    .optional(),
+  players: z.array(playerSchema).min(1).max(4).optional(),
+});
+
+export function createGolfToursController(deps: {
+  createGolfTour: CreateGolfTour;
+  getGolfTour: GetGolfTour;
+  updateGolfTour: UpdateGolfTour;
+  completeGolfTour: CompleteGolfTour;
+  listMyGolfTours: ListMyGolfTours;
+  addCamp: AddGolfTourCamp;
+  updateCamp: UpdateGolfTourCamp;
+  addRound: AddGolfTourRound;
+  updateRound: UpdateGolfTourRound;
+  addFourball: AddGolfTourFourball;
+  updateFourball: UpdateGolfTourFourball;
+  startFourball: StartGolfTourFourball;
+  getLeaderboard: GetGolfTourLeaderboard;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async create(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const body = z.parse(createBodySchema, req.body ?? {});
+        const result = await deps.createGolfTour.execute({ userId, ...body });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async listMine(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const result = await deps.listMyGolfTours.execute({ userId });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async get(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const result = await deps.getGolfTour.execute({ userId, tourId: id });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async update(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const body = z.parse(updateBodySchema, req.body ?? {});
+        const result = await deps.updateGolfTour.execute({
+          userId,
+          tourId: id,
+          ...body,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async complete(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const result = await deps.completeGolfTour.execute({
+          userId,
+          tourId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async addCamp(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const body = z.parse(campBodySchema, req.body ?? {});
+        const result = await deps.addCamp.execute({
+          userId,
+          tourId: id,
+          name: body.name,
+          color: body.color,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async updateCamp(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, campId } = z.parse(campParamSchema, req.params);
+        const body = z.parse(updateCampBodySchema, req.body ?? {});
+        const result = await deps.updateCamp.execute({
+          userId,
+          tourId: id,
+          campId,
+          ...body,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async addRound(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const body = z.parse(roundBodySchema, req.body ?? {});
+        const result = await deps.addRound.execute({
+          userId,
+          tourId: id,
+          ...body,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async updateRound(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, roundId } = z.parse(roundParamSchema, req.params);
+        const body = z.parse(updateRoundBodySchema, req.body ?? {});
+        const result = await deps.updateRound.execute({
+          userId,
+          tourId: id,
+          roundId,
+          ...body,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async addFourball(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, roundId } = z.parse(roundParamSchema, req.params);
+        const body = z.parse(createFourballBodySchema, req.body ?? {});
+        const result = await deps.addFourball.execute({
+          userId,
+          tourId: id,
+          roundId,
+          campId: body.campId,
+          players: body.players,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async updateFourball(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, fourballId } = z.parse(fourballParamSchema, req.params);
+        const body = z.parse(updateFourballBodySchema, req.body ?? {});
+        const result = await deps.updateFourball.execute({
+          userId,
+          tourId: id,
+          fourballId,
+          ...body,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async startFourball(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, fourballId } = z.parse(fourballParamSchema, req.params);
+        const body = z.parse(startFourballBodySchema, req.body ?? {});
+        const result = await deps.startFourball.execute({
+          userId,
+          tourId: id,
+          fourballId,
+          ...body,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async leaderboard(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const result = await deps.getLeaderboard.execute({
+          userId,
+          tourId: id,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+  };
+}
+
+function sendGolfTourError(res: Response, error: unknown) {
+  if (
+    error instanceof GolfTourNotFoundError ||
+    error instanceof GolfTourCampNotFoundError ||
+    error instanceof GolfTourRoundNotFoundError ||
+    error instanceof GolfTourFourballNotFoundError ||
+    error instanceof GolfTourVenueNotFoundError ||
+    error instanceof GolfRoundVenueNotFoundError
+  ) {
+    return res.status(404).json({ error: error.message });
+  }
+  if (error instanceof GolfTourForbiddenError) {
+    return res.status(403).json({ error: error.message });
+  }
+  if (error instanceof GolfTourNotReadyError) {
+    return res.status(400).json({ error: error.message });
+  }
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+  if (error instanceof z.ZodError) {
+    return res.status(400).json({ error: "Invalid golf tour payload" });
+  }
+  if (
+    error instanceof GolfTourPersistenceError ||
+    error instanceof GolfRoundPersistenceError
+  ) {
+    return res.status(503).json({ error: error.message });
+  }
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/golf-tours/controllers/golf-tours.http.test.ts
+++ b/src/modules/golf-tours/controllers/golf-tours.http.test.ts
@@ -1,0 +1,415 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { InMemoryGolfRoundRepository } from "../../golf-round/repositories/in-memory-golf-round.repository";
+import { signAuthenticationToken } from "../../identity/utils/jwt";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { InMemoryGolfTourRepository } from "../repositories/in-memory-golf-tour.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+type PublicTour = {
+  id: string;
+  name: string;
+  status: string;
+  startDate: string;
+  endDate: string;
+  viewer: { role: string };
+  camps: Array<{ id: string; name: string; sortOrder: number }>;
+  rounds: Array<{ id: string; date: string; venueCmsId: string; format: string }>;
+  fourballs: Array<{
+    id: string;
+    campId: string;
+    status: string;
+    golfRoundId: string | null;
+    path: string | null;
+    players: Array<{ slot: number; userId: string | null; isGuest: boolean }>;
+  }>;
+};
+
+function scoreForSlots(slots: number[], stroke: number) {
+  return {
+    holes: Array.from({ length: 9 }, (_, index) => ({
+      number: index + 1,
+      strokes: Object.fromEntries(slots.map((slot) => [String(slot), stroke])),
+    })),
+  };
+}
+
+describe("golf tours HTTP", () => {
+  const config = makeConfig();
+  let venues: InMemoryVenueRepository;
+  let golf: InMemoryGolfRoundRepository;
+  let tours: InMemoryGolfTourRepository;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  function cookie(userId: string) {
+    return `token=${signAuthenticationToken(config, { userId })}`;
+  }
+
+  async function json(
+    path: string,
+    init: RequestInit & { userId?: string } = {},
+  ) {
+    const headers = new Headers(init.headers);
+    if (init.body && !headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+    if (init.userId) headers.set("Cookie", cookie(init.userId));
+    return fetch(`${server.url}${path}`, { ...init, headers });
+  }
+
+  beforeEach(async () => {
+    venues = new InMemoryVenueRepository();
+    golf = new InMemoryGolfRoundRepository();
+    tours = new InMemoryGolfTourRepository();
+    await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-course-1"),
+        VenueName.from("Golf Club"),
+        Slug.from("golf-club"),
+      ),
+      { refreshDetails: false },
+    );
+    app = await createApp(config, {
+      venueRepository: venues,
+      golfRoundRepository: golf,
+      golfTourRepository: tours,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("create tour with two camps, rounds/fourballs, start, locked leaderboard, permissions, complete", async () => {
+    const created = await json("/api/golf-tours", {
+      method: "POST",
+      userId: "user-host",
+      body: JSON.stringify({
+        name: "Friends Cup",
+        startDate: "2026-09-12",
+        endDate: "2026-09-14",
+      }),
+    });
+    expect(created.status).toBe(201);
+    const createdBody = (await created.json()) as { tour: PublicTour };
+    expect(createdBody.tour.camps).toHaveLength(2);
+    expect(createdBody.tour.camps.map((camp) => camp.name)).toEqual([
+      "Camp A",
+      "Camp B",
+    ]);
+    expect(createdBody.tour.status).toBe("draft");
+    const tourId = createdBody.tour.id;
+    const campA = createdBody.tour.camps[0]!.id;
+
+    const forbidden = await json(`/api/golf-tours/${tourId}`, {
+      method: "PATCH",
+      userId: "user-other",
+      body: JSON.stringify({ name: "Hijack" }),
+    });
+    expect(forbidden.status).toBe(403);
+
+    const roundRes = await json(`/api/golf-tours/${tourId}/rounds`, {
+      method: "POST",
+      userId: "user-host",
+      body: JSON.stringify({
+        date: "2026-09-12",
+        venueCmsId: "sanity-course-1",
+        label: "Saturday AM",
+        format: "stroke",
+      }),
+    });
+    expect(roundRes.status).toBe(201);
+    const withRound = (await roundRes.json()) as { tour: PublicTour };
+    const roundId = withRound.tour.rounds[0]!.id;
+
+    const scramble = await json(`/api/golf-tours/${tourId}/rounds`, {
+      method: "POST",
+      userId: "user-host",
+      body: JSON.stringify({
+        date: "2026-09-13",
+        venueCmsId: "sanity-course-1",
+        format: "scramble",
+      }),
+    });
+    expect(scramble.status).toBe(400);
+
+    const fbLockedRes = await json(
+      `/api/golf-tours/${tourId}/rounds/${roundId}/fourballs`,
+      {
+        method: "POST",
+        userId: "user-host",
+        body: JSON.stringify({
+          campId: campA,
+          players: [
+            {
+              slot: 1,
+              displayName: "Alex",
+              isGuest: false,
+              userId: "user-host",
+            },
+            { slot: 2, displayName: "Pat", isGuest: true, userId: null },
+          ],
+        }),
+      },
+    );
+    expect(fbLockedRes.status).toBe(201);
+    const fbLocked = (await fbLockedRes.json()) as {
+      tour: PublicTour;
+      fourball: PublicTour["fourballs"][number];
+    };
+
+    const fbLiveRes = await json(
+      `/api/golf-tours/${tourId}/rounds/${roundId}/fourballs`,
+      {
+        method: "POST",
+        userId: "user-host",
+        body: JSON.stringify({
+          campId: campA,
+          players: [
+            {
+              slot: 1,
+              displayName: "Alex",
+              isGuest: false,
+              userId: "user-host",
+            },
+            {
+              slot: 2,
+              displayName: "Sam",
+              isGuest: false,
+              userId: "user-sam",
+            },
+          ],
+        }),
+      },
+    );
+    const fbLive = (await fbLiveRes.json()) as {
+      fourball: PublicTour["fourballs"][number];
+    };
+
+    const missingTee = await json(
+      `/api/golf-tours/${tourId}/fourballs/${fbLocked.fourball.id}/start`,
+      { method: "POST", userId: "user-host", body: JSON.stringify({}) },
+    );
+    expect(missingTee.status).toBe(400);
+
+    const started = await json(
+      `/api/golf-tours/${tourId}/fourballs/${fbLocked.fourball.id}/start`,
+      {
+        method: "POST",
+        userId: "user-host",
+        body: JSON.stringify({ teeName: "White" }),
+      },
+    );
+    expect(started.status).toBe(201);
+    const startedBody = (await started.json()) as {
+      golfRoundId: string;
+      path: string;
+      fourball: PublicTour["fourballs"][number];
+      tour: PublicTour;
+    };
+    expect(startedBody.golfRoundId).toBeTruthy();
+    expect(startedBody.path).toBe(`/golf/${startedBody.golfRoundId}`);
+    expect(startedBody.fourball.status).toBe("live");
+    expect(startedBody.tour.status).toBe("active");
+
+    await json(
+      `/api/golf-tours/${tourId}/fourballs/${fbLive.fourball.id}/start`,
+      {
+        method: "POST",
+        userId: "user-host",
+        body: JSON.stringify({ teeName: "White" }),
+      },
+    );
+
+    const lock = await json(`/api/golf-rounds/${startedBody.golfRoundId}/lock`, {
+      method: "POST",
+      userId: "user-host",
+      body: JSON.stringify({ score: scoreForSlots([1, 2], 4) }),
+    });
+    expect(lock.status).toBe(200);
+
+    const board = await json(`/api/golf-tours/${tourId}/leaderboard`, {
+      userId: "user-host",
+    });
+    expect(board.status).toBe(200);
+    const boardBody = (await board.json()) as {
+      leaderboard: {
+        camps: Array<{
+          campId: string;
+          players: Array<{
+            playerKey: string;
+            isGuest: boolean;
+            playerRoundsCounted: number;
+            totalStrokes: number;
+            avgGross: number;
+          }>;
+        }>;
+      };
+    };
+    const campBoard = boardBody.leaderboard.camps.find(
+      (camp) => camp.campId === campA,
+    )!;
+    expect(campBoard.players).toHaveLength(2);
+    expect(campBoard.players.map((player) => player.playerKey).sort()).toEqual([
+      "guest:pat",
+      "user:user-host",
+    ]);
+    expect(
+      campBoard.players.every((player) => player.playerRoundsCounted === 1),
+    ).toBe(true);
+    expect(campBoard.players.every((player) => player.totalStrokes === 36)).toBe(
+      true,
+    );
+    expect(campBoard.players.find((player) => player.isGuest)?.avgGross).toBe(36);
+
+    const asPlayer = await json(`/api/golf-tours/${tourId}`, {
+      userId: "user-sam",
+    });
+    expect(asPlayer.status).toBe(200);
+    expect(((await asPlayer.json()) as { tour: PublicTour }).tour.viewer.role).toBe(
+      "player",
+    );
+
+    const stranger = await json(`/api/golf-tours/${tourId}`, {
+      userId: "user-stranger",
+    });
+    expect(stranger.status).toBe(404);
+
+    const mineHost = await json("/api/golf-tours/mine", { userId: "user-host" });
+    expect(mineHost.status).toBe(200);
+    expect(
+      ((await mineHost.json()) as { tours: Array<{ id: string }> }).tours,
+    ).toEqual(expect.arrayContaining([expect.objectContaining({ id: tourId })]));
+
+    const minePlayer = await json("/api/golf-tours/mine", { userId: "user-sam" });
+    expect(minePlayer.status).toBe(200);
+    expect(
+      ((await minePlayer.json()) as { tours: Array<{ id: string }> }).tours[0]
+        ?.id,
+    ).toBe(tourId);
+
+    const completed = await json(`/api/golf-tours/${tourId}/complete`, {
+      method: "POST",
+      userId: "user-host",
+    });
+    expect(completed.status).toBe(200);
+    expect(((await completed.json()) as { tour: PublicTour }).tour.status).toBe(
+      "completed",
+    );
+
+    const afterComplete = await json(`/api/golf-tours/${tourId}/rounds`, {
+      method: "POST",
+      userId: "user-host",
+      body: JSON.stringify({
+        date: "2026-09-13",
+        venueCmsId: "sanity-course-1",
+      }),
+    });
+    expect(afterComplete.status).toBe(400);
+  });
+
+  test("locking the last playable fourball auto-completes the tour", async () => {
+    const created = await json("/api/golf-tours", {
+      method: "POST",
+      userId: "user-host",
+      body: JSON.stringify({
+        name: "Solo Day",
+        startDate: "2026-09-12",
+        endDate: "2026-09-12",
+      }),
+    });
+    const { tour } = (await created.json()) as { tour: PublicTour };
+    const roundRes = await json(`/api/golf-tours/${tour.id}/rounds`, {
+      method: "POST",
+      userId: "user-host",
+      body: JSON.stringify({
+        date: "2026-09-12",
+        venueCmsId: "sanity-course-1",
+      }),
+    });
+    const withRound = (await roundRes.json()) as { tour: PublicTour };
+    const fbRes = await json(
+      `/api/golf-tours/${tour.id}/rounds/${withRound.tour.rounds[0]!.id}/fourballs`,
+      {
+        method: "POST",
+        userId: "user-host",
+        body: JSON.stringify({
+          campId: tour.camps[0]!.id,
+          players: [
+            {
+              slot: 1,
+              displayName: "Alex",
+              isGuest: false,
+              userId: "user-host",
+            },
+          ],
+        }),
+      },
+    );
+    const fb = (await fbRes.json()) as {
+      fourball: PublicTour["fourballs"][number];
+    };
+    const started = await json(
+      `/api/golf-tours/${tour.id}/fourballs/${fb.fourball.id}/start`,
+      {
+        method: "POST",
+        userId: "user-host",
+        body: JSON.stringify({ teeName: "White" }),
+      },
+    );
+    const startedBody = (await started.json()) as { golfRoundId: string };
+    const lock = await json(`/api/golf-rounds/${startedBody.golfRoundId}/lock`, {
+      method: "POST",
+      userId: "user-host",
+      body: JSON.stringify({ score: scoreForSlots([1], 5) }),
+    });
+    expect(lock.status).toBe(200);
+
+    const read = await json(`/api/golf-tours/${tour.id}`, {
+      userId: "user-host",
+    });
+    const body = (await read.json()) as { tour: PublicTour };
+    expect(body.tour.fourballs[0]!.status).toBe("locked");
+    expect(body.tour.status).toBe("completed");
+  });
+});

--- a/src/modules/golf-tours/entities/golf-tour-camp-name.ts
+++ b/src/modules/golf-tours/entities/golf-tour-camp-name.ts
@@ -1,0 +1,19 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const MAX_LENGTH = 40;
+
+export class GolfTourCampName {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): GolfTourCampName {
+    const name = requiredTrimmed(raw, "name");
+    if (name.length > MAX_LENGTH) {
+      throw new DomainError(`name must be at most ${MAX_LENGTH} characters`);
+    }
+    return new GolfTourCampName(name);
+  }
+
+  equals(other: GolfTourCampName): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-camp-not-found-error.ts
+++ b/src/modules/golf-tours/entities/golf-tour-camp-not-found-error.ts
@@ -1,0 +1,6 @@
+export class GolfTourCampNotFoundError extends Error {
+  constructor(message = "Camp not found") {
+    super(message);
+    this.name = "GolfTourCampNotFoundError";
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-camp.ts
+++ b/src/modules/golf-tours/entities/golf-tour-camp.ts
@@ -1,0 +1,83 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { GolfTourCampName } from "./golf-tour-camp-name";
+
+const COLOR_MAX_LENGTH = 32;
+
+export type GolfTourCampSnapshot = {
+  id: string;
+  name: string;
+  color: string | null;
+  sortOrder: number;
+};
+
+export class GolfTourCamp {
+  private constructor(
+    readonly id: string,
+    private nameValue: GolfTourCampName,
+    private colorValue: string | null,
+    readonly sortOrder: number,
+  ) {}
+
+  static create(props: {
+    id: string;
+    name: GolfTourCampName;
+    color?: string | null;
+    sortOrder: number;
+  }): GolfTourCamp {
+    return new GolfTourCamp(
+      props.id,
+      props.name,
+      parseColor(props.color),
+      props.sortOrder,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    name: GolfTourCampName;
+    color: string | null;
+    sortOrder: number;
+  }): GolfTourCamp {
+    return new GolfTourCamp(props.id, props.name, props.color, props.sortOrder);
+  }
+
+  static fromSnapshot(snapshot: GolfTourCampSnapshot): GolfTourCamp {
+    return GolfTourCamp.rehydrate({
+      id: snapshot.id,
+      name: GolfTourCampName.from(snapshot.name),
+      color: snapshot.color,
+      sortOrder: snapshot.sortOrder,
+    });
+  }
+
+  get name(): GolfTourCampName {
+    return this.nameValue;
+  }
+
+  get color(): string | null {
+    return this.colorValue;
+  }
+
+  rename(details: { name?: GolfTourCampName; color?: string | null }): void {
+    if (details.name) this.nameValue = details.name;
+    if ("color" in details) this.colorValue = parseColor(details.color);
+  }
+
+  toSnapshot(): GolfTourCampSnapshot {
+    return {
+      id: this.id,
+      name: this.nameValue.value,
+      color: this.colorValue,
+      sortOrder: this.sortOrder,
+    };
+  }
+}
+
+export function parseColor(raw: unknown): string | null {
+  if (raw == null || raw === "") return null;
+  const value = requiredTrimmed(raw, "color");
+  if (value.length > COLOR_MAX_LENGTH) {
+    throw new DomainError(`color must be at most ${COLOR_MAX_LENGTH} characters`);
+  }
+  return value;
+}

--- a/src/modules/golf-tours/entities/golf-tour-forbidden-error.ts
+++ b/src/modules/golf-tours/entities/golf-tour-forbidden-error.ts
@@ -1,0 +1,6 @@
+export class GolfTourForbiddenError extends Error {
+  constructor(message = "Not allowed for this golf tour") {
+    super(message);
+    this.name = "GolfTourForbiddenError";
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-format.ts
+++ b/src/modules/golf-tours/entities/golf-tour-format.ts
@@ -1,0 +1,37 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const GOLF_TOUR_FORMATS = ["stroke"] as const;
+export type GolfTourFormatValue = (typeof GOLF_TOUR_FORMATS)[number];
+
+/**
+ * Pluggable scoring format. v1 is stroke only. v1.1 may add scramble
+ * (and later handicap nets) without changing the tour aggregate.
+ */
+export class GolfTourFormat {
+  static readonly STROKE = new GolfTourFormat("stroke");
+
+  private constructor(readonly value: GolfTourFormatValue) {}
+
+  static from(raw: unknown): GolfTourFormat {
+    if (raw == null || raw === "") return GolfTourFormat.STROKE;
+    if (typeof raw !== "string") {
+      throw new DomainError("format must be stroke");
+    }
+    const format = raw.trim().toLowerCase();
+    if (format === "stroke") return GolfTourFormat.STROKE;
+    if (format === "scramble") {
+      throw new DomainError(
+        "format scramble is not supported in v1; only stroke is enabled",
+      );
+    }
+    throw new DomainError("format must be stroke");
+  }
+
+  get isStroke(): boolean {
+    return this.value === "stroke";
+  }
+
+  equals(other: GolfTourFormat): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-fourball-not-found-error.ts
+++ b/src/modules/golf-tours/entities/golf-tour-fourball-not-found-error.ts
@@ -1,0 +1,6 @@
+export class GolfTourFourballNotFoundError extends Error {
+  constructor(message = "Fourball not found") {
+    super(message);
+    this.name = "GolfTourFourballNotFoundError";
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-fourball-status.ts
+++ b/src/modules/golf-tours/entities/golf-tour-fourball-status.ts
@@ -1,0 +1,53 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const GOLF_TOUR_FOURBALL_STATUSES = [
+  "pending",
+  "live",
+  "locked",
+  "cancelled",
+] as const;
+export type GolfTourFourballStatusValue =
+  (typeof GOLF_TOUR_FOURBALL_STATUSES)[number];
+
+export class GolfTourFourballStatus {
+  static readonly PENDING = new GolfTourFourballStatus("pending");
+  static readonly LIVE = new GolfTourFourballStatus("live");
+  static readonly LOCKED = new GolfTourFourballStatus("locked");
+  static readonly CANCELLED = new GolfTourFourballStatus("cancelled");
+
+  private constructor(readonly value: GolfTourFourballStatusValue) {}
+
+  static from(raw: unknown): GolfTourFourballStatus {
+    if (raw === "pending") return GolfTourFourballStatus.PENDING;
+    if (raw === "live") return GolfTourFourballStatus.LIVE;
+    if (raw === "locked") return GolfTourFourballStatus.LOCKED;
+    if (raw === "cancelled") return GolfTourFourballStatus.CANCELLED;
+    throw new DomainError(
+      "status must be pending, live, locked, or cancelled",
+    );
+  }
+
+  get isPending(): boolean {
+    return this.value === "pending";
+  }
+
+  get isLive(): boolean {
+    return this.value === "live";
+  }
+
+  get isLocked(): boolean {
+    return this.value === "locked";
+  }
+
+  get isCancelled(): boolean {
+    return this.value === "cancelled";
+  }
+
+  get isPlayable(): boolean {
+    return this.isPending || this.isLive || this.isLocked;
+  }
+
+  equals(other: GolfTourFourballStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-fourball.ts
+++ b/src/modules/golf-tours/entities/golf-tour-fourball.ts
@@ -1,0 +1,172 @@
+import { DomainError } from "../../../lib/domain-error";
+import {
+  GolfPlayer,
+  GolfPlayerInput,
+  GolfPlayerSnapshot,
+} from "../../golf-round/entities/golf-player";
+import { GolfTourFourballStatus } from "./golf-tour-fourball-status";
+import { GolfTourNotReadyError } from "./golf-tour-not-ready-error";
+
+export type GolfTourFourballSnapshot = {
+  id: string;
+  roundId: string;
+  campId: string;
+  golfRoundId: string | null;
+  status: "pending" | "live" | "locked" | "cancelled";
+  players: GolfPlayerSnapshot[];
+};
+
+export class GolfTourFourball {
+  private constructor(
+    readonly id: string,
+    readonly roundId: string,
+    private campIdValue: string,
+    private golfRoundIdValue: string | null,
+    private statusValue: GolfTourFourballStatus,
+    private playersValue: GolfPlayer[],
+  ) {}
+
+  static create(props: {
+    id: string;
+    roundId: string;
+    campId: string;
+    players?: GolfPlayer[];
+  }): GolfTourFourball {
+    return new GolfTourFourball(
+      props.id,
+      props.roundId,
+      props.campId,
+      null,
+      GolfTourFourballStatus.PENDING,
+      props.players ?? [],
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    roundId: string;
+    campId: string;
+    golfRoundId: string | null;
+    status: GolfTourFourballStatus;
+    players: GolfPlayer[];
+  }): GolfTourFourball {
+    return new GolfTourFourball(
+      props.id,
+      props.roundId,
+      props.campId,
+      props.golfRoundId,
+      props.status,
+      [...props.players],
+    );
+  }
+
+  static fromSnapshot(snapshot: GolfTourFourballSnapshot): GolfTourFourball {
+    return GolfTourFourball.rehydrate({
+      id: snapshot.id,
+      roundId: snapshot.roundId,
+      campId: snapshot.campId,
+      golfRoundId: snapshot.golfRoundId,
+      status: GolfTourFourballStatus.from(snapshot.status),
+      players: snapshot.players.map((player) => GolfPlayer.from(player)),
+    });
+  }
+
+  get campId(): string {
+    return this.campIdValue;
+  }
+
+  get golfRoundId(): string | null {
+    return this.golfRoundIdValue;
+  }
+
+  get status(): GolfTourFourballStatus {
+    return this.statusValue;
+  }
+
+  get players(): readonly GolfPlayer[] {
+    return this.playersValue;
+  }
+
+  get path(): string | null {
+    return this.golfRoundIdValue ? `/golf/${this.golfRoundIdValue}` : null;
+  }
+
+  hasPlayerUserId(userId: string): boolean {
+    return this.playersValue.some((player) => player.hasUserId(userId));
+  }
+
+  assignPlayers(players: GolfPlayer[]): void {
+    if (!this.statusValue.isPending) {
+      throw new DomainError("Players can only be assigned while the fourball is pending");
+    }
+    this.playersValue = players;
+  }
+
+  moveToCamp(campId: string): void {
+    if (!this.statusValue.isPending) {
+      throw new DomainError("Camp can only be changed while the fourball is pending");
+    }
+    this.campIdValue = campId;
+  }
+
+  cancel(): void {
+    if (!this.statusValue.isPending) {
+      throw new DomainError("Only a pending fourball can be cancelled");
+    }
+    this.statusValue = GolfTourFourballStatus.CANCELLED;
+  }
+
+  start(golfRoundId: string): void {
+    if (this.statusValue.isLive && this.golfRoundIdValue === golfRoundId) {
+      return;
+    }
+    if (this.statusValue.isLocked && this.golfRoundIdValue === golfRoundId) {
+      return;
+    }
+    if (!this.statusValue.isPending) {
+      throw new DomainError("Only a pending fourball can be started");
+    }
+    if (this.playersValue.length < 1) {
+      throw new GolfTourNotReadyError(
+        "Assign at least one player before starting this fourball",
+      );
+    }
+    const id = golfRoundId.trim();
+    if (!id) {
+      throw new DomainError("golfRoundId is required");
+    }
+    this.golfRoundIdValue = id;
+    this.statusValue = GolfTourFourballStatus.LIVE;
+  }
+
+  lockFromScorecard(golfRoundId: string): void {
+    if (this.golfRoundIdValue !== golfRoundId) return;
+    if (this.statusValue.isLocked) return;
+    if (!this.statusValue.isLive) return;
+    this.statusValue = GolfTourFourballStatus.LOCKED;
+  }
+
+  toSnapshot(): GolfTourFourballSnapshot {
+    return {
+      id: this.id,
+      roundId: this.roundId,
+      campId: this.campIdValue,
+      golfRoundId: this.golfRoundIdValue,
+      status: this.statusValue.value,
+      players: this.playersValue.map((player) => player.toSnapshot()),
+    };
+  }
+}
+
+export function parseFourballPlayers(raw: unknown): GolfPlayer[] {
+  if (raw == null) return [];
+  if (!Array.isArray(raw)) {
+    throw new DomainError("players must be an array");
+  }
+  if (raw.length === 0) return [];
+  return GolfPlayer.fromPlayers(raw as GolfPlayerInput[]);
+}
+
+export function golfRoundPath(golfRoundId: string): string {
+  return `/golf/${golfRoundId}`;
+}

--- a/src/modules/golf-tours/entities/golf-tour-name.ts
+++ b/src/modules/golf-tours/entities/golf-tour-name.ts
@@ -1,0 +1,19 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+const MAX_LENGTH = 80;
+
+export class GolfTourName {
+  private constructor(readonly value: string) {}
+
+  static from(raw: unknown): GolfTourName {
+    const name = requiredTrimmed(raw, "name");
+    if (name.length > MAX_LENGTH) {
+      throw new DomainError(`name must be at most ${MAX_LENGTH} characters`);
+    }
+    return new GolfTourName(name);
+  }
+
+  equals(other: GolfTourName): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-not-found-error.ts
+++ b/src/modules/golf-tours/entities/golf-tour-not-found-error.ts
@@ -1,0 +1,6 @@
+export class GolfTourNotFoundError extends Error {
+  constructor(message = "Golf tour not found") {
+    super(message);
+    this.name = "GolfTourNotFoundError";
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-not-ready-error.ts
+++ b/src/modules/golf-tours/entities/golf-tour-not-ready-error.ts
@@ -1,0 +1,6 @@
+export class GolfTourNotReadyError extends Error {
+  constructor(message = "Golf tour is not ready") {
+    super(message);
+    this.name = "GolfTourNotReadyError";
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-persistence-error.ts
+++ b/src/modules/golf-tours/entities/golf-tour-persistence-error.ts
@@ -1,0 +1,6 @@
+export class GolfTourPersistenceError extends Error {
+  constructor(message = "Unable to save golf tour", options?: ErrorOptions) {
+    super(message, options);
+    this.name = "GolfTourPersistenceError";
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-round-not-found-error.ts
+++ b/src/modules/golf-tours/entities/golf-tour-round-not-found-error.ts
@@ -1,0 +1,6 @@
+export class GolfTourRoundNotFoundError extends Error {
+  constructor(message = "Tour round not found") {
+    super(message);
+    this.name = "GolfTourRoundNotFoundError";
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-round.ts
+++ b/src/modules/golf-tours/entities/golf-tour-round.ts
@@ -1,0 +1,113 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { CmsId } from "../../venue/entities/cms-id";
+import { GolfTourFormat } from "./golf-tour-format";
+import { TourDate } from "./tour-date";
+
+const LABEL_MAX_LENGTH = 80;
+
+export type GolfTourRoundSnapshot = {
+  id: string;
+  date: string;
+  venueCmsId: string;
+  label: string | null;
+  format: "stroke";
+};
+
+export class GolfTourRound {
+  private constructor(
+    readonly id: string,
+    private dateValue: TourDate,
+    private venueCmsIdValue: CmsId,
+    private labelValue: string | null,
+    private formatValue: GolfTourFormat,
+  ) {}
+
+  static create(props: {
+    id: string;
+    date: TourDate;
+    venueCmsId: CmsId;
+    label?: string | null;
+    format?: GolfTourFormat;
+  }): GolfTourRound {
+    return new GolfTourRound(
+      props.id,
+      props.date,
+      props.venueCmsId,
+      parseLabel(props.label),
+      props.format ?? GolfTourFormat.STROKE,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    date: TourDate;
+    venueCmsId: CmsId;
+    label: string | null;
+    format: GolfTourFormat;
+  }): GolfTourRound {
+    return new GolfTourRound(
+      props.id,
+      props.date,
+      props.venueCmsId,
+      props.label,
+      props.format,
+    );
+  }
+
+  static fromSnapshot(snapshot: GolfTourRoundSnapshot): GolfTourRound {
+    return GolfTourRound.rehydrate({
+      id: snapshot.id,
+      date: TourDate.from(snapshot.date, "date"),
+      venueCmsId: CmsId.from(snapshot.venueCmsId),
+      label: snapshot.label,
+      format: GolfTourFormat.from(snapshot.format),
+    });
+  }
+
+  get date(): TourDate {
+    return this.dateValue;
+  }
+
+  get venueCmsId(): CmsId {
+    return this.venueCmsIdValue;
+  }
+
+  get label(): string | null {
+    return this.labelValue;
+  }
+
+  get format(): GolfTourFormat {
+    return this.formatValue;
+  }
+
+  update(details: {
+    date?: TourDate;
+    venueCmsId?: CmsId;
+    label?: string | null;
+    format?: GolfTourFormat;
+  }): void {
+    if (details.date) this.dateValue = details.date;
+    if (details.venueCmsId) this.venueCmsIdValue = details.venueCmsId;
+    if ("label" in details) this.labelValue = parseLabel(details.label);
+    if (details.format) this.formatValue = details.format;
+  }
+
+  toSnapshot(): GolfTourRoundSnapshot {
+    return {
+      id: this.id,
+      date: this.dateValue.toDayString(),
+      venueCmsId: this.venueCmsIdValue.value,
+      label: this.labelValue,
+      format: this.formatValue.value,
+    };
+  }
+}
+
+export function parseLabel(raw: unknown): string | null {
+  if (raw == null || raw === "") return null;
+  const value = requiredTrimmed(raw, "label");
+  if (value.length > LABEL_MAX_LENGTH) {
+    throw new DomainError(`label must be at most ${LABEL_MAX_LENGTH} characters`);
+  }
+  return value;
+}

--- a/src/modules/golf-tours/entities/golf-tour-status.ts
+++ b/src/modules/golf-tours/entities/golf-tour-status.ts
@@ -1,0 +1,39 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const GOLF_TOUR_STATUSES = ["draft", "active", "completed"] as const;
+export type GolfTourStatusValue = (typeof GOLF_TOUR_STATUSES)[number];
+
+export class GolfTourStatus {
+  static readonly DRAFT = new GolfTourStatus("draft");
+  static readonly ACTIVE = new GolfTourStatus("active");
+  static readonly COMPLETED = new GolfTourStatus("completed");
+
+  private constructor(readonly value: GolfTourStatusValue) {}
+
+  static from(raw: unknown): GolfTourStatus {
+    if (raw === "draft") return GolfTourStatus.DRAFT;
+    if (raw === "active") return GolfTourStatus.ACTIVE;
+    if (raw === "completed") return GolfTourStatus.COMPLETED;
+    throw new DomainError("status must be draft, active, or completed");
+  }
+
+  get isDraft(): boolean {
+    return this.value === "draft";
+  }
+
+  get isActive(): boolean {
+    return this.value === "active";
+  }
+
+  get isCompleted(): boolean {
+    return this.value === "completed";
+  }
+
+  get isMutable(): boolean {
+    return !this.isCompleted;
+  }
+
+  equals(other: GolfTourStatus): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-venue-not-found-error.ts
+++ b/src/modules/golf-tours/entities/golf-tour-venue-not-found-error.ts
@@ -1,0 +1,6 @@
+export class GolfTourVenueNotFoundError extends Error {
+  constructor(message = "Venue not found") {
+    super(message);
+    this.name = "GolfTourVenueNotFoundError";
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour.test.ts
+++ b/src/modules/golf-tours/entities/golf-tour.test.ts
@@ -1,0 +1,182 @@
+import { DomainError } from "../../../lib/domain-error";
+import { GolfPlayer } from "../../golf-round/entities/golf-player";
+import { CmsId } from "../../venue/entities/cms-id";
+import { GolfTour } from "./golf-tour";
+import { GolfTourCampName } from "./golf-tour-camp-name";
+import { GolfTourForbiddenError } from "./golf-tour-forbidden-error";
+import { GolfTourFormat } from "./golf-tour-format";
+import { GolfTourName } from "./golf-tour-name";
+import { GolfTourNotReadyError } from "./golf-tour-not-ready-error";
+import { GolfTourStatus } from "./golf-tour-status";
+import { TourDate } from "./tour-date";
+import { parseFourballPlayers } from "./golf-tour-fourball";
+
+function draft() {
+  return GolfTour.create({
+    name: GolfTourName.from("Friends Cup"),
+    startDate: TourDate.from("2026-09-12", "startDate"),
+    endDate: TourDate.from("2026-09-14", "endDate"),
+    hostUserId: "user-host",
+  });
+}
+
+describe("golf tour value objects", () => {
+  test("status is a closed enum", () => {
+    expect(GolfTourStatus.from("draft").isDraft).toBe(true);
+    expect(() => GolfTourStatus.from("registration")).toThrow(DomainError);
+  });
+
+  test("format is stroke only in v1", () => {
+    expect(GolfTourFormat.from(undefined).isStroke).toBe(true);
+    expect(GolfTourFormat.from("STROKE").value).toBe("stroke");
+    expect(() => GolfTourFormat.from("scramble")).toThrow(
+      /scramble is not supported in v1/,
+    );
+  });
+
+  test("tour dates reject inverted ranges via the aggregate", () => {
+    expect(() =>
+      GolfTour.create({
+        name: GolfTourName.from("Nope"),
+        startDate: TourDate.from("2026-09-14", "startDate"),
+        endDate: TourDate.from("2026-09-12", "endDate"),
+        hostUserId: "user-host",
+      }),
+    ).toThrow(DomainError);
+  });
+});
+
+describe(GolfTour, () => {
+  test("create is a draft with two default camps", () => {
+    const tour = draft();
+    const snapshot = tour.toSnapshot();
+    expect(snapshot).toMatchObject({
+      name: "Friends Cup",
+      startDate: "2026-09-12",
+      endDate: "2026-09-14",
+      status: "draft",
+      hostUserId: "user-host",
+    });
+    expect(snapshot.camps).toHaveLength(2);
+    expect(snapshot.camps.map((camp) => camp.name)).toEqual([
+      "Camp A",
+      "Camp B",
+    ]);
+    expect(snapshot.rounds).toEqual([]);
+    expect(snapshot.fourballs).toEqual([]);
+  });
+
+  test("only the host can edit, add camps, or complete", () => {
+    const tour = draft();
+    expect(() =>
+      tour.updateDetails("user-z", { name: GolfTourName.from("Nope") }),
+    ).toThrow(GolfTourForbiddenError);
+    expect(() =>
+      tour.addCamp("user-z", { name: GolfTourCampName.from("Camp C") }),
+    ).toThrow(GolfTourForbiddenError);
+    expect(() => tour.complete("user-z")).toThrow(GolfTourForbiddenError);
+
+    tour.updateDetails("user-host", { name: GolfTourName.from("Renamed") });
+    expect(tour.name.value).toBe("Renamed");
+    tour.addCamp("user-host", { name: GolfTourCampName.from("Camp C") });
+    expect(tour.camps).toHaveLength(3);
+  });
+
+  test("rounds must fall within the tour dates", () => {
+    const tour = draft();
+    expect(() =>
+      tour.addRound("user-host", {
+        date: TourDate.from("2026-09-20", "date"),
+        venueCmsId: CmsId.from("course-1"),
+      }),
+    ).toThrow(DomainError);
+
+    const round = tour.addRound("user-host", {
+      date: TourDate.from("2026-09-13", "date"),
+      venueCmsId: CmsId.from("course-1"),
+      label: "Saturday AM",
+    });
+    expect(round.toSnapshot()).toMatchObject({
+      date: "2026-09-13",
+      venueCmsId: "course-1",
+      label: "Saturday AM",
+      format: "stroke",
+    });
+  });
+
+  test("fourball start requires players and activates the tour", () => {
+    const tour = draft();
+    const round = tour.addRound("user-host", {
+      date: TourDate.from("2026-09-12", "date"),
+      venueCmsId: CmsId.from("course-1"),
+    });
+    const fourball = tour.addFourball("user-host", {
+      roundId: round.id,
+      campId: tour.camps[0]!.id,
+    });
+    expect(() => tour.startFourball(fourball.id, "golf-1")).toThrow(
+      GolfTourNotReadyError,
+    );
+
+    tour.assignFourballPlayers("user-host", fourball.id, [
+      GolfPlayer.from({
+        slot: 1,
+        displayName: "Alex",
+        isGuest: false,
+        userId: "user-alex",
+      }),
+    ]);
+    tour.startFourball(fourball.id, "golf-1");
+    expect(tour.status.isActive).toBe(true);
+    expect(tour.fourballById(fourball.id)?.status.isLive).toBe(true);
+    expect(tour.fourballById(fourball.id)?.golfRoundId).toBe("golf-1");
+    expect(tour.fourballById(fourball.id)?.path).toBe("/golf/golf-1");
+  });
+
+  test("locking the last playable fourball auto-completes the tour", () => {
+    const tour = draft();
+    const round = tour.addRound("user-host", {
+      date: TourDate.from("2026-09-12", "date"),
+      venueCmsId: CmsId.from("course-1"),
+    });
+    const fourball = tour.addFourball("user-host", {
+      roundId: round.id,
+      campId: tour.camps[0]!.id,
+      players: parseFourballPlayers([
+        { slot: 1, displayName: "Alex", isGuest: false, userId: "user-alex" },
+      ]),
+    });
+    tour.startFourball(fourball.id, "golf-1");
+    tour.lockFourballFromScorecard("golf-1");
+    expect(tour.fourballById(fourball.id)?.status.isLocked).toBe(true);
+    expect(tour.status.isCompleted).toBe(true);
+  });
+
+  test("host can complete while fourballs are still pending", () => {
+    const tour = draft();
+    tour.complete("user-host");
+    expect(tour.status.isCompleted).toBe(true);
+    expect(() =>
+      tour.addCamp("user-host", { name: GolfTourCampName.from("Late") }),
+    ).toThrow(DomainError);
+  });
+
+  test("seated players can read the tour; outsiders cannot", () => {
+    const tour = draft();
+    const round = tour.addRound("user-host", {
+      date: TourDate.from("2026-09-12", "date"),
+      venueCmsId: CmsId.from("course-1"),
+    });
+    tour.addFourball("user-host", {
+      roundId: round.id,
+      campId: tour.camps[0]!.id,
+      players: parseFourballPlayers([
+        { slot: 1, displayName: "Alex", isGuest: false, userId: "user-alex" },
+        { slot: 2, displayName: "Pat", isGuest: true, userId: null },
+      ]),
+    });
+    expect(tour.canRead("user-host")).toBe(true);
+    expect(tour.canRead("user-alex")).toBe(true);
+    expect(tour.canRead("user-stranger")).toBe(false);
+  });
+});

--- a/src/modules/golf-tours/entities/golf-tour.ts
+++ b/src/modules/golf-tours/entities/golf-tour.ts
@@ -1,0 +1,480 @@
+import { randomUUID } from "node:crypto";
+
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import type { GolfPlayer } from "../../golf-round/entities/golf-player";
+import { CmsId } from "../../venue/entities/cms-id";
+import { GolfTourCamp } from "./golf-tour-camp";
+import { GolfTourCampName } from "./golf-tour-camp-name";
+import { GolfTourCampNotFoundError } from "./golf-tour-camp-not-found-error";
+import { GolfTourForbiddenError } from "./golf-tour-forbidden-error";
+import { GolfTourFormat } from "./golf-tour-format";
+import { GolfTourFourball } from "./golf-tour-fourball";
+import { GolfTourFourballNotFoundError } from "./golf-tour-fourball-not-found-error";
+import { GolfTourName } from "./golf-tour-name";
+import { GolfTourRound } from "./golf-tour-round";
+import { GolfTourRoundNotFoundError } from "./golf-tour-round-not-found-error";
+import { GolfTourStatus } from "./golf-tour-status";
+import { TourDate } from "./tour-date";
+
+export const DEFAULT_CAMP_NAMES = ["Camp A", "Camp B"] as const;
+
+export type GolfTourSnapshot = {
+  id: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  status: "draft" | "active" | "completed";
+  hostUserId: string;
+  createdAt: string;
+  updatedAt: string;
+  camps: ReturnType<GolfTourCamp["toSnapshot"]>[];
+  rounds: ReturnType<GolfTourRound["toSnapshot"]>[];
+  fourballs: ReturnType<GolfTourFourball["toSnapshot"]>[];
+};
+
+export type CreateGolfTourProps = {
+  name: GolfTourName;
+  startDate: TourDate;
+  endDate: TourDate;
+  hostUserId: string;
+  campNames?: GolfTourCampName[];
+};
+
+export type UpdateGolfTourDetailsProps = {
+  name?: GolfTourName;
+  startDate?: TourDate;
+  endDate?: TourDate;
+};
+
+export class GolfTour {
+  private constructor(
+    readonly id: string,
+    private nameValue: GolfTourName,
+    private startDateValue: TourDate,
+    private endDateValue: TourDate,
+    private statusValue: GolfTourStatus,
+    readonly hostUserId: string,
+    readonly createdAt: Date,
+    private updatedAtValue: Date,
+    private campsValue: GolfTourCamp[],
+    private roundsValue: GolfTourRound[],
+    private fourballsValue: GolfTourFourball[],
+  ) {}
+
+  static create(props: CreateGolfTourProps): GolfTour {
+    const hostUserId = requiredTrimmed(props.hostUserId, "userId");
+    assertDateRange(props.startDate, props.endDate);
+    const campNames = props.campNames ?? [
+      GolfTourCampName.from(DEFAULT_CAMP_NAMES[0]),
+      GolfTourCampName.from(DEFAULT_CAMP_NAMES[1]),
+    ];
+    if (campNames.length < 2) {
+      throw new DomainError("A tour needs at least two camps");
+    }
+    const now = new Date();
+    const camps = campNames.map((name, index) =>
+      GolfTourCamp.create({
+        id: randomUUID(),
+        name,
+        sortOrder: index,
+      }),
+    );
+    return new GolfTour(
+      randomUUID(),
+      props.name,
+      props.startDate,
+      props.endDate,
+      GolfTourStatus.DRAFT,
+      hostUserId,
+      now,
+      now,
+      camps,
+      [],
+      [],
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    name: GolfTourName;
+    startDate: TourDate;
+    endDate: TourDate;
+    status: GolfTourStatus;
+    hostUserId: string;
+    createdAt: Date;
+    updatedAt: Date;
+    camps: GolfTourCamp[];
+    rounds: GolfTourRound[];
+    fourballs: GolfTourFourball[];
+  }): GolfTour {
+    return new GolfTour(
+      props.id,
+      props.name,
+      props.startDate,
+      props.endDate,
+      props.status,
+      props.hostUserId,
+      props.createdAt,
+      props.updatedAt,
+      [...props.camps].sort((a, b) => a.sortOrder - b.sortOrder),
+      [...props.rounds],
+      [...props.fourballs],
+    );
+  }
+
+  static fromSnapshot(snapshot: GolfTourSnapshot): GolfTour {
+    return GolfTour.rehydrate({
+      id: snapshot.id,
+      name: GolfTourName.from(snapshot.name),
+      startDate: TourDate.from(snapshot.startDate, "startDate"),
+      endDate: TourDate.from(snapshot.endDate, "endDate"),
+      status: GolfTourStatus.from(snapshot.status),
+      hostUserId: snapshot.hostUserId,
+      createdAt: new Date(snapshot.createdAt),
+      updatedAt: new Date(snapshot.updatedAt),
+      camps: snapshot.camps.map((camp) => GolfTourCamp.fromSnapshot(camp)),
+      rounds: snapshot.rounds.map((round) => GolfTourRound.fromSnapshot(round)),
+      fourballs: snapshot.fourballs.map((fourball) =>
+        GolfTourFourball.fromSnapshot(fourball),
+      ),
+    });
+  }
+
+  get name(): GolfTourName {
+    return this.nameValue;
+  }
+
+  get startDate(): TourDate {
+    return this.startDateValue;
+  }
+
+  get endDate(): TourDate {
+    return this.endDateValue;
+  }
+
+  get status(): GolfTourStatus {
+    return this.statusValue;
+  }
+
+  get updatedAt(): Date {
+    return this.updatedAtValue;
+  }
+
+  get camps(): readonly GolfTourCamp[] {
+    return this.campsValue;
+  }
+
+  get rounds(): readonly GolfTourRound[] {
+    return this.roundsValue;
+  }
+
+  get fourballs(): readonly GolfTourFourball[] {
+    return this.fourballsValue;
+  }
+
+  isHost(userId: string): boolean {
+    return this.hostUserId === userId.trim();
+  }
+
+  isPlayer(userId: string): boolean {
+    const id = userId.trim();
+    return this.fourballsValue.some((fourball) => fourball.hasPlayerUserId(id));
+  }
+
+  canRead(userId: string): boolean {
+    return this.isHost(userId) || this.isPlayer(userId);
+  }
+
+  campById(campId: string): GolfTourCamp | null {
+    return this.campsValue.find((camp) => camp.id === campId) ?? null;
+  }
+
+  roundById(roundId: string): GolfTourRound | null {
+    return this.roundsValue.find((round) => round.id === roundId) ?? null;
+  }
+
+  fourballById(fourballId: string): GolfTourFourball | null {
+    return (
+      this.fourballsValue.find((fourball) => fourball.id === fourballId) ?? null
+    );
+  }
+
+  fourballByGolfRoundId(golfRoundId: string): GolfTourFourball | null {
+    const id = golfRoundId.trim();
+    return (
+      this.fourballsValue.find((fourball) => fourball.golfRoundId === id) ??
+      null
+    );
+  }
+
+  assertHost(userId: string): void {
+    if (!this.isHost(userId)) {
+      throw new GolfTourForbiddenError("Only the tour host can do that");
+    }
+  }
+
+  assertCanStartFourball(userId: string, fourball: GolfTourFourball): void {
+    if (this.isHost(userId) || fourball.hasPlayerUserId(userId)) return;
+    throw new GolfTourForbiddenError(
+      "Only the host or a seated player can start this fourball",
+    );
+  }
+
+  updateDetails(actorId: string, details: UpdateGolfTourDetailsProps): void {
+    this.assertHost(actorId);
+    this.assertMutable();
+    if (!details.name && !details.startDate && !details.endDate) {
+      throw new DomainError("At least one field is required");
+    }
+    const start = details.startDate ?? this.startDateValue;
+    const end = details.endDate ?? this.endDateValue;
+    assertDateRange(start, end);
+    for (const round of this.roundsValue) {
+      if (!round.date.isWithin(start, end)) {
+        throw new DomainError(
+          "Existing rounds must stay within the tour start and end dates",
+        );
+      }
+    }
+    if (details.name) this.nameValue = details.name;
+    this.startDateValue = start;
+    this.endDateValue = end;
+    this.touch();
+  }
+
+  addCamp(
+    actorId: string,
+    props: { name: GolfTourCampName; color?: string | null },
+  ): GolfTourCamp {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const sortOrder =
+      this.campsValue.reduce((max, camp) => Math.max(max, camp.sortOrder), -1) +
+      1;
+    const camp = GolfTourCamp.create({
+      id: randomUUID(),
+      name: props.name,
+      color: props.color,
+      sortOrder,
+    });
+    this.campsValue = [...this.campsValue, camp];
+    this.touch();
+    return camp;
+  }
+
+  renameCamp(
+    actorId: string,
+    campId: string,
+    details: { name?: GolfTourCampName; color?: string | null },
+  ): GolfTourCamp {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const camp = this.requireCamp(campId);
+    if (!details.name && !("color" in details)) {
+      throw new DomainError("At least one field is required");
+    }
+    camp.rename(details);
+    this.touch();
+    return camp;
+  }
+
+  addRound(
+    actorId: string,
+    props: {
+      date: TourDate;
+      venueCmsId: CmsId;
+      label?: string | null;
+      format?: GolfTourFormat;
+    },
+  ): GolfTourRound {
+    this.assertHost(actorId);
+    this.assertMutable();
+    this.assertRoundDate(props.date);
+    const round = GolfTourRound.create({
+      id: randomUUID(),
+      date: props.date,
+      venueCmsId: props.venueCmsId,
+      label: props.label,
+      format: props.format,
+    });
+    this.roundsValue = [...this.roundsValue, round];
+    this.touch();
+    return round;
+  }
+
+  updateRound(
+    actorId: string,
+    roundId: string,
+    details: {
+      date?: TourDate;
+      venueCmsId?: CmsId;
+      label?: string | null;
+      format?: GolfTourFormat;
+    },
+  ): GolfTourRound {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const round = this.requireRound(roundId);
+    if (
+      !details.date &&
+      !details.venueCmsId &&
+      !("label" in details) &&
+      !details.format
+    ) {
+      throw new DomainError("At least one field is required");
+    }
+    const nextDate = details.date ?? round.date;
+    this.assertRoundDate(nextDate);
+    round.update(details);
+    this.touch();
+    return round;
+  }
+
+  addFourball(
+    actorId: string,
+    props: { roundId: string; campId: string; players?: GolfPlayer[] },
+  ): GolfTourFourball {
+    this.assertHost(actorId);
+    this.assertMutable();
+    this.requireRound(props.roundId);
+    this.requireCamp(props.campId);
+    const fourball = GolfTourFourball.create({
+      id: randomUUID(),
+      roundId: props.roundId,
+      campId: props.campId,
+      players: props.players,
+    });
+    this.fourballsValue = [...this.fourballsValue, fourball];
+    this.touch();
+    return fourball;
+  }
+
+  assignFourballPlayers(
+    actorId: string,
+    fourballId: string,
+    players: GolfPlayer[],
+  ): GolfTourFourball {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const fourball = this.requireFourball(fourballId);
+    fourball.assignPlayers(players);
+    this.touch();
+    return fourball;
+  }
+
+  moveFourballCamp(
+    actorId: string,
+    fourballId: string,
+    campId: string,
+  ): GolfTourFourball {
+    this.assertHost(actorId);
+    this.assertMutable();
+    this.requireCamp(campId);
+    const fourball = this.requireFourball(fourballId);
+    fourball.moveToCamp(campId);
+    this.touch();
+    return fourball;
+  }
+
+  cancelFourball(actorId: string, fourballId: string): GolfTourFourball {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const fourball = this.requireFourball(fourballId);
+    fourball.cancel();
+    this.touch();
+    return fourball;
+  }
+
+  startFourball(fourballId: string, golfRoundId: string): GolfTourFourball {
+    this.assertMutable();
+    const fourball = this.requireFourball(fourballId);
+    fourball.start(golfRoundId);
+    if (this.statusValue.isDraft) {
+      this.statusValue = GolfTourStatus.ACTIVE;
+    }
+    this.touch();
+    return fourball;
+  }
+
+  lockFourballFromScorecard(golfRoundId: string): GolfTourFourball | null {
+    const fourball = this.fourballByGolfRoundId(golfRoundId);
+    if (!fourball) return null;
+    fourball.lockFromScorecard(golfRoundId);
+    if (this.shouldAutoComplete()) {
+      this.statusValue = GolfTourStatus.COMPLETED;
+    }
+    this.touch();
+    return fourball;
+  }
+
+  complete(actorId: string): void {
+    this.assertHost(actorId);
+    if (this.statusValue.isCompleted) return;
+    this.statusValue = GolfTourStatus.COMPLETED;
+    this.touch();
+  }
+
+  shouldAutoComplete(): boolean {
+    const playable = this.fourballsValue.filter(
+      (fourball) => !fourball.status.isCancelled,
+    );
+    if (playable.length === 0) return false;
+    return playable.every((fourball) => fourball.status.isLocked);
+  }
+
+  toSnapshot(): GolfTourSnapshot {
+    return {
+      id: this.id,
+      name: this.nameValue.value,
+      startDate: this.startDateValue.toDayString(),
+      endDate: this.endDateValue.toDayString(),
+      status: this.statusValue.value,
+      hostUserId: this.hostUserId,
+      createdAt: this.createdAt.toISOString(),
+      updatedAt: this.updatedAtValue.toISOString(),
+      camps: this.campsValue.map((camp) => camp.toSnapshot()),
+      rounds: this.roundsValue.map((round) => round.toSnapshot()),
+      fourballs: this.fourballsValue.map((fourball) => fourball.toSnapshot()),
+    };
+  }
+
+  private requireCamp(campId: string): GolfTourCamp {
+    const camp = this.campById(campId.trim());
+    if (!camp) throw new GolfTourCampNotFoundError();
+    return camp;
+  }
+
+  private requireRound(roundId: string): GolfTourRound {
+    const round = this.roundById(roundId.trim());
+    if (!round) throw new GolfTourRoundNotFoundError();
+    return round;
+  }
+
+  private requireFourball(fourballId: string): GolfTourFourball {
+    const fourball = this.fourballById(fourballId.trim());
+    if (!fourball) throw new GolfTourFourballNotFoundError();
+    return fourball;
+  }
+
+  private assertMutable(): void {
+    if (!this.statusValue.isMutable) {
+      throw new DomainError("A completed tour cannot be changed");
+    }
+  }
+
+  private assertRoundDate(date: TourDate): void {
+    if (!date.isWithin(this.startDateValue, this.endDateValue)) {
+      throw new DomainError("Round date must be within the tour start and end dates");
+    }
+  }
+
+  private touch(now = new Date()): void {
+    this.updatedAtValue = now;
+  }
+}
+
+function assertDateRange(start: TourDate, end: TourDate): void {
+  if (end.isBefore(start)) {
+    throw new DomainError("endDate must be on or after startDate");
+  }
+}

--- a/src/modules/golf-tours/entities/tour-date.ts
+++ b/src/modules/golf-tours/entities/tour-date.ts
@@ -1,0 +1,60 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export class TourDate {
+  private constructor(readonly value: Date) {}
+
+  static from(raw: unknown, field = "date"): TourDate {
+    if (raw instanceof Date) {
+      if (Number.isNaN(raw.getTime())) {
+        throw new DomainError(`${field} is invalid`);
+      }
+      return new TourDate(utcDay(raw));
+    }
+    if (typeof raw !== "string") {
+      throw new DomainError(`${field} is required`);
+    }
+    const trimmed = raw.trim();
+    const match = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (!match) {
+      throw new DomainError(`${field} must be an ISO date (YYYY-MM-DD)`);
+    }
+    const date = new Date(`${match[1]}-${match[2]}-${match[3]}T00:00:00.000Z`);
+    if (Number.isNaN(date.getTime())) {
+      throw new DomainError(`${field} is invalid`);
+    }
+    if (date.toISOString().slice(0, 10) !== `${match[1]}-${match[2]}-${match[3]}`) {
+      throw new DomainError(`${field} is invalid`);
+    }
+    return new TourDate(date);
+  }
+
+  toDayString(): string {
+    return this.value.toISOString().slice(0, 10);
+  }
+
+  toStartsAtIso(): string {
+    return `${this.toDayString()}T08:00:00.000Z`;
+  }
+
+  isAfter(other: TourDate): boolean {
+    return this.value.getTime() > other.value.getTime();
+  }
+
+  isBefore(other: TourDate): boolean {
+    return this.value.getTime() < other.value.getTime();
+  }
+
+  isWithin(start: TourDate, end: TourDate): boolean {
+    return !this.isBefore(start) && !this.isAfter(end);
+  }
+
+  equals(other: TourDate): boolean {
+    return this.value.getTime() === other.value.getTime();
+  }
+}
+
+function utcDay(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+}

--- a/src/modules/golf-tours/index.ts
+++ b/src/modules/golf-tours/index.ts
@@ -1,0 +1,116 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { GolfRoundRepository } from "../golf-round/repositories/golf-round.repository";
+import { CreateGolfRound } from "../golf-round/services/create-golf-round.service";
+import { GetGolfRoundById } from "../golf-round/services/get-golf-round-by-id.service";
+import { VenueRepository } from "../venue/repositories/venue.repository";
+import { createGolfToursController } from "./controllers/golf-tours.controller";
+import { PrismaGolfTourRepository } from "./repositories/prisma-golf-tour.repository";
+import { GolfTourRepository } from "./repositories/golf-tour.repository";
+import { createGolfToursRoutes } from "./routes/golf-tours.routes";
+import { LockGolfTourFourballOnScorecardLock } from "./services/lock-fourball-on-scorecard-lock";
+import {
+  AddGolfTourCamp,
+  AddGolfTourFourball,
+  AddGolfTourRound,
+  CompleteGolfTour,
+  CreateGolfTour,
+  GetGolfTour,
+  GetGolfTourLeaderboard,
+  ListMyGolfTours,
+  StartGolfTourFourball,
+  UpdateGolfTour,
+  UpdateGolfTourCamp,
+  UpdateGolfTourFourball,
+  UpdateGolfTourRound,
+} from "./services/golf-tours.service";
+
+export type CreateGolfToursModuleParams = {
+  prisma: PrismaClient;
+  venueRepository: VenueRepository;
+  golfRoundRepository: GolfRoundRepository;
+  golfTourRepository?: GolfTourRepository;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type GolfToursModule = {
+  router: Router;
+  golfTourRepository: GolfTourRepository;
+  lockFourballOnScorecardLock: LockGolfTourFourballOnScorecardLock;
+};
+
+export function createGolfToursModule({
+  prisma,
+  venueRepository,
+  golfRoundRepository,
+  golfTourRepository: golfTourRepositoryOverride,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreateGolfToursModuleParams): GolfToursModule {
+  const golfTourRepository =
+    golfTourRepositoryOverride ?? new PrismaGolfTourRepository(prisma);
+
+  const controller = createGolfToursController({
+    createGolfTour: new CreateGolfTour(golfTourRepository),
+    getGolfTour: new GetGolfTour(golfTourRepository),
+    updateGolfTour: new UpdateGolfTour(golfTourRepository),
+    completeGolfTour: new CompleteGolfTour(golfTourRepository),
+    listMyGolfTours: new ListMyGolfTours(golfTourRepository),
+    addCamp: new AddGolfTourCamp(golfTourRepository),
+    updateCamp: new UpdateGolfTourCamp(golfTourRepository),
+    addRound: new AddGolfTourRound(golfTourRepository, venueRepository),
+    updateRound: new UpdateGolfTourRound(golfTourRepository, venueRepository),
+    addFourball: new AddGolfTourFourball(golfTourRepository),
+    updateFourball: new UpdateGolfTourFourball(golfTourRepository),
+    startFourball: new StartGolfTourFourball(
+      golfTourRepository,
+      new CreateGolfRound(golfRoundRepository, venueRepository),
+    ),
+    getLeaderboard: new GetGolfTourLeaderboard(
+      golfTourRepository,
+      new GetGolfRoundById(golfRoundRepository),
+    ),
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createGolfToursRoutes(controller, { requireAuth }),
+    golfTourRepository,
+    lockFourballOnScorecardLock: new LockGolfTourFourballOnScorecardLock(
+      golfTourRepository,
+    ),
+  };
+}
+
+export { createGolfToursController } from "./controllers/golf-tours.controller";
+export { InMemoryGolfTourRepository } from "./repositories/in-memory-golf-tour.repository";
+export { PrismaGolfTourRepository } from "./repositories/prisma-golf-tour.repository";
+export type { GolfTourRepository } from "./repositories/golf-tour.repository";
+export { GolfTour } from "./entities/golf-tour";
+export { LockGolfTourFourballOnScorecardLock } from "./services/lock-fourball-on-scorecard-lock";
+export {
+  AddGolfTourCamp,
+  AddGolfTourFourball,
+  AddGolfTourRound,
+  CompleteGolfTour,
+  CreateGolfTour,
+  GetGolfTour,
+  GetGolfTourLeaderboard,
+  ListMyGolfTours,
+  StartGolfTourFourball,
+  UpdateGolfTour,
+  UpdateGolfTourCamp,
+  UpdateGolfTourFourball,
+  UpdateGolfTourRound,
+} from "./services/golf-tours.service";
+export type {
+  PublicGolfTour,
+  PublicGolfTourSummary,
+} from "./services/golf-tours.service";

--- a/src/modules/golf-tours/repositories/golf-tour.repository.ts
+++ b/src/modules/golf-tours/repositories/golf-tour.repository.ts
@@ -1,0 +1,10 @@
+import { GolfTour } from "../entities/golf-tour";
+
+export interface GolfTourRepository {
+  findById(id: string): Promise<GolfTour | null>;
+  findByGolfRoundId(golfRoundId: string): Promise<GolfTour | null>;
+  create(tour: GolfTour): Promise<GolfTour>;
+  persist(tour: GolfTour): Promise<GolfTour>;
+  listForHost(userId: string): Promise<GolfTour[]>;
+  listForPlayerUserId(userId: string): Promise<GolfTour[]>;
+}

--- a/src/modules/golf-tours/repositories/in-memory-golf-tour.repository.ts
+++ b/src/modules/golf-tours/repositories/in-memory-golf-tour.repository.ts
@@ -1,0 +1,55 @@
+import { GolfTour } from "../entities/golf-tour";
+import { GolfTourPersistenceError } from "../entities/golf-tour-persistence-error";
+import { GolfTourRepository } from "./golf-tour.repository";
+
+export class InMemoryGolfTourRepository implements GolfTourRepository {
+  private readonly byId = new Map<string, GolfTour>();
+
+  async findById(id: string): Promise<GolfTour | null> {
+    return clone(this.byId.get(id) ?? null);
+  }
+
+  async findByGolfRoundId(golfRoundId: string): Promise<GolfTour | null> {
+    const id = golfRoundId.trim();
+    for (const tour of this.byId.values()) {
+      if (tour.fourballByGolfRoundId(id)) {
+        return clone(tour);
+      }
+    }
+    return null;
+  }
+
+  async create(tour: GolfTour): Promise<GolfTour> {
+    const stored = clone(tour)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async persist(tour: GolfTour): Promise<GolfTour> {
+    if (!this.byId.has(tour.id)) {
+      throw new GolfTourPersistenceError("Unable to save golf tour");
+    }
+    const stored = clone(tour)!;
+    this.byId.set(stored.id, stored);
+    return clone(stored)!;
+  }
+
+  async listForHost(userId: string): Promise<GolfTour[]> {
+    return [...this.byId.values()]
+      .filter((tour) => tour.isHost(userId))
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+      .map((tour) => clone(tour)!);
+  }
+
+  async listForPlayerUserId(userId: string): Promise<GolfTour[]> {
+    return [...this.byId.values()]
+      .filter((tour) => tour.isPlayer(userId))
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())
+      .map((tour) => clone(tour)!);
+  }
+}
+
+function clone(tour: GolfTour | null): GolfTour | null {
+  if (!tour) return null;
+  return GolfTour.fromSnapshot(tour.toSnapshot());
+}

--- a/src/modules/golf-tours/repositories/prisma-golf-tour.repository.ts
+++ b/src/modules/golf-tours/repositories/prisma-golf-tour.repository.ts
@@ -1,0 +1,322 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { GolfPlayer } from "../../golf-round/entities/golf-player";
+import { CmsId } from "../../venue/entities/cms-id";
+import { GolfTour } from "../entities/golf-tour";
+import { GolfTourCamp } from "../entities/golf-tour-camp";
+import { GolfTourCampName } from "../entities/golf-tour-camp-name";
+import { GolfTourFormat } from "../entities/golf-tour-format";
+import { GolfTourFourball } from "../entities/golf-tour-fourball";
+import { GolfTourFourballStatus } from "../entities/golf-tour-fourball-status";
+import { GolfTourName } from "../entities/golf-tour-name";
+import { GolfTourPersistenceError } from "../entities/golf-tour-persistence-error";
+import { GolfTourRound } from "../entities/golf-tour-round";
+import { GolfTourStatus } from "../entities/golf-tour-status";
+import { TourDate } from "../entities/tour-date";
+import { GolfTourRepository } from "./golf-tour.repository";
+
+type PlayerRow = {
+  slot: number;
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+};
+
+type FourballRow = {
+  id: string;
+  roundId: string;
+  campId: string;
+  golfRoundId: string | null;
+  status: "pending" | "live" | "locked" | "cancelled";
+  players: PlayerRow[];
+};
+
+type CampRow = {
+  id: string;
+  name: string;
+  color: string | null;
+  sortOrder: number;
+};
+
+type RoundRow = {
+  id: string;
+  date: Date;
+  venueCmsId: string;
+  label: string | null;
+  format: "stroke";
+};
+
+type TourRow = {
+  id: string;
+  name: string;
+  startDate: Date;
+  endDate: Date;
+  status: "draft" | "active" | "completed";
+  hostUserId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  camps: CampRow[];
+  rounds: RoundRow[];
+  fourballs: FourballRow[];
+};
+
+const includeRelations = {
+  camps: { orderBy: { sortOrder: "asc" as const } },
+  rounds: { orderBy: { date: "asc" as const } },
+  fourballs: {
+    orderBy: { createdAt: "asc" as const },
+    include: { players: { orderBy: { slot: "asc" as const } } },
+  },
+};
+
+function toDomain(row: TourRow): GolfTour {
+  return GolfTour.rehydrate({
+    id: row.id,
+    name: GolfTourName.from(row.name),
+    startDate: TourDate.from(row.startDate, "startDate"),
+    endDate: TourDate.from(row.endDate, "endDate"),
+    status: GolfTourStatus.from(row.status),
+    hostUserId: row.hostUserId,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    camps: row.camps.map((camp) =>
+      GolfTourCamp.rehydrate({
+        id: camp.id,
+        name: GolfTourCampName.from(camp.name),
+        color: camp.color,
+        sortOrder: camp.sortOrder,
+      }),
+    ),
+    rounds: row.rounds.map((round) =>
+      GolfTourRound.rehydrate({
+        id: round.id,
+        date: TourDate.from(round.date, "date"),
+        venueCmsId: CmsId.from(round.venueCmsId),
+        label: round.label,
+        format: GolfTourFormat.from(round.format),
+      }),
+    ),
+    fourballs: row.fourballs.map((fourball) =>
+      GolfTourFourball.rehydrate({
+        id: fourball.id,
+        roundId: fourball.roundId,
+        campId: fourball.campId,
+        golfRoundId: fourball.golfRoundId,
+        status: GolfTourFourballStatus.from(fourball.status),
+        players: fourball.players.map((player) =>
+          GolfPlayer.from({
+            slot: player.slot,
+            userId: player.userId,
+            displayName: player.displayName,
+            isGuest: player.isGuest,
+          }),
+        ),
+      }),
+    ),
+  });
+}
+
+export class PrismaGolfTourRepository implements GolfTourRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(id: string): Promise<GolfTour | null> {
+    try {
+      const row = await this.prisma.golfTour.findUnique({
+        where: { id },
+        include: includeRelations,
+      });
+      return row ? toDomain(row) : null;
+    } catch (error) {
+      throw new GolfTourPersistenceError("Failed to load golf tour", {
+        cause: error,
+      });
+    }
+  }
+
+  async findByGolfRoundId(golfRoundId: string): Promise<GolfTour | null> {
+    try {
+      const fourball = await this.prisma.golfTourFourball.findUnique({
+        where: { golfRoundId: golfRoundId.trim() },
+        select: { tourId: true },
+      });
+      if (!fourball) return null;
+      return this.findById(fourball.tourId);
+    } catch (error) {
+      throw new GolfTourPersistenceError("Failed to load golf tour", {
+        cause: error,
+      });
+    }
+  }
+
+  async create(tour: GolfTour): Promise<GolfTour> {
+    const snapshot = tour.toSnapshot();
+    try {
+      const row = await this.prisma.golfTour.create({
+        data: {
+          id: snapshot.id,
+          name: snapshot.name,
+          startDate: tour.startDate.value,
+          endDate: tour.endDate.value,
+          status: snapshot.status,
+          hostUserId: snapshot.hostUserId,
+          createdAt: tour.createdAt,
+          updatedAt: tour.updatedAt,
+          camps: {
+            create: snapshot.camps.map((camp) => ({
+              id: camp.id,
+              name: camp.name,
+              color: camp.color,
+              sortOrder: camp.sortOrder,
+            })),
+          },
+        },
+        include: includeRelations,
+      });
+      return toDomain(row);
+    } catch (error) {
+      throw new GolfTourPersistenceError("Failed to create golf tour", {
+        cause: error,
+      });
+    }
+  }
+
+  async persist(tour: GolfTour): Promise<GolfTour> {
+    const snapshot = tour.toSnapshot();
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.golfTour.update({
+          where: { id: snapshot.id },
+          data: {
+            name: snapshot.name,
+            startDate: tour.startDate.value,
+            endDate: tour.endDate.value,
+            status: snapshot.status,
+            updatedAt: tour.updatedAt,
+          },
+        });
+
+        for (const camp of snapshot.camps) {
+          await tx.golfTourCamp.upsert({
+            where: { id: camp.id },
+            create: {
+              id: camp.id,
+              tourId: snapshot.id,
+              name: camp.name,
+              color: camp.color,
+              sortOrder: camp.sortOrder,
+            },
+            update: {
+              name: camp.name,
+              color: camp.color,
+              sortOrder: camp.sortOrder,
+            },
+          });
+        }
+
+        for (const round of snapshot.rounds) {
+          await tx.golfTourRound.upsert({
+            where: { id: round.id },
+            create: {
+              id: round.id,
+              tourId: snapshot.id,
+              date: TourDate.from(round.date, "date").value,
+              venueCmsId: round.venueCmsId,
+              label: round.label,
+              format: round.format,
+            },
+            update: {
+              date: TourDate.from(round.date, "date").value,
+              venueCmsId: round.venueCmsId,
+              label: round.label,
+              format: round.format,
+            },
+          });
+        }
+
+        const fourballIds = snapshot.fourballs.map((fourball) => fourball.id);
+        await tx.golfTourFourball.deleteMany({
+          where: {
+            tourId: snapshot.id,
+            id: { notIn: fourballIds },
+          },
+        });
+
+        for (const fourball of snapshot.fourballs) {
+          await tx.golfTourFourball.upsert({
+            where: { id: fourball.id },
+            create: {
+              id: fourball.id,
+              tourId: snapshot.id,
+              roundId: fourball.roundId,
+              campId: fourball.campId,
+              golfRoundId: fourball.golfRoundId,
+              status: fourball.status,
+            },
+            update: {
+              campId: fourball.campId,
+              golfRoundId: fourball.golfRoundId,
+              status: fourball.status,
+            },
+          });
+
+          await tx.golfTourFourballPlayer.deleteMany({
+            where: { fourballId: fourball.id },
+          });
+          if (fourball.players.length > 0) {
+            await tx.golfTourFourballPlayer.createMany({
+              data: fourball.players.map((player) => ({
+                fourballId: fourball.id,
+                slot: player.slot,
+                userId: player.userId,
+                displayName: player.displayName,
+                isGuest: player.isGuest,
+              })),
+            });
+          }
+        }
+      });
+
+      const reloaded = await this.findById(snapshot.id);
+      if (!reloaded) {
+        throw new GolfTourPersistenceError("Failed to load golf tour");
+      }
+      return reloaded;
+    } catch (error) {
+      if (error instanceof GolfTourPersistenceError) throw error;
+      throw new GolfTourPersistenceError("Failed to save golf tour", {
+        cause: error,
+      });
+    }
+  }
+
+  async listForHost(userId: string): Promise<GolfTour[]> {
+    try {
+      const rows = await this.prisma.golfTour.findMany({
+        where: { hostUserId: userId },
+        include: includeRelations,
+        orderBy: { updatedAt: "desc" },
+      });
+      return rows.map(toDomain);
+    } catch (error) {
+      throw new GolfTourPersistenceError("Failed to list golf tours", {
+        cause: error,
+      });
+    }
+  }
+
+  async listForPlayerUserId(userId: string): Promise<GolfTour[]> {
+    try {
+      const rows = await this.prisma.golfTour.findMany({
+        where: {
+          fourballs: { some: { players: { some: { userId } } } },
+        },
+        include: includeRelations,
+        orderBy: { updatedAt: "desc" },
+      });
+      return rows.map(toDomain);
+    } catch (error) {
+      throw new GolfTourPersistenceError("Failed to list golf tours", {
+        cause: error,
+      });
+    }
+  }
+}

--- a/src/modules/golf-tours/routes/golf-tours.routes.ts
+++ b/src/modules/golf-tours/routes/golf-tours.routes.ts
@@ -1,0 +1,94 @@
+import { Router } from "express";
+
+import { createGolfToursController } from "../controllers/golf-tours.controller";
+
+export function createGolfToursRoutes(
+  controller: ReturnType<typeof createGolfToursController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.post("/api/golf-tours", options.requireAuth, (req, res) => {
+    void controller.create(req, res);
+  });
+
+  router.get("/api/golf-tours/mine", options.requireAuth, (req, res) => {
+    void controller.listMine(req, res);
+  });
+
+  router.get("/api/golf-tours/:id", options.requireAuth, (req, res) => {
+    void controller.get(req, res);
+  });
+
+  router.patch("/api/golf-tours/:id", options.requireAuth, (req, res) => {
+    void controller.update(req, res);
+  });
+
+  router.post("/api/golf-tours/:id/complete", options.requireAuth, (req, res) => {
+    void controller.complete(req, res);
+  });
+
+  router.post("/api/golf-tours/:id/camps", options.requireAuth, (req, res) => {
+    void controller.addCamp(req, res);
+  });
+
+  router.patch(
+    "/api/golf-tours/:id/camps/:campId",
+    options.requireAuth,
+    (req, res) => {
+      void controller.updateCamp(req, res);
+    },
+  );
+
+  router.post("/api/golf-tours/:id/rounds", options.requireAuth, (req, res) => {
+    void controller.addRound(req, res);
+  });
+
+  router.patch(
+    "/api/golf-tours/:id/rounds/:roundId",
+    options.requireAuth,
+    (req, res) => {
+      void controller.updateRound(req, res);
+    },
+  );
+
+  router.post(
+    "/api/golf-tours/:id/rounds/:roundId/fourballs",
+    options.requireAuth,
+    (req, res) => {
+      void controller.addFourball(req, res);
+    },
+  );
+
+  router.patch(
+    "/api/golf-tours/:id/fourballs/:fourballId",
+    options.requireAuth,
+    (req, res) => {
+      void controller.updateFourball(req, res);
+    },
+  );
+
+  router.post(
+    "/api/golf-tours/:id/fourballs/:fourballId/start",
+    options.requireAuth,
+    (req, res) => {
+      void controller.startFourball(req, res);
+    },
+  );
+
+  router.get(
+    "/api/golf-tours/:id/leaderboard",
+    options.requireAuth,
+    (req, res) => {
+      void controller.leaderboard(req, res);
+    },
+  );
+
+  return router;
+}

--- a/src/modules/golf-tours/services/golf-tours.service.test.ts
+++ b/src/modules/golf-tours/services/golf-tours.service.test.ts
@@ -1,0 +1,270 @@
+import { DomainError } from "../../../lib/domain-error";
+import { InMemoryGolfRoundRepository } from "../../golf-round/repositories/in-memory-golf-round.repository";
+import { CreateGolfRound } from "../../golf-round/services/create-golf-round.service";
+import { GetGolfRoundById } from "../../golf-round/services/get-golf-round-by-id.service";
+import { LockGolfRound } from "../../golf-round/services/lock-golf-round.service";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { GolfTourForbiddenError } from "../entities/golf-tour-forbidden-error";
+import { GolfTourNotFoundError } from "../entities/golf-tour-not-found-error";
+import { InMemoryGolfTourRepository } from "../repositories/in-memory-golf-tour.repository";
+import { LockGolfTourFourballOnScorecardLock } from "./lock-fourball-on-scorecard-lock";
+import {
+  AddGolfTourFourball,
+  AddGolfTourRound,
+  CompleteGolfTour,
+  CreateGolfTour,
+  GetGolfTour,
+  GetGolfTourLeaderboard,
+  StartGolfTourFourball,
+  UpdateGolfTour,
+} from "./golf-tours.service";
+
+const COURSE = "sanity-course-1";
+
+async function seedVenue(venues: InMemoryVenueRepository) {
+  await venues.ensureFromCms(
+    Venue.registerFromCms(
+      CmsId.from(COURSE),
+      VenueName.from("Golf Club"),
+      Slug.from("golf-club"),
+    ),
+    { refreshDetails: false },
+  );
+}
+
+function scoreForSlots(slots: number[], stroke: number) {
+  return {
+    holes: Array.from({ length: 9 }, (_, index) => ({
+      number: index + 1,
+      strokes: Object.fromEntries(slots.map((slot) => [String(slot), stroke])),
+    })),
+  };
+}
+
+describe("golf tours application", () => {
+  async function setup() {
+    const tours = new InMemoryGolfTourRepository();
+    const venues = new InMemoryVenueRepository();
+    const golf = new InMemoryGolfRoundRepository();
+    await seedVenue(venues);
+    const createGolfRound = new CreateGolfRound(golf, venues);
+    const lockFourball = new LockGolfTourFourballOnScorecardLock(tours);
+    const lockGolf = new LockGolfRound(golf, (event) => lockFourball.execute(event));
+    return {
+      tours,
+      venues,
+      golf,
+      create: new CreateGolfTour(tours),
+      get: new GetGolfTour(tours),
+      update: new UpdateGolfTour(tours),
+      complete: new CompleteGolfTour(tours),
+      addRound: new AddGolfTourRound(tours, venues),
+      addFourball: new AddGolfTourFourball(tours),
+      start: new StartGolfTourFourball(tours, createGolfRound),
+      leaderboard: new GetGolfTourLeaderboard(tours, new GetGolfRoundById(golf)),
+      lockGolf,
+    };
+  }
+
+  test("create defaults to two camps", async () => {
+    const ctx = await setup();
+    const { tour } = await ctx.create.execute({
+      userId: "user-host",
+      name: "Friends Cup",
+      startDate: "2026-09-12",
+      endDate: "2026-09-14",
+    });
+    expect(tour.status).toBe("draft");
+    expect(tour.camps.map((camp) => camp.name)).toEqual(["Camp A", "Camp B"]);
+    expect(tour.viewer.role).toBe("host");
+  });
+
+  test("start creates a golf round and returns golfRoundId + path", async () => {
+    const ctx = await setup();
+    const created = await ctx.create.execute({
+      userId: "user-host",
+      name: "Friends Cup",
+      startDate: "2026-09-12",
+      endDate: "2026-09-14",
+    });
+    const withRound = await ctx.addRound.execute({
+      userId: "user-host",
+      tourId: created.tour.id,
+      date: "2026-09-12",
+      venueCmsId: COURSE,
+      label: "Saturday AM",
+    });
+    const roundId = withRound.tour.rounds[0]!.id;
+    const withFourball = await ctx.addFourball.execute({
+      userId: "user-host",
+      tourId: created.tour.id,
+      roundId,
+      campId: created.tour.camps[0]!.id,
+      players: [
+        { slot: 1, displayName: "Alex", isGuest: false, userId: "user-host" },
+        { slot: 2, displayName: "Pat", isGuest: true, userId: null },
+      ],
+    });
+
+    const started = await ctx.start.execute({
+      userId: "user-host",
+      tourId: created.tour.id,
+      fourballId: withFourball.fourball.id,
+      teeName: "White",
+    });
+
+    expect(started.golfRoundId).toBeTruthy();
+    expect(started.path).toBe(`/golf/${started.golfRoundId}`);
+    expect(started.fourball.status).toBe("live");
+    expect(started.tour.status).toBe("active");
+    const card = await ctx.golf.findById(started.golfRoundId);
+    expect(card?.venueCmsId.value).toBe(COURSE);
+    expect(card?.teeName).toBe("White");
+    expect(card?.holesPlayed).toBe(9);
+  });
+
+  test("leaderboard uses only locked cards and includes guests", async () => {
+    const ctx = await setup();
+    const created = await ctx.create.execute({
+      userId: "user-host",
+      name: "Friends Cup",
+      startDate: "2026-09-12",
+      endDate: "2026-09-14",
+    });
+    const tourId = created.tour.id;
+    const campA = created.tour.camps[0]!.id;
+    const withRound = await ctx.addRound.execute({
+      userId: "user-host",
+      tourId,
+      date: "2026-09-12",
+      venueCmsId: COURSE,
+    });
+    const roundId = withRound.tour.rounds[0]!.id;
+
+    const lockedFb = await ctx.addFourball.execute({
+      userId: "user-host",
+      tourId,
+      roundId,
+      campId: campA,
+      players: [
+        { slot: 1, displayName: "Alex", isGuest: false, userId: "user-host" },
+        { slot: 2, displayName: "Pat", isGuest: true, userId: null },
+      ],
+    });
+    const liveFb = await ctx.addFourball.execute({
+      userId: "user-host",
+      tourId,
+      roundId,
+      campId: campA,
+      players: [
+        { slot: 1, displayName: "Alex", isGuest: false, userId: "user-host" },
+        { slot: 2, displayName: "Sam", isGuest: false, userId: "user-sam" },
+      ],
+    });
+
+    const startedLocked = await ctx.start.execute({
+      userId: "user-host",
+      tourId,
+      fourballId: lockedFb.fourball.id,
+      teeName: "White",
+    });
+    await ctx.lockGolf.execute({
+      roundId: startedLocked.golfRoundId,
+      lockedByUserId: "user-host",
+      score: scoreForSlots([1, 2], 4),
+    });
+
+    await ctx.start.execute({
+      userId: "user-host",
+      tourId,
+      fourballId: liveFb.fourball.id,
+      teeName: "White",
+    });
+
+    const { leaderboard } = await ctx.leaderboard.execute({
+      userId: "user-host",
+      tourId,
+    });
+    const camp = leaderboard.camps.find((row) => row.campId === campA)!;
+    expect(camp.players).toHaveLength(2);
+    expect(camp.players.map((player) => player.playerKey).sort()).toEqual([
+      "guest:pat",
+      "user:user-host",
+    ]);
+    expect(camp.players.every((player) => player.playerRoundsCounted === 1)).toBe(
+      true,
+    );
+    expect(camp.players.every((player) => player.totalStrokes === 36)).toBe(true);
+    expect(camp.players.find((player) => player.isGuest)?.displayName).toBe("Pat");
+  });
+
+  test("non-host cannot mutate; seated player can read", async () => {
+    const ctx = await setup();
+    const { tour } = await ctx.create.execute({
+      userId: "user-host",
+      name: "Friends Cup",
+      startDate: "2026-09-12",
+      endDate: "2026-09-14",
+    });
+    await expect(
+      ctx.update.execute({
+        userId: "user-other",
+        tourId: tour.id,
+        name: "Hijack",
+      }),
+    ).rejects.toBeInstanceOf(GolfTourForbiddenError);
+
+    const withRound = await ctx.addRound.execute({
+      userId: "user-host",
+      tourId: tour.id,
+      date: "2026-09-12",
+      venueCmsId: COURSE,
+    });
+    await ctx.addFourball.execute({
+      userId: "user-host",
+      tourId: tour.id,
+      roundId: withRound.tour.rounds[0]!.id,
+      campId: tour.camps[0]!.id,
+      players: [
+        { slot: 1, displayName: "Sam", isGuest: false, userId: "user-sam" },
+      ],
+    });
+
+    const asPlayer = await ctx.get.execute({
+      userId: "user-sam",
+      tourId: tour.id,
+    });
+    expect(asPlayer.tour.viewer.role).toBe("player");
+
+    await expect(
+      ctx.get.execute({ userId: "user-stranger", tourId: tour.id }),
+    ).rejects.toBeInstanceOf(GolfTourNotFoundError);
+  });
+
+  test("host complete freezes the tour", async () => {
+    const ctx = await setup();
+    const { tour } = await ctx.create.execute({
+      userId: "user-host",
+      name: "Friends Cup",
+      startDate: "2026-09-12",
+      endDate: "2026-09-14",
+    });
+    const completed = await ctx.complete.execute({
+      userId: "user-host",
+      tourId: tour.id,
+    });
+    expect(completed.tour.status).toBe("completed");
+    await expect(
+      ctx.addRound.execute({
+        userId: "user-host",
+        tourId: tour.id,
+        date: "2026-09-12",
+        venueCmsId: COURSE,
+      }),
+    ).rejects.toBeInstanceOf(DomainError);
+  });
+});

--- a/src/modules/golf-tours/services/golf-tours.service.ts
+++ b/src/modules/golf-tours/services/golf-tours.service.ts
@@ -1,0 +1,541 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import { GolfPlayerInput } from "../../golf-round/entities/golf-player";
+import { CreateGolfRound } from "../../golf-round/services/create-golf-round.service";
+import { GetGolfRoundById } from "../../golf-round/services/get-golf-round-by-id.service";
+import { defaultNineHoleCourse } from "../../organised-games/services/default-golf-course";
+import { CmsId } from "../../venue/entities/cms-id";
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { GolfTour } from "../entities/golf-tour";
+import { GolfTourCampName } from "../entities/golf-tour-camp-name";
+import { GolfTourFormat } from "../entities/golf-tour-format";
+import {
+  golfRoundPath,
+  parseFourballPlayers,
+} from "../entities/golf-tour-fourball";
+import { GolfTourName } from "../entities/golf-tour-name";
+import { GolfTourNotFoundError } from "../entities/golf-tour-not-found-error";
+import { GolfTourFourballNotFoundError } from "../entities/golf-tour-fourball-not-found-error";
+import { GolfTourVenueNotFoundError } from "../entities/golf-tour-venue-not-found-error";
+import { TourDate } from "../entities/tour-date";
+import { GolfTourRepository } from "../repositories/golf-tour.repository";
+import {
+  buildLeaderboard,
+  PublicGolfTourLeaderboard,
+} from "./leaderboard";
+
+export type PublicGolfTourPlayer = {
+  slot: 1 | 2 | 3 | 4;
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+};
+
+export type PublicGolfTourFourball = {
+  id: string;
+  roundId: string;
+  campId: string;
+  status: "pending" | "live" | "locked" | "cancelled";
+  golfRoundId: string | null;
+  path: string | null;
+  players: PublicGolfTourPlayer[];
+};
+
+export type PublicGolfTourCamp = {
+  id: string;
+  name: string;
+  color: string | null;
+  sortOrder: number;
+};
+
+export type PublicGolfTourRound = {
+  id: string;
+  date: string;
+  venueCmsId: string;
+  label: string | null;
+  format: "stroke";
+};
+
+export type PublicGolfTour = {
+  id: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  status: "draft" | "active" | "completed";
+  hostUserId: string;
+  viewer: { role: "host" | "player" };
+  camps: PublicGolfTourCamp[];
+  rounds: PublicGolfTourRound[];
+  fourballs: PublicGolfTourFourball[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PublicGolfTourSummary = {
+  id: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  status: "draft" | "active" | "completed";
+  hostUserId: string;
+  viewer: { role: "host" | "player" };
+  campCount: number;
+  roundCount: number;
+  fourballCount: number;
+  updatedAt: string;
+};
+
+function toPublicTour(tour: GolfTour, userId: string): PublicGolfTour {
+  const snapshot = tour.toSnapshot();
+  return {
+    id: snapshot.id,
+    name: snapshot.name,
+    startDate: snapshot.startDate,
+    endDate: snapshot.endDate,
+    status: snapshot.status,
+    hostUserId: snapshot.hostUserId,
+    viewer: { role: tour.isHost(userId) ? "host" : "player" },
+    camps: snapshot.camps,
+    rounds: snapshot.rounds,
+    fourballs: snapshot.fourballs.map((fourball) => ({
+      id: fourball.id,
+      roundId: fourball.roundId,
+      campId: fourball.campId,
+      status: fourball.status,
+      golfRoundId: fourball.golfRoundId,
+      path: fourball.golfRoundId ? golfRoundPath(fourball.golfRoundId) : null,
+      players: fourball.players,
+    })),
+    createdAt: snapshot.createdAt,
+    updatedAt: snapshot.updatedAt,
+  };
+}
+
+function toPublicSummary(tour: GolfTour, userId: string): PublicGolfTourSummary {
+  const snapshot = tour.toSnapshot();
+  return {
+    id: snapshot.id,
+    name: snapshot.name,
+    startDate: snapshot.startDate,
+    endDate: snapshot.endDate,
+    status: snapshot.status,
+    hostUserId: snapshot.hostUserId,
+    viewer: { role: tour.isHost(userId) ? "host" : "player" },
+    campCount: snapshot.camps.length,
+    roundCount: snapshot.rounds.length,
+    fourballCount: snapshot.fourballs.length,
+    updatedAt: snapshot.updatedAt,
+  };
+}
+
+async function requireReadableTour(
+  tours: GolfTourRepository,
+  tourId: string,
+  userId: string,
+): Promise<GolfTour> {
+  const tour = await tours.findById(tourId.trim());
+  if (!tour || !tour.canRead(userId)) {
+    throw new GolfTourNotFoundError();
+  }
+  return tour;
+}
+
+async function requireHostTour(
+  tours: GolfTourRepository,
+  tourId: string,
+  userId: string,
+): Promise<GolfTour> {
+  const tour = await tours.findById(tourId.trim());
+  if (!tour) throw new GolfTourNotFoundError();
+  tour.assertHost(userId);
+  return tour;
+}
+
+async function assertVenueExists(
+  venues: VenueRepository,
+  venueCmsId: CmsId,
+): Promise<void> {
+  const venue = await venues.findByCmsId(venueCmsId);
+  if (!venue) throw new GolfTourVenueNotFoundError();
+}
+
+function parseOptionalCampNames(raw: unknown): GolfTourCampName[] | undefined {
+  if (raw == null) return undefined;
+  if (!Array.isArray(raw)) {
+    throw new DomainError("campNames must be an array of names");
+  }
+  return raw.map((name) => GolfTourCampName.from(name));
+}
+
+export class CreateGolfTour {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    name: unknown;
+    startDate: unknown;
+    endDate: unknown;
+    campNames?: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = GolfTour.create({
+      name: GolfTourName.from(input.name),
+      startDate: TourDate.from(input.startDate, "startDate"),
+      endDate: TourDate.from(input.endDate, "endDate"),
+      hostUserId: userId,
+      campNames: parseOptionalCampNames(input.campNames),
+    });
+    const saved = await this.tours.create(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+export class GetGolfTour {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: { userId: string; tourId: string }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireReadableTour(this.tours, input.tourId, userId);
+    return { tour: toPublicTour(tour, userId) };
+  }
+}
+
+export class UpdateGolfTour {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    name?: unknown;
+    startDate?: unknown;
+    endDate?: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    tour.updateDetails(userId, {
+      name: input.name === undefined ? undefined : GolfTourName.from(input.name),
+      startDate:
+        input.startDate === undefined
+          ? undefined
+          : TourDate.from(input.startDate, "startDate"),
+      endDate:
+        input.endDate === undefined
+          ? undefined
+          : TourDate.from(input.endDate, "endDate"),
+    });
+    const saved = await this.tours.persist(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+export class CompleteGolfTour {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: { userId: string; tourId: string }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    tour.complete(userId);
+    const saved = await this.tours.persist(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+export class ListMyGolfTours {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: { userId: string }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const [hosting, playing] = await Promise.all([
+      this.tours.listForHost(userId),
+      this.tours.listForPlayerUserId(userId),
+    ]);
+    const byId = new Map<string, GolfTour>();
+    for (const tour of [...hosting, ...playing]) {
+      byId.set(tour.id, tour);
+    }
+    const tours = [...byId.values()].sort(
+      (a, b) => b.updatedAt.getTime() - a.updatedAt.getTime(),
+    );
+    return { tours: tours.map((tour) => toPublicSummary(tour, userId)) };
+  }
+}
+
+export class AddGolfTourCamp {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    name: unknown;
+    color?: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    tour.addCamp(userId, {
+      name: GolfTourCampName.from(input.name),
+      color: input.color as string | null | undefined,
+    });
+    const saved = await this.tours.persist(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+export class UpdateGolfTourCamp {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    campId: string;
+    name?: unknown;
+    color?: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    const details: { name?: GolfTourCampName; color?: string | null } = {};
+    if (input.name !== undefined) details.name = GolfTourCampName.from(input.name);
+    if ("color" in input) details.color = input.color as string | null;
+    tour.renameCamp(userId, input.campId, details);
+    const saved = await this.tours.persist(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+export class AddGolfTourRound {
+  constructor(
+    private readonly tours: GolfTourRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    date: unknown;
+    venueCmsId: unknown;
+    label?: unknown;
+    format?: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const venueCmsId = CmsId.from(input.venueCmsId);
+    await assertVenueExists(this.venues, venueCmsId);
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    tour.addRound(userId, {
+      date: TourDate.from(input.date, "date"),
+      venueCmsId,
+      label: input.label as string | null | undefined,
+      format: GolfTourFormat.from(input.format),
+    });
+    const saved = await this.tours.persist(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+export class UpdateGolfTourRound {
+  constructor(
+    private readonly tours: GolfTourRepository,
+    private readonly venues: VenueRepository,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    roundId: string;
+    date?: unknown;
+    venueCmsId?: unknown;
+    label?: unknown;
+    format?: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    const details: {
+      date?: TourDate;
+      venueCmsId?: CmsId;
+      label?: string | null;
+      format?: GolfTourFormat;
+    } = {};
+    if (input.date !== undefined) {
+      details.date = TourDate.from(input.date, "date");
+    }
+    if (input.venueCmsId !== undefined) {
+      const venueCmsId = CmsId.from(input.venueCmsId);
+      await assertVenueExists(this.venues, venueCmsId);
+      details.venueCmsId = venueCmsId;
+    }
+    if ("label" in input) details.label = input.label as string | null;
+    if (input.format !== undefined) details.format = GolfTourFormat.from(input.format);
+    tour.updateRound(userId, input.roundId, details);
+    const saved = await this.tours.persist(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+export class AddGolfTourFourball {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    roundId: string;
+    campId: unknown;
+    players?: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    const fourball = tour.addFourball(userId, {
+      roundId: input.roundId,
+      campId: requiredTrimmed(input.campId, "campId"),
+      players: parseFourballPlayers(input.players),
+    });
+    const saved = await this.tours.persist(tour);
+    return {
+      tour: toPublicTour(saved, userId),
+      fourball: toPublicTour(saved, userId).fourballs.find(
+        (row) => row.id === fourball.id,
+      )!,
+    };
+  }
+}
+
+export class UpdateGolfTourFourball {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    fourballId: string;
+    players?: unknown;
+    campId?: unknown;
+    status?: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    if (
+      input.players === undefined &&
+      input.campId === undefined &&
+      input.status === undefined
+    ) {
+      throw new DomainError("At least one field is required");
+    }
+    if (input.players !== undefined) {
+      tour.assignFourballPlayers(
+        userId,
+        input.fourballId,
+        parseFourballPlayers(input.players),
+      );
+    }
+    if (input.campId !== undefined) {
+      tour.moveFourballCamp(
+        userId,
+        input.fourballId,
+        requiredTrimmed(input.campId, "campId"),
+      );
+    }
+    if (input.status !== undefined) {
+      const status = requiredTrimmed(input.status, "status");
+      if (status !== "cancelled") {
+        throw new DomainError("status can only be set to cancelled");
+      }
+      tour.cancelFourball(userId, input.fourballId);
+    }
+    const saved = await this.tours.persist(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+export type StartGolfTourFourballInput = {
+  userId: string;
+  tourId: string;
+  fourballId: string;
+  teeName?: unknown;
+  holesPlayed?: unknown;
+  startingHole?: unknown;
+  course?: unknown;
+  players?: GolfPlayerInput[];
+};
+
+export class StartGolfTourFourball {
+  constructor(
+    private readonly tours: GolfTourRepository,
+    private readonly createGolfRound: CreateGolfRound,
+  ) {}
+
+  async execute(input: StartGolfTourFourballInput) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await this.tours.findById(input.tourId.trim());
+    if (!tour || !tour.canRead(userId)) {
+      throw new GolfTourNotFoundError();
+    }
+    const fourball = tour.fourballById(input.fourballId);
+    if (!fourball) throw new GolfTourFourballNotFoundError();
+    tour.assertCanStartFourball(userId, fourball);
+
+    if (fourball.golfRoundId && (fourball.status.isLive || fourball.status.isLocked)) {
+      return {
+        tour: toPublicTour(tour, userId),
+        fourball: toPublicTour(tour, userId).fourballs.find(
+          (row) => row.id === fourball.id,
+        )!,
+        golfRoundId: fourball.golfRoundId,
+        path: golfRoundPath(fourball.golfRoundId),
+      };
+    }
+
+    const round = tour.roundById(fourball.roundId);
+    if (!round) throw new GolfTourFourballNotFoundError();
+
+    const players =
+      input.players ??
+      fourball.players.map((player) => player.toSnapshot());
+    const holesPlayed = input.holesPlayed ?? 9;
+    const course =
+      input.course ??
+      (holesPlayed === 9 ? defaultNineHoleCourse() : undefined);
+
+    const golfRound = await this.createGolfRound.execute({
+      venueCmsId: round.venueCmsId.value,
+      startsAt: round.date.toStartsAtIso(),
+      holesPlayed,
+      startingHole: input.startingHole,
+      teeName: input.teeName,
+      course,
+      players,
+    });
+
+    tour.startFourball(fourball.id, golfRound.id);
+    const saved = await this.tours.persist(tour);
+    const publicTour = toPublicTour(saved, userId);
+    const publicFourball = publicTour.fourballs.find(
+      (row) => row.id === fourball.id,
+    )!;
+    return {
+      tour: publicTour,
+      fourball: publicFourball,
+      golfRoundId: golfRound.id,
+      path: golfRoundPath(golfRound.id),
+    };
+  }
+}
+
+export class GetGolfTourLeaderboard {
+  constructor(
+    private readonly tours: GolfTourRepository,
+    private readonly getGolfRound: GetGolfRoundById,
+  ) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+  }): Promise<{ leaderboard: PublicGolfTourLeaderboard }> {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireReadableTour(this.tours, input.tourId, userId);
+    const lockedRounds = new Map<
+      string,
+      NonNullable<Awaited<ReturnType<GetGolfRoundById["execute"]>>>
+    >();
+    for (const fourball of tour.fourballs) {
+      if (!fourball.status.isLocked || !fourball.golfRoundId) continue;
+      const round = await this.getGolfRound.execute(fourball.golfRoundId);
+      if (round) lockedRounds.set(fourball.golfRoundId, round);
+    }
+    return { leaderboard: buildLeaderboard(tour, lockedRounds) };
+  }
+}

--- a/src/modules/golf-tours/services/leaderboard.ts
+++ b/src/modules/golf-tours/services/leaderboard.ts
@@ -1,0 +1,145 @@
+import { GolfRound } from "../../golf-round/entities/golf-round";
+import { GolfScore } from "../../golf-round/entities/golf-score";
+import { GolfTour } from "../entities/golf-tour";
+import { GolfTourFourball } from "../entities/golf-tour-fourball";
+
+export type PublicLeaderboardPlayer = {
+  playerKey: string;
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+  avgGross: number;
+  playerRoundsCounted: number;
+  totalStrokes: number;
+};
+
+export type PublicCampLeaderboard = {
+  campId: string;
+  name: string;
+  color: string | null;
+  players: PublicLeaderboardPlayer[];
+};
+
+export type PublicGolfTourLeaderboard = {
+  tourId: string;
+  status: "draft" | "active" | "completed";
+  camps: PublicCampLeaderboard[];
+};
+
+/**
+ * Guest identity is the trimmed, lowercased display name within a camp
+ * (`guest:{name}`). Registered players use `user:{userId}`. The same guest
+ * name in two locked fourballs of one camp aggregates as one person.
+ */
+export function playerIdentityKey(player: {
+  userId: string | null;
+  isGuest: boolean;
+  displayName: string;
+}): string {
+  if (!player.isGuest && player.userId) {
+    return `user:${player.userId}`;
+  }
+  return `guest:${player.displayName.trim().toLowerCase()}`;
+}
+
+export function grossStrokesBySlot(score: GolfScore): Map<number, number> {
+  const totals = new Map<number, number>();
+  for (const hole of score.holes) {
+    for (const [slot, strokes] of Object.entries(hole.strokes)) {
+      const key = Number(slot);
+      totals.set(key, (totals.get(key) ?? 0) + strokes);
+    }
+  }
+  return totals;
+}
+
+type Accumulator = {
+  playerKey: string;
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+  totalStrokes: number;
+  playerRoundsCounted: number;
+};
+
+export function buildLeaderboard(
+  tour: GolfTour,
+  lockedRounds: Map<string, GolfRound>,
+): PublicGolfTourLeaderboard {
+  const camps = tour.camps.map((camp) => {
+    const byKey = new Map<string, Accumulator>();
+    const fourballs = tour.fourballs.filter(
+      (fourball) =>
+        fourball.campId === camp.id && fourball.status.isLocked,
+    );
+
+    for (const fourball of fourballs) {
+      addLockedFourball(fourball, lockedRounds, byKey);
+    }
+
+    const players = [...byKey.values()]
+      .map((row) => ({
+        playerKey: row.playerKey,
+        userId: row.userId,
+        displayName: row.displayName,
+        isGuest: row.isGuest,
+        totalStrokes: row.totalStrokes,
+        playerRoundsCounted: row.playerRoundsCounted,
+        avgGross: row.totalStrokes / row.playerRoundsCounted,
+      }))
+      .sort(compareLeaderboardPlayers);
+
+    return {
+      campId: camp.id,
+      name: camp.name.value,
+      color: camp.color,
+      players,
+    };
+  });
+
+  return {
+    tourId: tour.id,
+    status: tour.status.value,
+    camps,
+  };
+}
+
+function addLockedFourball(
+  fourball: GolfTourFourball,
+  lockedRounds: Map<string, GolfRound>,
+  byKey: Map<string, Accumulator>,
+): void {
+  if (!fourball.golfRoundId) return;
+  const round = lockedRounds.get(fourball.golfRoundId);
+  if (!round?.isLocked || !round.score) return;
+
+  const gross = grossStrokesBySlot(round.score);
+  for (const player of fourball.players) {
+    const strokes = gross.get(player.slot);
+    if (strokes == null) continue;
+    const playerKey = playerIdentityKey(player);
+    const existing = byKey.get(playerKey);
+    if (existing) {
+      existing.totalStrokes += strokes;
+      existing.playerRoundsCounted += 1;
+      continue;
+    }
+    byKey.set(playerKey, {
+      playerKey,
+      userId: player.userId,
+      displayName: player.displayName,
+      isGuest: player.isGuest,
+      totalStrokes: strokes,
+      playerRoundsCounted: 1,
+    });
+  }
+}
+
+function compareLeaderboardPlayers(
+  a: PublicLeaderboardPlayer,
+  b: PublicLeaderboardPlayer,
+): number {
+  if (a.avgGross !== b.avgGross) return a.avgGross - b.avgGross;
+  if (a.totalStrokes !== b.totalStrokes) return a.totalStrokes - b.totalStrokes;
+  return a.displayName.localeCompare(b.displayName);
+}

--- a/src/modules/golf-tours/services/lock-fourball-on-scorecard-lock.ts
+++ b/src/modules/golf-tours/services/lock-fourball-on-scorecard-lock.ts
@@ -1,0 +1,21 @@
+import { ScorecardLockedEvent } from "../../scorecards/on-scorecard-locked";
+import { GolfTourPersistenceError } from "../entities/golf-tour-persistence-error";
+import { GolfTourRepository } from "../repositories/golf-tour.repository";
+
+export class LockGolfTourFourballOnScorecardLock {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(event: ScorecardLockedEvent): Promise<void> {
+    if (event.sport !== "golf") return;
+    try {
+      const tour = await this.tours.findByGolfRoundId(event.scorecardId);
+      if (!tour) return;
+      const fourball = tour.lockFourballFromScorecard(event.scorecardId);
+      if (!fourball) return;
+      await this.tours.persist(tour);
+    } catch (error) {
+      if (error instanceof GolfTourPersistenceError) return;
+      console.error("Failed to lock golf tour fourball from scorecard lock", error);
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #54.

Multi-day multi-course friend golf event. Naming is **Tour** + **Camp** (N≥2). Not a single-elim Tournament.

Fourballs reuse the **existing golf scorecard**. Leaderboard is **average gross strokes per player-round** on **locked** cards only. `format` is pluggable; v1 is `stroke` only (scramble / handicaps = v1.1). Each fourball has its own golf round id for multi-device scoring.

**Do not merge** until ready to run `prisma migrate deploy` (`20260909120000_golf_tour`).

## Complete behavior

- Host `POST /api/golf-tours/:id/complete` may complete a draft/active tour at any time (including pending fourballs). Idempotent.
- Auto-complete when a fourball is locked from `POST /api/golf-rounds/:id/lock` **and** every non-cancelled fourball is locked. Empty tours are not auto-completed.

## Scoring

Per camp, across locked fourballs whose golf round is also locked:

```
avgGross = totalGrossStrokes / playerRoundsCounted
```

Sort: `avgGross` asc, then `totalStrokes` asc, then `displayName`. Guests use `guest:{trimmed lowercased displayName}` within a camp; registered players use `user:{userId}`.

## Frontend contract

Session cookie + `requireAuth` on every route. Dates are `YYYY-MM-DD`. Nested writes return `{ tour }`. Start returns `{ fourball, golfRoundId, path }` with `path = /golf/{golfRoundId}` for the existing golf UI.

| Method | Path |
| --- | --- |
| `POST` | `/api/golf-tours` |
| `GET` | `/api/golf-tours/mine` |
| `GET` | `/api/golf-tours/:id` |
| `PATCH` | `/api/golf-tours/:id` |
| `POST` | `/api/golf-tours/:id/complete` |
| `POST` | `/api/golf-tours/:id/camps` |
| `PATCH` | `/api/golf-tours/:id/camps/:campId` |
| `POST` | `/api/golf-tours/:id/rounds` |
| `PATCH` | `/api/golf-tours/:id/rounds/:roundId` |
| `POST` | `/api/golf-tours/:id/rounds/:roundId/fourballs` |
| `PATCH` | `/api/golf-tours/:id/fourballs/:fourballId` |
| `POST` | `/api/golf-tours/:id/fourballs/:fourballId/start` |
| `GET` | `/api/golf-tours/:id/leaderboard` |

Create defaults to **2** camps (`Camp A`, `Camp B`). Host mutates; host or seated registered player may start a fourball and read the tour/leaderboard. Full shapes: `src/modules/golf-tours/README.md`.

## Tests

Tour create with 2 camps, rounds/fourballs, start → `golfRoundId`, leaderboard uses only locked cards (guests included), host permissions, host complete, auto-complete when the last fourball locks. Full suite 423 passing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-646d4353-91b6-47eb-97ae-b1d578baf6a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-646d4353-91b6-47eb-97ae-b1d578baf6a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

