### PR TITLE
Golf tour setup v2 (roster + standing fourballs)

### DIFF
--- a/prisma/migrations/20260909180000_golf_tour_setup_v2/migration.sql
+++ b/prisma/migrations/20260909180000_golf_tour_setup_v2/migration.sql
@@ -1,0 +1,89 @@
+-- AlterTable
+ALTER TABLE "GolfTourFourball" ADD COLUMN "standingFourballId" TEXT,
+ADD COLUMN "sitOut" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "GolfTourFourballPlayer" ADD COLUMN "sitOut" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "GolfTourCampMember" (
+    "id" TEXT NOT NULL,
+    "campId" TEXT NOT NULL,
+    "userId" TEXT,
+    "displayName" TEXT NOT NULL,
+    "isGuest" BOOLEAN NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GolfTourCampMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GolfTourStandingFourball" (
+    "id" TEXT NOT NULL,
+    "tourId" TEXT NOT NULL,
+    "campId" TEXT NOT NULL,
+    "name" TEXT,
+    "sortOrder" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GolfTourStandingFourball_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GolfTourStandingFourballPlayer" (
+    "id" TEXT NOT NULL,
+    "templateId" TEXT NOT NULL,
+    "slot" INTEGER NOT NULL,
+    "userId" TEXT,
+    "displayName" TEXT NOT NULL,
+    "isGuest" BOOLEAN NOT NULL,
+
+    CONSTRAINT "GolfTourStandingFourballPlayer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "GolfTourCampMember_campId_idx" ON "GolfTourCampMember"("campId");
+
+-- CreateIndex
+CREATE INDEX "GolfTourCampMember_userId_idx" ON "GolfTourCampMember"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GolfTourCampMember_campId_userId_key" ON "GolfTourCampMember"("campId", "userId") WHERE "userId" IS NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "GolfTourStandingFourball_tourId_idx" ON "GolfTourStandingFourball"("tourId");
+
+-- CreateIndex
+CREATE INDEX "GolfTourStandingFourball_campId_idx" ON "GolfTourStandingFourball"("campId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GolfTourStandingFourballPlayer_templateId_slot_key" ON "GolfTourStandingFourballPlayer"("templateId", "slot");
+
+-- CreateIndex
+CREATE INDEX "GolfTourStandingFourballPlayer_templateId_idx" ON "GolfTourStandingFourballPlayer"("templateId");
+
+-- CreateIndex
+CREATE INDEX "GolfTourStandingFourballPlayer_userId_idx" ON "GolfTourStandingFourballPlayer"("userId");
+
+-- CreateIndex
+CREATE INDEX "GolfTourFourball_standingFourballId_idx" ON "GolfTourFourball"("standingFourballId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GolfTourFourball_roundId_standingFourballId_key" ON "GolfTourFourball"("roundId", "standingFourballId") WHERE "standingFourballId" IS NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "GolfTourCampMember" ADD CONSTRAINT "GolfTourCampMember_campId_fkey" FOREIGN KEY ("campId") REFERENCES "GolfTourCamp"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GolfTourStandingFourball" ADD CONSTRAINT "GolfTourStandingFourball_tourId_fkey" FOREIGN KEY ("tourId") REFERENCES "GolfTour"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GolfTourStandingFourball" ADD CONSTRAINT "GolfTourStandingFourball_campId_fkey" FOREIGN KEY ("campId") REFERENCES "GolfTourCamp"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GolfTourStandingFourballPlayer" ADD CONSTRAINT "GolfTourStandingFourballPlayer_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "GolfTourStandingFourball"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GolfTourFourball" ADD CONSTRAINT "GolfTourFourball_standingFourballId_fkey" FOREIGN KEY ("standingFourballId") REFERENCES "GolfTourStandingFourball"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -936,17 +936,18 @@ enum GolfTourFourballStatus {
 // No User FK — same as Team / OrganisedGame. Fourballs link to GolfRound
 // (existing scorecard). format is pluggable; v1 is stroke only.
 model GolfTour {
-  id         String         @id @default(uuid())
-  name       String
-  startDate  DateTime       @db.Date
-  endDate    DateTime       @db.Date
-  status     GolfTourStatus @default(draft)
-  hostUserId String
-  createdAt  DateTime       @default(now())
-  updatedAt  DateTime       @updatedAt
-  camps      GolfTourCamp[]
-  rounds     GolfTourRound[]
-  fourballs  GolfTourFourball[]
+  id                String                     @id @default(uuid())
+  name              String
+  startDate         DateTime                   @db.Date
+  endDate           DateTime                   @db.Date
+  status            GolfTourStatus             @default(draft)
+  hostUserId        String
+  createdAt         DateTime                   @default(now())
+  updatedAt         DateTime                   @updatedAt
+  camps             GolfTourCamp[]
+  rounds            GolfTourRound[]
+  fourballs         GolfTourFourball[]
+  standingFourballs GolfTourStandingFourball[]
 
   @@index([hostUserId])
   @@index([status, startDate])
@@ -954,17 +955,69 @@ model GolfTour {
 }
 
 model GolfTourCamp {
-  id        String   @id @default(uuid())
-  tourId    String
-  name      String
-  color     String?
-  sortOrder Int
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  tour      GolfTour @relation(fields: [tourId], references: [id], onDelete: Cascade)
-  fourballs GolfTourFourball[]
+  id                String                     @id @default(uuid())
+  tourId            String
+  name              String
+  color             String?
+  sortOrder         Int
+  createdAt         DateTime                   @default(now())
+  updatedAt         DateTime                   @updatedAt
+  tour              GolfTour                   @relation(fields: [tourId], references: [id], onDelete: Cascade)
+  fourballs         GolfTourFourball[]
+  roster            GolfTourCampMember[]
+  standingFourballs GolfTourStandingFourball[]
 
   @@index([tourId])
+}
+
+// Camp roster (registered user and/or guest display name). No User FK —
+// same as GolfTourFourballPlayer. Unique registered user per camp is a
+// partial index in 20260909180000_golf_tour_setup_v2.
+model GolfTourCampMember {
+  id          String       @id @default(uuid())
+  campId      String
+  userId      String?
+  displayName String
+  isGuest     Boolean
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+  camp        GolfTourCamp @relation(fields: [campId], references: [id], onDelete: Cascade)
+
+  @@index([campId])
+  @@index([userId])
+}
+
+// Tour-scoped standing fourball template. Instances are GolfTourFourball
+// rows with standingFourballId. Deleting a template nulls that link.
+model GolfTourStandingFourball {
+  id        String                           @id @default(uuid())
+  tourId    String
+  campId    String
+  name      String?
+  sortOrder Int
+  createdAt DateTime                         @default(now())
+  updatedAt DateTime                         @updatedAt
+  tour      GolfTour                         @relation(fields: [tourId], references: [id], onDelete: Cascade)
+  camp      GolfTourCamp                     @relation(fields: [campId], references: [id], onDelete: Cascade)
+  players   GolfTourStandingFourballPlayer[]
+  instances GolfTourFourball[]
+
+  @@index([tourId])
+  @@index([campId])
+}
+
+model GolfTourStandingFourballPlayer {
+  id          String                   @id @default(uuid())
+  templateId  String
+  slot        Int
+  userId      String?
+  displayName String
+  isGuest     Boolean
+  template    GolfTourStandingFourball @relation(fields: [templateId], references: [id], onDelete: Cascade)
+
+  @@unique([templateId, slot])
+  @@index([templateId])
+  @@index([userId])
 }
 
 model GolfTourRound {
@@ -985,24 +1038,28 @@ model GolfTourRound {
 }
 
 model GolfTourFourball {
-  id          String                 @id @default(uuid())
-  tourId      String
-  roundId     String
-  campId      String
-  golfRoundId String?                @unique
-  status      GolfTourFourballStatus @default(pending)
-  createdAt   DateTime               @default(now())
-  updatedAt   DateTime               @updatedAt
-  tour        GolfTour               @relation(fields: [tourId], references: [id], onDelete: Cascade)
-  round       GolfTourRound          @relation(fields: [roundId], references: [id], onDelete: Cascade)
-  camp        GolfTourCamp           @relation(fields: [campId], references: [id], onDelete: Cascade)
-  golfRound   GolfRound?             @relation(fields: [golfRoundId], references: [id])
-  players     GolfTourFourballPlayer[]
+  id                 String                   @id @default(uuid())
+  tourId             String
+  roundId            String
+  campId             String
+  golfRoundId        String?                  @unique
+  standingFourballId String?
+  sitOut             Boolean                  @default(false)
+  status             GolfTourFourballStatus   @default(pending)
+  createdAt          DateTime                 @default(now())
+  updatedAt          DateTime                 @updatedAt
+  tour               GolfTour                 @relation(fields: [tourId], references: [id], onDelete: Cascade)
+  round              GolfTourRound            @relation(fields: [roundId], references: [id], onDelete: Cascade)
+  camp               GolfTourCamp             @relation(fields: [campId], references: [id], onDelete: Cascade)
+  golfRound          GolfRound?               @relation(fields: [golfRoundId], references: [id])
+  standingFourball   GolfTourStandingFourball? @relation(fields: [standingFourballId], references: [id], onDelete: SetNull)
+  players            GolfTourFourballPlayer[]
 
   @@index([tourId])
   @@index([roundId])
   @@index([campId])
   @@index([golfRoundId])
+  @@index([standingFourballId])
 }
 
 model GolfTourFourballPlayer {
@@ -1012,6 +1069,7 @@ model GolfTourFourballPlayer {
   userId      String?
   displayName String
   isGuest     Boolean
+  sitOut      Boolean          @default(false)
   fourball    GolfTourFourball @relation(fields: [fourballId], references: [id], onDelete: Cascade)
 
   @@unique([fourballId, slot])

--- a/src/modules/golf-tours/README.md
+++ b/src/modules/golf-tours/README.md
@@ -1,25 +1,69 @@
-# Golf tour / camp event v1
+# Golf tour / camp event
 
 Multi-day, multi-course friend golf event. Naming is **Tour** + **Camp** (N≥2). This is **not** a single-elim Tournament.
 
-Fourballs reuse the **existing golf scorecard** (`POST /api/golf-rounds`). Each fourball has its own golf round id so groups can score on different devices. Handicaps and scramble are **v1.1** — `format` is stored and pluggable; v1 accepts **`stroke` only**.
+Fourballs reuse the **existing golf scorecard** (`POST /api/golf-rounds`). Each fourball has its own golf round id so groups can score on different devices. Handicaps and scramble are **v1.1** — `format` is stored and pluggable; **v1 and v2 accept `stroke` only**.
 
-## Migration
+## Migrations
 
-`20260909120000_golf_tour`
+| Version | Name |
+| --- | --- |
+| v1 | `20260909120000_golf_tour` |
+| v2 | `20260909180000_golf_tour_setup_v2` |
 
 Applied on merge via Railway `preDeployCommand` (`prisma migrate deploy`). **Do not merge until ready to migrate.**
+
+## Setup v2 flow
+
+Roster-first + **standing fourballs** so hosts do not rebuild pairings every round.
+
+1. Host creates a tour (still defaults to two camps).
+2. Host adds a **camp roster** (registered `userId` and/or guest display name).
+3. Host creates **standing fourball templates** (tour-scoped): optional name, `campId`, up to 4 members from the roster (`rosterMemberId`) or inline guests, `sortOrder`.
+4. Host adds a **round**. If templates exist, the tour **auto-prepares** one pending fourball instance per template (`standingFourballId` set).
+5. Host can also call **`POST .../rounds/:roundId/prepare`** (idempotent) after adding templates later.
+6. Per instance the host may:
+   - **Sit out** the group (`sitOut: true`) or a player (`players[].sitOut` / `playerSitOuts`) — template unchanged.
+   - **Custom this round** — `PATCH` instance `players` while pending. Does **not** write back to the standing template.
+   - **Start** the instance with the existing fourball start endpoint (scorecard).
+7. **Copy from previous round** — `POST .../rounds/:roundId/copy-from/:sourceRoundId` creates or edits target instances from the source round’s groups (sit-out is not copied).
+
+**Also update standing** from a custom instance is **out / future**. Edit the template directly if the standing group should change.
+
+The v1 per-round fourball endpoints stay working. A host can still `POST .../rounds/:roundId/fourballs` for one-off groups that are not linked to a template.
+
+### Prepare semantics
+
+- For each standing template, if a fourball already exists for `(roundId, standingFourballId)`, **skip**.
+- Otherwise create a pending instance with the template’s `campId` and cloned players.
+- Does **not** overwrite custom players on an existing instance.
+- Adding a round runs the same spawn. Calling prepare again is a no-op when every template already has an instance.
+- Deleting a template detaches existing instances (`standingFourballId` → `null`); it does not delete them.
+
+### Sit-out
+
+- Instance `sitOut: true` — the whole group is excluded from the leaderboard and from auto-complete; it cannot be started until cleared.
+- Player×round `sitOut` — that seat is excluded from leaderboard averages and omitted from the default start-card players.
+- The standing template is never changed.
+
+### Copy from previous round
+
+- Source cancelled fourballs are ignored.
+- Templated source groups upsert the pending target instance with the same `standingFourballId` (create if missing).
+- Untemplated source groups create a target instance unless one already exists on that round with the same camp + player identities.
+- Sit-out flags are **not** copied (fresh round).
+- Idempotent for a second call with the same source groups.
 
 ## Complete behavior
 
 - **Host** `POST /api/golf-tours/:id/complete` may complete a draft or active tour at any time (including while fourballs are still pending). Idempotent if already completed.
-- **Auto-complete** runs when a fourball is locked from its golf scorecard (`POST /api/golf-rounds/:id/lock`) **and** every non-cancelled fourball on the tour is `locked`. Cancelled fourballs are ignored. An empty tour (no fourballs) is **not** auto-completed.
+- **Auto-complete** runs when a fourball is locked from its golf scorecard (`POST /api/golf-rounds/:id/lock`) **and** every non-cancelled, **non-sit-out** fourball on the tour is `locked`. Cancelled and sit-out fourballs are ignored. An empty tour (no playable fourballs) is **not** auto-completed.
 
 Starting the first fourball moves the tour from `draft` → `active`. A completed tour cannot be mutated.
 
 ## Scoring / leaderboard
 
-`GET /api/golf-tours/:id/leaderboard` is **gross stroke average per player-round**. Only **locked** fourballs whose linked golf round is also **locked** count.
+`GET /api/golf-tours/:id/leaderboard` is **gross stroke average per player-round**. Only **locked, non-sit-out** fourballs whose linked golf round is also **locked** count. Sit-out players on those cards are excluded from `playerRoundsCounted`.
 
 For each player in a camp, across those locked cards:
 
@@ -28,9 +72,9 @@ avgGross = totalGrossStrokes / playerRoundsCounted
 ```
 
 - `totalGrossStrokes` = sum of hole strokes on that player’s scorecard slot.
-- `playerRoundsCounted` = number of locked fourballs in that camp the player was seated in.
+- `playerRoundsCounted` = number of locked, non-sit-out player-rounds in that camp.
 - Sort: `avgGross` ascending, then `totalStrokes` ascending, then `displayName`.
-- Live / pending / cancelled fourballs are ignored, even if a live card has hole scores.
+- Live / pending / cancelled / sit-out fourballs are ignored, even if a live card has hole scores.
 
 ### Guest identity
 
@@ -51,9 +95,9 @@ Prisma `GolfTourFormat` is currently `{ stroke }`. Round create/edit rejects `sc
 
 Session cookie + `requireAuth` on every route.
 
-- **Host** mutates (CRUD tour, camps, rounds, fourballs, complete).
+- **Host** mutates (CRUD tour, camps, roster, standing templates, rounds, fourballs, prepare, copy, complete).
 - **Host or seated registered player** may start a fourball (so the group can open the card on their device).
-- **Host or seated registered player** may `GET` the tour and leaderboard. Outsiders get `404`.
+- **Host, roster member, standing-template player, or seated registered player** may `GET` the tour, camp roster, and leaderboard. Outsiders get `404`.
 
 ## Frontend contract
 
@@ -62,16 +106,25 @@ All mutate/read routes need the session cookie. Dates are `YYYY-MM-DD`. Nested w
 | Method | Path | Body | Response |
 | --- | --- | --- | --- |
 | `POST` | `/api/golf-tours` | `{ name, startDate, endDate, campNames? }` | `201 { tour }` — default **2** camps (`Camp A`, `Camp B`) if `campNames` omitted. `campNames` must have N≥2. |
-| `GET` | `/api/golf-tours/mine` | | `200 { tours }` hosting **or** seated as a registered player |
+| `GET` | `/api/golf-tours/mine` | | `200 { tours }` hosting **or** seated / rostered as a registered player |
 | `GET` | `/api/golf-tours/:id` | | `200 { tour }` |
 | `PATCH` | `/api/golf-tours/:id` | `{ name?, startDate?, endDate? }` | `200 { tour }` |
 | `POST` | `/api/golf-tours/:id/complete` | | `200 { tour }` |
 | `POST` | `/api/golf-tours/:id/camps` | `{ name, color? }` | `201 { tour }` |
 | `PATCH` | `/api/golf-tours/:id/camps/:campId` | `{ name?, color? }` | `200 { tour }` |
-| `POST` | `/api/golf-tours/:id/rounds` | `{ date, venueCmsId, label?, format? }` | `201 { tour }` — `format` defaults to `stroke` |
+| `GET` | `/api/golf-tours/:id/camps/:campId/roster` | | `200 { roster }` |
+| `POST` | `/api/golf-tours/:id/camps/:campId/roster` | `{ displayName, isGuest, userId? }` | `201 { tour, member }` |
+| `PATCH` | `/api/golf-tours/:id/camps/:campId/roster/:memberId` | `{ displayName?, isGuest?, userId? }` | `200 { tour }` |
+| `DELETE` | `/api/golf-tours/:id/camps/:campId/roster/:memberId` | | `200 { tour }` |
+| `POST` | `/api/golf-tours/:id/standing-fourballs` | `{ campId, name?, players?, sortOrder? }` | `201 { tour, standingFourball }` — `players[]` may use `rosterMemberId` instead of identity fields |
+| `PATCH` | `/api/golf-tours/:id/standing-fourballs/:templateId` | `{ campId?, name?, players? }` | `200 { tour }` |
+| `DELETE` | `/api/golf-tours/:id/standing-fourballs/:templateId` | | `200 { tour }` — instances are detached, not deleted |
+| `POST` | `/api/golf-tours/:id/rounds` | `{ date, venueCmsId, label?, format? }` | `201 { tour }` — `format` defaults to `stroke`; auto-prepares instances from templates |
 | `PATCH` | `/api/golf-tours/:id/rounds/:roundId` | `{ date?, venueCmsId?, label?, format? }` | `200 { tour }` |
-| `POST` | `/api/golf-tours/:id/rounds/:roundId/fourballs` | `{ campId, players? }` | `201 { tour, fourball }` |
-| `PATCH` | `/api/golf-tours/:id/fourballs/:fourballId` | `{ players?, campId?, status? }` | `200 { tour }` — `status` may only be `cancelled` (pending only) |
+| `POST` | `/api/golf-tours/:id/rounds/:roundId/prepare` | | `200 { tour, createdIds, fourballs }` — idempotent |
+| `POST` | `/api/golf-tours/:id/rounds/:roundId/copy-from/:sourceRoundId` | | `200 { tour }` |
+| `POST` | `/api/golf-tours/:id/rounds/:roundId/fourballs` | `{ campId, players? }` | `201 { tour, fourball }` — v1 one-off instance (no template) |
+| `PATCH` | `/api/golf-tours/:id/fourballs/:fourballId` | `{ players?, campId?, status?, sitOut?, playerSitOuts? }` | `200 { tour }` — `status` may only be `cancelled` (pending only). `players` override is pending-only and does **not** mutate the standing template. `sitOut` / `playerSitOuts` allowed on live/locked. |
 | `POST` | `/api/golf-tours/:id/fourballs/:fourballId/start` | `{ teeName, holesPlayed?, startingHole?, course?, players? }` | `201 { tour, fourball, golfRoundId, path }` |
 | `GET` | `/api/golf-tours/:id/leaderboard` | | `200 { leaderboard }` |
 
@@ -86,13 +139,30 @@ All mutate/read routes need the session cookie. Dates are `YYYY-MM-DD`. Nested w
   "status": "draft",
   "hostUserId": "…",
   "viewer": { "role": "host" },
-  "camps": [{ "id": "…", "name": "Camp A", "color": null, "sortOrder": 0 }],
+  "camps": [{
+    "id": "…",
+    "name": "Camp A",
+    "color": null,
+    "sortOrder": 0,
+    "roster": [
+      { "id": "…", "campId": "…", "userId": "…", "displayName": "Alex", "isGuest": false }
+    ]
+  }],
   "rounds": [{
     "id": "…",
     "date": "2026-09-12",
     "venueCmsId": "sanity-course-1",
     "label": "Saturday AM",
     "format": "stroke"
+  }],
+  "standingFourballs": [{
+    "id": "…",
+    "campId": "…",
+    "name": "Morning group",
+    "sortOrder": 0,
+    "players": [
+      { "slot": 1, "userId": "…", "displayName": "Alex", "isGuest": false }
+    ]
   }],
   "fourballs": [{
     "id": "…",
@@ -101,9 +171,11 @@ All mutate/read routes need the session cookie. Dates are `YYYY-MM-DD`. Nested w
     "status": "pending",
     "golfRoundId": null,
     "path": null,
+    "standingFourballId": "…",
+    "sitOut": false,
     "players": [
-      { "slot": 1, "userId": "…", "displayName": "Alex", "isGuest": false },
-      { "slot": 2, "userId": null, "displayName": "Pat", "isGuest": true }
+      { "slot": 1, "userId": "…", "displayName": "Alex", "isGuest": false, "sitOut": false },
+      { "slot": 2, "userId": null, "displayName": "Pat", "isGuest": true, "sitOut": false }
     ]
   }],
   "createdAt": "…",
@@ -119,9 +191,10 @@ Wires **venue from the tour round** and **tees/course like organise→golf start
 
 - `teeName` is required (same as golf round create).
 - Default `holesPlayed` is `9` with the default 9-hole par-4 course when `course` is omitted.
-- Seated fourball players are copied onto the golf card (override with `players` if needed).
+- Seated, **non-sit-out** fourball players are copied onto the golf card (override with `players` if needed).
 - Returns `{ golfRoundId, path }` where `path` is `/golf/{golfRoundId}` — open the existing golf scorecard UI.
 - Idempotent if the fourball is already `live` or `locked`.
+- A sit-out instance cannot be started.
 
 Locking that card (`POST /api/golf-rounds/:id/lock`) marks the fourball `locked` and may auto-complete the tour.
 
@@ -150,11 +223,11 @@ Locking that card (`POST /api/golf-rounds/:id/lock`) marks the fourball `locked`
 }
 ```
 
-Players with zero locked rounds in that camp are omitted.
+Players with zero locked, non-sit-out rounds in that camp are omitted.
 
 ## Out of scope
 
-Scramble engine, handicaps, booking/payments, Frontend, SEO. In-app notifications for “fourball ready” / “tour completed” are a nice-to-have and not in this v1.
+Scramble engine, handicaps, booking/payments, Frontend, SEO. Writing a custom instance back onto the standing template. In-app notifications for “fourball ready” / “tour completed” are a nice-to-have.
 
 ## Link to golf rounds
 
@@ -162,4 +235,4 @@ Scramble engine, handicaps, booking/payments, Frontend, SEO. In-app notification
 | --- | --- |
 | Start fourball | `POST /api/golf-rounds` (create live card) |
 | Play / lock | existing golf UI + `POST /api/golf-rounds/:id/lock` |
-| Leaderboard | locked cards only (`GolfRound.status = locked`) |
+| Leaderboard | locked, non-sit-out cards only (`GolfRound.status = locked`) |

--- a/src/modules/golf-tours/controllers/golf-tours.controller.ts
+++ b/src/modules/golf-tours/controllers/golf-tours.controller.ts
@@ -10,22 +10,33 @@ import { GolfTourFourballNotFoundError } from "../entities/golf-tour-fourball-no
 import { GolfTourNotFoundError } from "../entities/golf-tour-not-found-error";
 import { GolfTourNotReadyError } from "../entities/golf-tour-not-ready-error";
 import { GolfTourPersistenceError } from "../entities/golf-tour-persistence-error";
+import { GolfTourRosterMemberNotFoundError } from "../entities/golf-tour-roster-member-not-found-error";
 import { GolfTourRoundNotFoundError } from "../entities/golf-tour-round-not-found-error";
+import { GolfTourStandingFourballNotFoundError } from "../entities/golf-tour-standing-fourball-not-found-error";
 import { GolfTourVenueNotFoundError } from "../entities/golf-tour-venue-not-found-error";
 import {
   AddGolfTourCamp,
   AddGolfTourFourball,
+  AddGolfTourRosterMember,
   AddGolfTourRound,
+  AddGolfTourStandingFourball,
   CompleteGolfTour,
+  CopyGolfTourRoundInstances,
   CreateGolfTour,
   GetGolfTour,
   GetGolfTourLeaderboard,
+  ListGolfTourRoster,
   ListMyGolfTours,
+  PrepareGolfTourRound,
+  RemoveGolfTourRosterMember,
+  RemoveGolfTourStandingFourball,
   StartGolfTourFourball,
   UpdateGolfTour,
   UpdateGolfTourCamp,
   UpdateGolfTourFourball,
+  UpdateGolfTourRosterMember,
   UpdateGolfTourRound,
+  UpdateGolfTourStandingFourball,
 } from "../services/golf-tours.service";
 
 const playerSchema = z.object({
@@ -33,6 +44,20 @@ const playerSchema = z.object({
   userId: z.string().nullable().optional(),
   displayName: z.string(),
   isGuest: z.boolean(),
+  sitOut: z.boolean().optional(),
+});
+
+const standingPlayerSchema = z.object({
+  slot: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
+  rosterMemberId: z.string().optional(),
+  userId: z.string().nullable().optional(),
+  displayName: z.string().optional(),
+  isGuest: z.boolean().optional(),
+});
+
+const playerSitOutSchema = z.object({
+  slot: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
+  sitOut: z.boolean(),
 });
 
 const courseHoleSchema = z.object({
@@ -81,6 +106,23 @@ const fourballParamSchema = z.object({
   fourballId: z.string(),
 });
 
+const rosterMemberParamSchema = z.object({
+  id: z.string(),
+  campId: z.string(),
+  memberId: z.string(),
+});
+
+const standingFourballParamSchema = z.object({
+  id: z.string(),
+  templateId: z.string(),
+});
+
+const copyFromParamSchema = z.object({
+  id: z.string(),
+  roundId: z.string(),
+  sourceRoundId: z.string(),
+});
+
 const campBodySchema = z.object({
   name: z.string(),
   color: z.string().nullable().optional(),
@@ -114,6 +156,33 @@ const updateFourballBodySchema = z.object({
   campId: z.string().optional(),
   players: z.array(playerSchema).max(4).optional(),
   status: z.string().optional(),
+  sitOut: z.boolean().optional(),
+  playerSitOuts: z.array(playerSitOutSchema).optional(),
+});
+
+const rosterBodySchema = z.object({
+  displayName: z.string(),
+  isGuest: z.boolean(),
+  userId: z.string().nullable().optional(),
+});
+
+const updateRosterBodySchema = z.object({
+  displayName: z.string().optional(),
+  isGuest: z.boolean().optional(),
+  userId: z.string().nullable().optional(),
+});
+
+const standingFourballBodySchema = z.object({
+  campId: z.string(),
+  name: z.string().nullable().optional(),
+  players: z.array(standingPlayerSchema).max(4).optional(),
+  sortOrder: z.number().optional(),
+});
+
+const updateStandingFourballBodySchema = z.object({
+  campId: z.string().optional(),
+  name: z.string().nullable().optional(),
+  players: z.array(standingPlayerSchema).max(4).optional(),
 });
 
 const startFourballBodySchema = z.object({
@@ -143,6 +212,15 @@ export function createGolfToursController(deps: {
   updateFourball: UpdateGolfTourFourball;
   startFourball: StartGolfTourFourball;
   getLeaderboard: GetGolfTourLeaderboard;
+  listRoster: ListGolfTourRoster;
+  addRosterMember: AddGolfTourRosterMember;
+  updateRosterMember: UpdateGolfTourRosterMember;
+  removeRosterMember: RemoveGolfTourRosterMember;
+  addStandingFourball: AddGolfTourStandingFourball;
+  updateStandingFourball: UpdateGolfTourStandingFourball;
+  removeStandingFourball: RemoveGolfTourStandingFourball;
+  prepareRound: PrepareGolfTourRound;
+  copyRoundInstances: CopyGolfTourRoundInstances;
   tryGetSessionUserId: (req: Request) => string | null;
 }) {
   return {
@@ -353,6 +431,179 @@ export function createGolfToursController(deps: {
         return sendGolfTourError(res, error);
       }
     },
+
+    async listRoster(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, campId } = z.parse(campParamSchema, req.params);
+        const result = await deps.listRoster.execute({
+          userId,
+          tourId: id,
+          campId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async addRosterMember(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, campId } = z.parse(campParamSchema, req.params);
+        const body = z.parse(rosterBodySchema, req.body ?? {});
+        const result = await deps.addRosterMember.execute({
+          userId,
+          tourId: id,
+          campId,
+          displayName: body.displayName,
+          isGuest: body.isGuest,
+          memberUserId: body.userId,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async updateRosterMember(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, campId, memberId } = z.parse(
+          rosterMemberParamSchema,
+          req.params,
+        );
+        const body = z.parse(updateRosterBodySchema, req.body ?? {});
+        const result = await deps.updateRosterMember.execute({
+          userId,
+          tourId: id,
+          campId,
+          memberId,
+          displayName: body.displayName,
+          isGuest: body.isGuest,
+          ...("userId" in body ? { memberUserId: body.userId } : {}),
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async removeRosterMember(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, campId, memberId } = z.parse(
+          rosterMemberParamSchema,
+          req.params,
+        );
+        const result = await deps.removeRosterMember.execute({
+          userId,
+          tourId: id,
+          campId,
+          memberId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async addStandingFourball(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id } = z.parse(idParamSchema, req.params);
+        const body = z.parse(standingFourballBodySchema, req.body ?? {});
+        const result = await deps.addStandingFourball.execute({
+          userId,
+          tourId: id,
+          ...body,
+        });
+        return res.status(201).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async updateStandingFourball(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, templateId } = z.parse(
+          standingFourballParamSchema,
+          req.params,
+        );
+        const body = z.parse(updateStandingFourballBodySchema, req.body ?? {});
+        const result = await deps.updateStandingFourball.execute({
+          userId,
+          tourId: id,
+          templateId,
+          ...body,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async removeStandingFourball(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, templateId } = z.parse(
+          standingFourballParamSchema,
+          req.params,
+        );
+        const result = await deps.removeStandingFourball.execute({
+          userId,
+          tourId: id,
+          templateId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async prepareRound(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, roundId } = z.parse(roundParamSchema, req.params);
+        const result = await deps.prepareRound.execute({
+          userId,
+          tourId: id,
+          roundId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
+
+    async copyFromRound(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+        const { id, roundId, sourceRoundId } = z.parse(
+          copyFromParamSchema,
+          req.params,
+        );
+        const result = await deps.copyRoundInstances.execute({
+          userId,
+          tourId: id,
+          roundId,
+          sourceRoundId,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendGolfTourError(res, error);
+      }
+    },
   };
 }
 
@@ -362,6 +613,8 @@ function sendGolfTourError(res: Response, error: unknown) {
     error instanceof GolfTourCampNotFoundError ||
     error instanceof GolfTourRoundNotFoundError ||
     error instanceof GolfTourFourballNotFoundError ||
+    error instanceof GolfTourRosterMemberNotFoundError ||
+    error instanceof GolfTourStandingFourballNotFoundError ||
     error instanceof GolfTourVenueNotFoundError ||
     error instanceof GolfRoundVenueNotFoundError
   ) {

--- a/src/modules/golf-tours/controllers/golf-tours.http.test.ts
+++ b/src/modules/golf-tours/controllers/golf-tours.http.test.ts
@@ -619,8 +619,8 @@ describe("golf tours HTTP", () => {
     const startedBody = (await started.json()) as { golfRoundId: string };
     const lock = await json(`/api/golf-rounds/${startedBody.golfRoundId}/lock`, {
       method: "POST",
-      userId: "user-host",
-      body: JSON.stringify({ score: scoreForSlots([1, 2], 4) }),
+      userId: "user-sam",
+      body: JSON.stringify({ score: scoreForSlots([1], 4) }),
     });
     expect(lock.status).toBe(200);
 

--- a/src/modules/golf-tours/controllers/golf-tours.http.test.ts
+++ b/src/modules/golf-tours/controllers/golf-tours.http.test.ts
@@ -55,10 +55,25 @@ type PublicTour = {
   fourballs: Array<{
     id: string;
     campId: string;
+    roundId: string;
     status: string;
     golfRoundId: string | null;
     path: string | null;
-    players: Array<{ slot: number; userId: string | null; isGuest: boolean }>;
+    standingFourballId: string | null;
+    sitOut: boolean;
+    players: Array<{
+      slot: number;
+      userId: string | null;
+      isGuest: boolean;
+      displayName: string;
+      sitOut: boolean;
+    }>;
+  }>;
+  standingFourballs: Array<{
+    id: string;
+    campId: string;
+    name: string | null;
+    players: Array<{ displayName: string }>;
   }>;
 };
 
@@ -411,5 +426,278 @@ describe("golf tours HTTP", () => {
     const body = (await read.json()) as { tour: PublicTour };
     expect(body.tour.fourballs[0]!.status).toBe("locked");
     expect(body.tour.status).toBe("completed");
+  });
+
+  test("setup v2 roster, standing templates, prepare, sit-out, copy, custom, permissions", async () => {
+    const created = await json("/api/golf-tours", {
+      method: "POST",
+      userId: "user-host",
+      body: JSON.stringify({
+        name: "Friends Cup",
+        startDate: "2026-09-12",
+        endDate: "2026-09-14",
+      }),
+    });
+    const { tour } = (await created.json()) as { tour: PublicTour };
+    const tourId = tour.id;
+    const campA = tour.camps[0]!.id;
+
+    const forbiddenRoster = await json(
+      `/api/golf-tours/${tourId}/camps/${campA}/roster`,
+      {
+        method: "POST",
+        userId: "user-other",
+        body: JSON.stringify({
+          displayName: "Alex",
+          isGuest: false,
+          userId: "user-alex",
+        }),
+      },
+    );
+    expect(forbiddenRoster.status).toBe(403);
+
+    const rosterRes = await json(
+      `/api/golf-tours/${tourId}/camps/${campA}/roster`,
+      {
+        method: "POST",
+        userId: "user-host",
+        body: JSON.stringify({
+          displayName: "Alex",
+          isGuest: false,
+          userId: "user-alex",
+        }),
+      },
+    );
+    expect(rosterRes.status).toBe(201);
+    const rosterBody = (await rosterRes.json()) as {
+      tour: PublicTour;
+      member: { id: string; displayName: string };
+    };
+    const memberId = rosterBody.member.id;
+
+    const guestRoster = await json(
+      `/api/golf-tours/${tourId}/camps/${campA}/roster`,
+      {
+        method: "POST",
+        userId: "user-host",
+        body: JSON.stringify({ displayName: "Pat", isGuest: true }),
+      },
+    );
+    expect(guestRoster.status).toBe(201);
+
+    const listRoster = await json(
+      `/api/golf-tours/${tourId}/camps/${campA}/roster`,
+      { userId: "user-alex" },
+    );
+    expect(listRoster.status).toBe(200);
+    expect(
+      ((await listRoster.json()) as { roster: Array<{ id: string }> }).roster,
+    ).toHaveLength(2);
+
+    const patchedRoster = await json(
+      `/api/golf-tours/${tourId}/camps/${campA}/roster/${memberId}`,
+      {
+        method: "PATCH",
+        userId: "user-host",
+        body: JSON.stringify({ displayName: "Alexander" }),
+      },
+    );
+    expect(patchedRoster.status).toBe(200);
+
+    const standingRes = await json(
+      `/api/golf-tours/${tourId}/standing-fourballs`,
+      {
+        method: "POST",
+        userId: "user-host",
+        body: JSON.stringify({
+          campId: campA,
+          name: "Morning group",
+          players: [
+            { slot: 1, rosterMemberId: memberId },
+            { slot: 2, displayName: "Pat", isGuest: true },
+          ],
+        }),
+      },
+    );
+    expect(standingRes.status).toBe(201);
+    const standingBody = (await standingRes.json()) as {
+      standingFourball: { id: string; players: Array<{ displayName: string }> };
+    };
+    expect(standingBody.standingFourball.players[0]!.displayName).toBe(
+      "Alexander",
+    );
+    const templateId = standingBody.standingFourball.id;
+
+    const forbiddenTemplate = await json(
+      `/api/golf-tours/${tourId}/standing-fourballs`,
+      {
+        method: "POST",
+        userId: "user-other",
+        body: JSON.stringify({ campId: campA }),
+      },
+    );
+    expect(forbiddenTemplate.status).toBe(403);
+
+    const round1 = await json(`/api/golf-tours/${tourId}/rounds`, {
+      method: "POST",
+      userId: "user-host",
+      body: JSON.stringify({
+        date: "2026-09-12",
+        venueCmsId: "sanity-course-1",
+      }),
+    });
+    const withRound1 = (await round1.json()) as { tour: PublicTour };
+    expect(withRound1.tour.fourballs).toHaveLength(1);
+    expect(withRound1.tour.fourballs[0]!.standingFourballId).toBe(templateId);
+    const round1Id = withRound1.tour.rounds[0]!.id;
+    const instanceId = withRound1.tour.fourballs[0]!.id;
+
+    const prepareAgain = await json(
+      `/api/golf-tours/${tourId}/rounds/${round1Id}/prepare`,
+      { method: "POST", userId: "user-host" },
+    );
+    expect(prepareAgain.status).toBe(200);
+    expect(
+      ((await prepareAgain.json()) as { createdIds: string[] }).createdIds,
+    ).toEqual([]);
+
+    const custom = await json(
+      `/api/golf-tours/${tourId}/fourballs/${instanceId}`,
+      {
+        method: "PATCH",
+        userId: "user-host",
+        body: JSON.stringify({
+          players: [
+            {
+              slot: 1,
+              displayName: "Sam",
+              isGuest: false,
+              userId: "user-sam",
+            },
+            { slot: 2, displayName: "Pat", isGuest: true, sitOut: true },
+          ],
+        }),
+      },
+    );
+    expect(custom.status).toBe(200);
+    const customTour = ((await custom.json()) as { tour: PublicTour }).tour;
+    expect(customTour.fourballs[0]!.players[0]!.displayName).toBe("Sam");
+    const templateStill = customTour.standingFourballs.find(
+      (row) => row.id === templateId,
+    );
+    expect(templateStill?.players[0]?.displayName).toBe("Alexander");
+
+    const extra = await json(
+      `/api/golf-tours/${tourId}/rounds/${round1Id}/fourballs`,
+      {
+        method: "POST",
+        userId: "user-host",
+        body: JSON.stringify({
+          campId: campA,
+          players: [
+            {
+              slot: 1,
+              displayName: "Open",
+              isGuest: false,
+              userId: "user-open",
+            },
+          ],
+        }),
+      },
+    );
+    expect(extra.status).toBe(201);
+
+    const started = await json(
+      `/api/golf-tours/${tourId}/fourballs/${instanceId}/start`,
+      {
+        method: "POST",
+        userId: "user-host",
+        body: JSON.stringify({ teeName: "White" }),
+      },
+    );
+    expect(started.status).toBe(201);
+    const startedBody = (await started.json()) as { golfRoundId: string };
+    const lock = await json(`/api/golf-rounds/${startedBody.golfRoundId}/lock`, {
+      method: "POST",
+      userId: "user-host",
+      body: JSON.stringify({ score: scoreForSlots([1, 2], 4) }),
+    });
+    expect(lock.status).toBe(200);
+
+    const board = await json(`/api/golf-tours/${tourId}/leaderboard`, {
+      userId: "user-host",
+    });
+    const campBoard = (
+      (await board.json()) as {
+        leaderboard: {
+          camps: Array<{
+            campId: string;
+            players: Array<{ playerKey: string }>;
+          }>;
+        };
+      }
+    ).leaderboard.camps.find((camp) => camp.campId === campA)!;
+    expect(campBoard.players.map((player) => player.playerKey)).toEqual([
+      "user:user-sam",
+    ]);
+
+    const sitOut = await json(
+      `/api/golf-tours/${tourId}/fourballs/${instanceId}`,
+      {
+        method: "PATCH",
+        userId: "user-host",
+        body: JSON.stringify({ sitOut: true }),
+      },
+    );
+    expect(sitOut.status).toBe(200);
+
+    const boardSitOut = await json(`/api/golf-tours/${tourId}/leaderboard`, {
+      userId: "user-host",
+    });
+    expect(
+      (
+        (await boardSitOut.json()) as {
+          leaderboard: {
+            camps: Array<{ campId: string; players: unknown[] }>;
+          };
+        }
+      ).leaderboard.camps.find((camp) => camp.campId === campA)!.players,
+    ).toEqual([]);
+
+    const round2 = await json(`/api/golf-tours/${tourId}/rounds`, {
+      method: "POST",
+      userId: "user-host",
+      body: JSON.stringify({
+        date: "2026-09-13",
+        venueCmsId: "sanity-course-1",
+      }),
+    });
+    const withRound2 = (await round2.json()) as { tour: PublicTour };
+    const round2Id = withRound2.tour.rounds[1]!.id;
+    expect(
+      withRound2.tour.fourballs.filter((fourball) => fourball.roundId === round2Id),
+    ).toHaveLength(1);
+
+    const copy = await json(
+      `/api/golf-tours/${tourId}/rounds/${round2Id}/copy-from/${round1Id}`,
+      { method: "POST", userId: "user-host" },
+    );
+    expect(copy.status).toBe(200);
+    const copiedTour = ((await copy.json()) as { tour: PublicTour }).tour;
+    const copied = copiedTour.fourballs.filter(
+      (fourball) => fourball.roundId === round2Id,
+    );
+    expect(copied.length).toBeGreaterThanOrEqual(1);
+    expect(
+      copied.some((fourball) =>
+        fourball.players.some((player) => player.displayName === "Sam"),
+      ),
+    ).toBe(true);
+
+    const deleted = await json(
+      `/api/golf-tours/${tourId}/camps/${campA}/roster/${memberId}`,
+      { method: "DELETE", userId: "user-host" },
+    );
+    expect(deleted.status).toBe(200);
   });
 });

--- a/src/modules/golf-tours/entities/golf-tour-camp.ts
+++ b/src/modules/golf-tours/entities/golf-tour-camp.ts
@@ -1,5 +1,7 @@
 import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
 import { GolfTourCampName } from "./golf-tour-camp-name";
+import { GolfTourRosterMember } from "./golf-tour-roster-member";
+import { GolfTourRosterMemberNotFoundError } from "./golf-tour-roster-member-not-found-error";
 
 const COLOR_MAX_LENGTH = 32;
 
@@ -8,6 +10,7 @@ export type GolfTourCampSnapshot = {
   name: string;
   color: string | null;
   sortOrder: number;
+  roster: ReturnType<GolfTourRosterMember["toSnapshot"]>[];
 };
 
 export class GolfTourCamp {
@@ -16,6 +19,7 @@ export class GolfTourCamp {
     private nameValue: GolfTourCampName,
     private colorValue: string | null,
     readonly sortOrder: number,
+    private rosterValue: GolfTourRosterMember[],
   ) {}
 
   static create(props: {
@@ -23,12 +27,14 @@ export class GolfTourCamp {
     name: GolfTourCampName;
     color?: string | null;
     sortOrder: number;
+    roster?: GolfTourRosterMember[];
   }): GolfTourCamp {
     return new GolfTourCamp(
       props.id,
       props.name,
       parseColor(props.color),
       props.sortOrder,
+      props.roster ?? [],
     );
   }
 
@@ -37,8 +43,15 @@ export class GolfTourCamp {
     name: GolfTourCampName;
     color: string | null;
     sortOrder: number;
+    roster?: GolfTourRosterMember[];
   }): GolfTourCamp {
-    return new GolfTourCamp(props.id, props.name, props.color, props.sortOrder);
+    return new GolfTourCamp(
+      props.id,
+      props.name,
+      props.color,
+      props.sortOrder,
+      [...(props.roster ?? [])],
+    );
   }
 
   static fromSnapshot(snapshot: GolfTourCampSnapshot): GolfTourCamp {
@@ -47,6 +60,9 @@ export class GolfTourCamp {
       name: GolfTourCampName.from(snapshot.name),
       color: snapshot.color,
       sortOrder: snapshot.sortOrder,
+      roster: (snapshot.roster ?? []).map((member) =>
+        GolfTourRosterMember.fromSnapshot(member),
+      ),
     });
   }
 
@@ -58,9 +74,49 @@ export class GolfTourCamp {
     return this.colorValue;
   }
 
+  get roster(): readonly GolfTourRosterMember[] {
+    return this.rosterValue;
+  }
+
+  rosterMemberById(memberId: string): GolfTourRosterMember | null {
+    return this.rosterValue.find((member) => member.id === memberId) ?? null;
+  }
+
+  hasPlayerUserId(userId: string): boolean {
+    return this.rosterValue.some((member) => member.hasUserId(userId));
+  }
+
   rename(details: { name?: GolfTourCampName; color?: string | null }): void {
     if (details.name) this.nameValue = details.name;
     if ("color" in details) this.colorValue = parseColor(details.color);
+  }
+
+  addMember(member: GolfTourRosterMember): void {
+    assertUniqueRosterMember(this.rosterValue, member);
+    this.rosterValue = [...this.rosterValue, member];
+  }
+
+  updateMember(
+    memberId: string,
+    details: {
+      userId?: string | null;
+      displayName?: unknown;
+      isGuest?: unknown;
+    },
+  ): GolfTourRosterMember {
+    const member = this.requireMember(memberId);
+    member.update(details);
+    assertUniqueRosterMember(
+      this.rosterValue.filter((row) => row.id !== member.id),
+      member,
+    );
+    return member;
+  }
+
+  removeMember(memberId: string): GolfTourRosterMember {
+    const member = this.requireMember(memberId);
+    this.rosterValue = this.rosterValue.filter((row) => row.id !== member.id);
+    return member;
   }
 
   toSnapshot(): GolfTourCampSnapshot {
@@ -69,7 +125,23 @@ export class GolfTourCamp {
       name: this.nameValue.value,
       color: this.colorValue,
       sortOrder: this.sortOrder,
+      roster: this.rosterValue.map((member) => member.toSnapshot()),
     };
+  }
+
+  private requireMember(memberId: string): GolfTourRosterMember {
+    const member = this.rosterMemberById(memberId.trim());
+    if (!member) throw new GolfTourRosterMemberNotFoundError();
+    return member;
+  }
+}
+
+function assertUniqueRosterMember(
+  existing: readonly GolfTourRosterMember[],
+  member: GolfTourRosterMember,
+): void {
+  if (existing.some((row) => row.identityKey === member.identityKey)) {
+    throw new DomainError("That player is already on this camp roster");
   }
 }
 

--- a/src/modules/golf-tours/entities/golf-tour-fourball.ts
+++ b/src/modules/golf-tours/entities/golf-tour-fourball.ts
@@ -7,13 +7,19 @@ import {
 import { GolfTourFourballStatus } from "./golf-tour-fourball-status";
 import { GolfTourNotReadyError } from "./golf-tour-not-ready-error";
 
+export type GolfTourFourballPlayerSnapshot = GolfPlayerSnapshot & {
+  sitOut: boolean;
+};
+
 export type GolfTourFourballSnapshot = {
   id: string;
   roundId: string;
   campId: string;
   golfRoundId: string | null;
   status: "pending" | "live" | "locked" | "cancelled";
-  players: GolfPlayerSnapshot[];
+  players: GolfTourFourballPlayerSnapshot[];
+  standingFourballId: string | null;
+  sitOut: boolean;
 };
 
 export class GolfTourFourball {
@@ -24,6 +30,9 @@ export class GolfTourFourball {
     private golfRoundIdValue: string | null,
     private statusValue: GolfTourFourballStatus,
     private playersValue: GolfPlayer[],
+    private standingFourballIdValue: string | null,
+    private sitOutValue: boolean,
+    private sitOutSlots: Set<number>,
   ) {}
 
   static create(props: {
@@ -31,6 +40,9 @@ export class GolfTourFourball {
     roundId: string;
     campId: string;
     players?: GolfPlayer[];
+    standingFourballId?: string | null;
+    sitOut?: boolean;
+    sitOutSlots?: Iterable<number>;
   }): GolfTourFourball {
     return new GolfTourFourball(
       props.id,
@@ -39,6 +51,9 @@ export class GolfTourFourball {
       null,
       GolfTourFourballStatus.PENDING,
       props.players ?? [],
+      props.standingFourballId ?? null,
+      props.sitOut === true,
+      new Set(props.sitOutSlots ?? []),
     );
   }
 
@@ -49,6 +64,9 @@ export class GolfTourFourball {
     golfRoundId: string | null;
     status: GolfTourFourballStatus;
     players: GolfPlayer[];
+    standingFourballId?: string | null;
+    sitOut?: boolean;
+    sitOutSlots?: Iterable<number>;
   }): GolfTourFourball {
     return new GolfTourFourball(
       props.id,
@@ -57,6 +75,9 @@ export class GolfTourFourball {
       props.golfRoundId,
       props.status,
       [...props.players],
+      props.standingFourballId ?? null,
+      props.sitOut === true,
+      new Set(props.sitOutSlots ?? []),
     );
   }
 
@@ -68,6 +89,11 @@ export class GolfTourFourball {
       golfRoundId: snapshot.golfRoundId,
       status: GolfTourFourballStatus.from(snapshot.status),
       players: snapshot.players.map((player) => GolfPlayer.from(player)),
+      standingFourballId: snapshot.standingFourballId ?? null,
+      sitOut: snapshot.sitOut === true,
+      sitOutSlots: snapshot.players
+        .filter((player) => player.sitOut)
+        .map((player) => player.slot),
     });
   }
 
@@ -87,6 +113,18 @@ export class GolfTourFourball {
     return this.playersValue;
   }
 
+  get standingFourballId(): string | null {
+    return this.standingFourballIdValue;
+  }
+
+  get sitOut(): boolean {
+    return this.sitOutValue;
+  }
+
+  detachStandingTemplate(): void {
+    this.standingFourballIdValue = null;
+  }
+
   get path(): string | null {
     return this.golfRoundIdValue ? `/golf/${this.golfRoundIdValue}` : null;
   }
@@ -95,11 +133,51 @@ export class GolfTourFourball {
     return this.playersValue.some((player) => player.hasUserId(userId));
   }
 
-  assignPlayers(players: GolfPlayer[]): void {
+  playerSitsOut(slot: number): boolean {
+    return this.sitOutValue || this.sitOutSlots.has(slot);
+  }
+
+  scoringPlayers(): GolfPlayer[] {
+    return this.playersValue.filter((player) => !this.playerSitsOut(player.slot));
+  }
+
+  assignPlayers(
+    players: GolfPlayer[],
+    sitOutBySlot?: Map<number, boolean>,
+  ): void {
     if (!this.statusValue.isPending) {
       throw new DomainError("Players can only be assigned while the fourball is pending");
     }
     this.playersValue = players;
+    if (sitOutBySlot) {
+      this.sitOutSlots = new Set(
+        [...sitOutBySlot.entries()]
+          .filter(([, sitOut]) => sitOut)
+          .map(([slot]) => slot),
+      );
+    } else {
+      this.sitOutSlots = new Set();
+    }
+  }
+
+  setSitOut(sitOut: boolean): void {
+    if (this.statusValue.isCancelled) {
+      throw new DomainError("A cancelled fourball cannot sit out");
+    }
+    this.sitOutValue = sitOut;
+  }
+
+  setPlayerSitOuts(updates: Map<number, boolean>): void {
+    if (this.statusValue.isCancelled) {
+      throw new DomainError("A cancelled fourball cannot sit out");
+    }
+    for (const [slot, sitOut] of updates) {
+      if (!this.playersValue.some((player) => player.slot === slot)) {
+        throw new DomainError(`No player in slot ${slot}`);
+      }
+      if (sitOut) this.sitOutSlots.add(slot);
+      else this.sitOutSlots.delete(slot);
+    }
   }
 
   moveToCamp(campId: string): void {
@@ -126,7 +204,10 @@ export class GolfTourFourball {
     if (!this.statusValue.isPending) {
       throw new DomainError("Only a pending fourball can be started");
     }
-    if (this.playersValue.length < 1) {
+    if (this.sitOutValue) {
+      throw new DomainError("A sit-out fourball cannot be started");
+    }
+    if (this.scoringPlayers().length < 1) {
       throw new GolfTourNotReadyError(
         "Assign at least one player before starting this fourball",
       );
@@ -153,7 +234,12 @@ export class GolfTourFourball {
       campId: this.campIdValue,
       golfRoundId: this.golfRoundIdValue,
       status: this.statusValue.value,
-      players: this.playersValue.map((player) => player.toSnapshot()),
+      standingFourballId: this.standingFourballIdValue,
+      sitOut: this.sitOutValue,
+      players: this.playersValue.map((player) => ({
+        ...player.toSnapshot(),
+        sitOut: this.sitOutSlots.has(player.slot),
+      })),
     };
   }
 }
@@ -165,6 +251,48 @@ export function parseFourballPlayers(raw: unknown): GolfPlayer[] {
   }
   if (raw.length === 0) return [];
   return GolfPlayer.fromPlayers(raw as GolfPlayerInput[]);
+}
+
+export type ParsedFourballSeats = {
+  players: GolfPlayer[];
+  sitOutBySlot: Map<number, boolean>;
+};
+
+export function parseFourballSeats(raw: unknown): ParsedFourballSeats {
+  const players = parseFourballPlayers(raw);
+  const sitOutBySlot = new Map<number, boolean>();
+  if (Array.isArray(raw)) {
+    for (const row of raw) {
+      if (
+        row &&
+        typeof row === "object" &&
+        "slot" in row &&
+        "sitOut" in row
+      ) {
+        const slot = (row as { slot: number }).slot;
+        sitOutBySlot.set(slot, (row as { sitOut: unknown }).sitOut === true);
+      }
+    }
+  }
+  return { players, sitOutBySlot };
+}
+
+export function parsePlayerSitOuts(raw: unknown): Map<number, boolean> {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new DomainError("playerSitOuts must be a non-empty array");
+  }
+  const updates = new Map<number, boolean>();
+  for (const row of raw) {
+    if (!row || typeof row !== "object" || !("slot" in row)) {
+      throw new DomainError("playerSitOuts.slot must be 1, 2, 3, or 4");
+    }
+    const slot = (row as { slot: unknown }).slot;
+    if (slot !== 1 && slot !== 2 && slot !== 3 && slot !== 4) {
+      throw new DomainError("playerSitOuts.slot must be 1, 2, 3, or 4");
+    }
+    updates.set(slot, (row as { sitOut?: unknown }).sitOut === true);
+  }
+  return updates;
 }
 
 export function golfRoundPath(golfRoundId: string): string {

--- a/src/modules/golf-tours/entities/golf-tour-roster-member-not-found-error.ts
+++ b/src/modules/golf-tours/entities/golf-tour-roster-member-not-found-error.ts
@@ -1,0 +1,6 @@
+export class GolfTourRosterMemberNotFoundError extends Error {
+  constructor(message = "Roster member not found") {
+    super(message);
+    this.name = "GolfTourRosterMemberNotFoundError";
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-roster-member.ts
+++ b/src/modules/golf-tours/entities/golf-tour-roster-member.ts
@@ -1,0 +1,143 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+
+export type GolfTourRosterMemberSnapshot = {
+  id: string;
+  campId: string;
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+};
+
+export type GolfTourRosterMemberInput = {
+  userId?: string | null;
+  displayName: unknown;
+  isGuest: unknown;
+};
+
+export class GolfTourRosterMember {
+  private constructor(
+    readonly id: string,
+    readonly campId: string,
+    private userIdValue: string | null,
+    private displayNameValue: string,
+    private isGuestValue: boolean,
+  ) {}
+
+  static create(props: {
+    id: string;
+    campId: string;
+    userId?: string | null;
+    displayName: unknown;
+    isGuest: unknown;
+  }): GolfTourRosterMember {
+    const identity = parseRosterIdentity(props);
+    return new GolfTourRosterMember(
+      props.id,
+      props.campId,
+      identity.userId,
+      identity.displayName,
+      identity.isGuest,
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    campId: string;
+    userId: string | null;
+    displayName: string;
+    isGuest: boolean;
+  }): GolfTourRosterMember {
+    return new GolfTourRosterMember(
+      props.id,
+      props.campId,
+      props.userId,
+      props.displayName,
+      props.isGuest,
+    );
+  }
+
+  static fromSnapshot(
+    snapshot: GolfTourRosterMemberSnapshot,
+  ): GolfTourRosterMember {
+    return GolfTourRosterMember.rehydrate(snapshot);
+  }
+
+  get userId(): string | null {
+    return this.userIdValue;
+  }
+
+  get displayName(): string {
+    return this.displayNameValue;
+  }
+
+  get isGuest(): boolean {
+    return this.isGuestValue;
+  }
+
+  get identityKey(): string {
+    if (!this.isGuestValue && this.userIdValue) {
+      return `user:${this.userIdValue}`;
+    }
+    return `guest:${this.displayNameValue.trim().toLowerCase()}`;
+  }
+
+  hasUserId(userId: string): boolean {
+    return this.userIdValue === userId;
+  }
+
+  update(details: GolfTourRosterMemberInput): void {
+    const identity = parseRosterIdentity({
+      userId: "userId" in details ? details.userId : this.userIdValue,
+      displayName:
+        details.displayName === undefined
+          ? this.displayNameValue
+          : details.displayName,
+      isGuest:
+        details.isGuest === undefined ? this.isGuestValue : details.isGuest,
+    });
+    this.userIdValue = identity.userId;
+    this.displayNameValue = identity.displayName;
+    this.isGuestValue = identity.isGuest;
+  }
+
+  toSnapshot(): GolfTourRosterMemberSnapshot {
+    return {
+      id: this.id,
+      campId: this.campId,
+      userId: this.userIdValue,
+      displayName: this.displayNameValue,
+      isGuest: this.isGuestValue,
+    };
+  }
+}
+
+function parseRosterIdentity(input: GolfTourRosterMemberInput): {
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+} {
+  const displayName = requiredTrimmed(input.displayName, "displayName");
+  const isGuest = input.isGuest === true;
+  const userId = optionalRosterUserId(input.userId);
+
+  if (isGuest) {
+    if (userId !== null) {
+      throw new DomainError("A guest roster member cannot have a userId");
+    }
+    return { userId: null, displayName, isGuest: true };
+  }
+
+  if (userId === null) {
+    throw new DomainError("A registered roster member requires a userId");
+  }
+  return { userId, displayName, isGuest: false };
+}
+
+function optionalRosterUserId(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "string") {
+    throw new DomainError("userId must be a string");
+  }
+  const value = raw.trim();
+  return value.length === 0 ? null : value;
+}

--- a/src/modules/golf-tours/entities/golf-tour-roster-member.ts
+++ b/src/modules/golf-tours/entities/golf-tour-roster-member.ts
@@ -10,8 +10,8 @@ export type GolfTourRosterMemberSnapshot = {
 
 export type GolfTourRosterMemberInput = {
   userId?: string | null;
-  displayName: unknown;
-  isGuest: unknown;
+  displayName?: unknown;
+  isGuest?: unknown;
 };
 
 export class GolfTourRosterMember {

--- a/src/modules/golf-tours/entities/golf-tour-standing-fourball-not-found-error.ts
+++ b/src/modules/golf-tours/entities/golf-tour-standing-fourball-not-found-error.ts
@@ -1,0 +1,6 @@
+export class GolfTourStandingFourballNotFoundError extends Error {
+  constructor(message = "Standing fourball not found") {
+    super(message);
+    this.name = "GolfTourStandingFourballNotFoundError";
+  }
+}

--- a/src/modules/golf-tours/entities/golf-tour-standing-fourball.ts
+++ b/src/modules/golf-tours/entities/golf-tour-standing-fourball.ts
@@ -1,0 +1,124 @@
+import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import {
+  GolfPlayer,
+  GolfPlayerSnapshot,
+} from "../../golf-round/entities/golf-player";
+import { parseFourballPlayers } from "./golf-tour-fourball";
+
+const NAME_MAX_LENGTH = 40;
+
+export type GolfTourStandingFourballSnapshot = {
+  id: string;
+  campId: string;
+  name: string | null;
+  sortOrder: number;
+  players: GolfPlayerSnapshot[];
+};
+
+export class GolfTourStandingFourball {
+  private constructor(
+    readonly id: string,
+    private campIdValue: string,
+    private nameValue: string | null,
+    readonly sortOrder: number,
+    private playersValue: GolfPlayer[],
+  ) {}
+
+  static create(props: {
+    id: string;
+    campId: string;
+    name?: string | null;
+    sortOrder: number;
+    players?: GolfPlayer[];
+  }): GolfTourStandingFourball {
+    return new GolfTourStandingFourball(
+      props.id,
+      props.campId,
+      parseStandingName(props.name),
+      props.sortOrder,
+      props.players ?? [],
+    );
+  }
+
+  static rehydrate(props: {
+    id: string;
+    campId: string;
+    name: string | null;
+    sortOrder: number;
+    players: GolfPlayer[];
+  }): GolfTourStandingFourball {
+    return new GolfTourStandingFourball(
+      props.id,
+      props.campId,
+      props.name,
+      props.sortOrder,
+      [...props.players],
+    );
+  }
+
+  static fromSnapshot(
+    snapshot: GolfTourStandingFourballSnapshot,
+  ): GolfTourStandingFourball {
+    return GolfTourStandingFourball.rehydrate({
+      id: snapshot.id,
+      campId: snapshot.campId,
+      name: snapshot.name,
+      sortOrder: snapshot.sortOrder,
+      players: snapshot.players.map((player) => GolfPlayer.from(player)),
+    });
+  }
+
+  get campId(): string {
+    return this.campIdValue;
+  }
+
+  get name(): string | null {
+    return this.nameValue;
+  }
+
+  get players(): readonly GolfPlayer[] {
+    return this.playersValue;
+  }
+
+  hasPlayerUserId(userId: string): boolean {
+    return this.playersValue.some((player) => player.hasUserId(userId));
+  }
+
+  update(details: {
+    campId?: string;
+    name?: string | null;
+    players?: GolfPlayer[];
+  }): void {
+    if (details.campId) this.campIdValue = details.campId;
+    if ("name" in details) this.nameValue = parseStandingName(details.name);
+    if (details.players) this.playersValue = details.players;
+  }
+
+  clonedPlayers(): GolfPlayer[] {
+    return this.playersValue.map((player) => GolfPlayer.from(player.toSnapshot()));
+  }
+
+  toSnapshot(): GolfTourStandingFourballSnapshot {
+    return {
+      id: this.id,
+      campId: this.campIdValue,
+      name: this.nameValue,
+      sortOrder: this.sortOrder,
+      players: this.playersValue.map((player) => player.toSnapshot()),
+    };
+  }
+}
+
+export function parseStandingName(raw: unknown): string | null {
+  if (raw == null || raw === "") return null;
+  const value = requiredTrimmed(raw, "name");
+  if (value.length > NAME_MAX_LENGTH) {
+    throw new DomainError(`name must be at most ${NAME_MAX_LENGTH} characters`);
+  }
+  return value;
+}
+
+export function parseStandingPlayers(raw: unknown): GolfPlayer[] {
+  if (raw == null) return [];
+  return parseFourballPlayers(raw);
+}

--- a/src/modules/golf-tours/entities/golf-tour.test.ts
+++ b/src/modules/golf-tours/entities/golf-tour.test.ts
@@ -179,4 +179,94 @@ describe(GolfTour, () => {
     expect(tour.canRead("user-alex")).toBe(true);
     expect(tour.canRead("user-stranger")).toBe(false);
   });
+
+  test("roster members can read; host-only roster and template writes", () => {
+    const tour = draft();
+    const campId = tour.camps[0]!.id;
+    expect(() =>
+      tour.addRosterMember("user-z", campId, {
+        displayName: "Alex",
+        isGuest: false,
+        userId: "user-alex",
+      }),
+    ).toThrow(GolfTourForbiddenError);
+
+    tour.addRosterMember("user-host", campId, {
+      displayName: "Alex",
+      isGuest: false,
+      userId: "user-alex",
+    });
+    expect(tour.canRead("user-alex")).toBe(true);
+
+    expect(() =>
+      tour.addStandingFourball("user-z", { campId }),
+    ).toThrow(GolfTourForbiddenError);
+  });
+
+  test("prepare is idempotent and custom players do not mutate the template", () => {
+    const tour = draft();
+    const campId = tour.camps[0]!.id;
+    const template = tour.addStandingFourball("user-host", {
+      campId,
+      name: "Group 1",
+      players: parseFourballPlayers([
+        { slot: 1, displayName: "Alex", isGuest: false, userId: "user-alex" },
+      ]),
+    });
+    const round = tour.addRound("user-host", {
+      date: TourDate.from("2026-09-12", "date"),
+      venueCmsId: CmsId.from("course-1"),
+    });
+    expect(tour.fourballs).toHaveLength(1);
+    expect(tour.fourballs[0]!.standingFourballId).toBe(template.id);
+
+    const again = tour.prepareRound("user-host", round.id);
+    expect(again).toHaveLength(0);
+    expect(tour.fourballs).toHaveLength(1);
+
+    tour.assignFourballPlayers("user-host", tour.fourballs[0]!.id, [
+      GolfPlayer.from({
+        slot: 1,
+        displayName: "Pat",
+        isGuest: true,
+        userId: null,
+      }),
+    ]);
+    expect(tour.standingFourballById(template.id)?.players[0]?.displayName).toBe(
+      "Alex",
+    );
+    expect(tour.fourballs[0]!.players[0]?.displayName).toBe("Pat");
+  });
+
+  test("copy from previous round clones groups without sit-out", () => {
+    const tour = draft();
+    const campId = tour.camps[0]!.id;
+    const first = tour.addRound("user-host", {
+      date: TourDate.from("2026-09-12", "date"),
+      venueCmsId: CmsId.from("course-1"),
+    });
+    const source = tour.addFourball("user-host", {
+      roundId: first.id,
+      campId,
+      players: parseFourballPlayers([
+        { slot: 1, displayName: "Alex", isGuest: false, userId: "user-alex" },
+      ]),
+    });
+    tour.setFourballSitOut("user-host", source.id, true);
+
+    const second = tour.addRound("user-host", {
+      date: TourDate.from("2026-09-13", "date"),
+      venueCmsId: CmsId.from("course-1"),
+    });
+    tour.copyRoundInstances("user-host", second.id, first.id);
+    const copied = tour.fourballs.filter((fourball) => fourball.roundId === second.id);
+    expect(copied).toHaveLength(1);
+    expect(copied[0]!.players[0]?.displayName).toBe("Alex");
+    expect(copied[0]!.sitOut).toBe(false);
+
+    tour.copyRoundInstances("user-host", second.id, first.id);
+    expect(
+      tour.fourballs.filter((fourball) => fourball.roundId === second.id),
+    ).toHaveLength(1);
+  });
 });

--- a/src/modules/golf-tours/entities/golf-tour.ts
+++ b/src/modules/golf-tours/entities/golf-tour.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 
 import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
-import type { GolfPlayer } from "../../golf-round/entities/golf-player";
+import { GolfPlayer } from "../../golf-round/entities/golf-player";
 import { CmsId } from "../../venue/entities/cms-id";
 import { GolfTourCamp } from "./golf-tour-camp";
 import { GolfTourCampName } from "./golf-tour-camp-name";
@@ -11,8 +11,11 @@ import { GolfTourFormat } from "./golf-tour-format";
 import { GolfTourFourball } from "./golf-tour-fourball";
 import { GolfTourFourballNotFoundError } from "./golf-tour-fourball-not-found-error";
 import { GolfTourName } from "./golf-tour-name";
+import { GolfTourRosterMember } from "./golf-tour-roster-member";
 import { GolfTourRound } from "./golf-tour-round";
 import { GolfTourRoundNotFoundError } from "./golf-tour-round-not-found-error";
+import { GolfTourStandingFourball } from "./golf-tour-standing-fourball";
+import { GolfTourStandingFourballNotFoundError } from "./golf-tour-standing-fourball-not-found-error";
 import { GolfTourStatus } from "./golf-tour-status";
 import { TourDate } from "./tour-date";
 
@@ -30,6 +33,7 @@ export type GolfTourSnapshot = {
   camps: ReturnType<GolfTourCamp["toSnapshot"]>[];
   rounds: ReturnType<GolfTourRound["toSnapshot"]>[];
   fourballs: ReturnType<GolfTourFourball["toSnapshot"]>[];
+  standingFourballs: ReturnType<GolfTourStandingFourball["toSnapshot"]>[];
 };
 
 export type CreateGolfTourProps = {
@@ -59,6 +63,7 @@ export class GolfTour {
     private campsValue: GolfTourCamp[],
     private roundsValue: GolfTourRound[],
     private fourballsValue: GolfTourFourball[],
+    private standingFourballsValue: GolfTourStandingFourball[],
   ) {}
 
   static create(props: CreateGolfTourProps): GolfTour {
@@ -91,6 +96,7 @@ export class GolfTour {
       camps,
       [],
       [],
+      [],
     );
   }
 
@@ -106,6 +112,7 @@ export class GolfTour {
     camps: GolfTourCamp[];
     rounds: GolfTourRound[];
     fourballs: GolfTourFourball[];
+    standingFourballs?: GolfTourStandingFourball[];
   }): GolfTour {
     return new GolfTour(
       props.id,
@@ -119,6 +126,9 @@ export class GolfTour {
       [...props.camps].sort((a, b) => a.sortOrder - b.sortOrder),
       [...props.rounds],
       [...props.fourballs],
+      [...(props.standingFourballs ?? [])].sort(
+        (a, b) => a.sortOrder - b.sortOrder,
+      ),
     );
   }
 
@@ -136,6 +146,9 @@ export class GolfTour {
       rounds: snapshot.rounds.map((round) => GolfTourRound.fromSnapshot(round)),
       fourballs: snapshot.fourballs.map((fourball) =>
         GolfTourFourball.fromSnapshot(fourball),
+      ),
+      standingFourballs: (snapshot.standingFourballs ?? []).map((template) =>
+        GolfTourStandingFourball.fromSnapshot(template),
       ),
     });
   }
@@ -172,13 +185,25 @@ export class GolfTour {
     return this.fourballsValue;
   }
 
+  get standingFourballs(): readonly GolfTourStandingFourball[] {
+    return this.standingFourballsValue;
+  }
+
   isHost(userId: string): boolean {
     return this.hostUserId === userId.trim();
   }
 
   isPlayer(userId: string): boolean {
     const id = userId.trim();
-    return this.fourballsValue.some((fourball) => fourball.hasPlayerUserId(id));
+    if (this.fourballsValue.some((fourball) => fourball.hasPlayerUserId(id))) {
+      return true;
+    }
+    if (this.campsValue.some((camp) => camp.hasPlayerUserId(id))) {
+      return true;
+    }
+    return this.standingFourballsValue.some((template) =>
+      template.hasPlayerUserId(id),
+    );
   }
 
   canRead(userId: string): boolean {
@@ -204,6 +229,14 @@ export class GolfTour {
     return (
       this.fourballsValue.find((fourball) => fourball.golfRoundId === id) ??
       null
+    );
+  }
+
+  standingFourballById(templateId: string): GolfTourStandingFourball | null {
+    return (
+      this.standingFourballsValue.find(
+        (template) => template.id === templateId,
+      ) ?? null
     );
   }
 
@@ -298,6 +331,7 @@ export class GolfTour {
       format: props.format,
     });
     this.roundsValue = [...this.roundsValue, round];
+    this.spawnInstancesFromTemplates(round.id);
     this.touch();
     return round;
   }
@@ -353,13 +387,227 @@ export class GolfTour {
     actorId: string,
     fourballId: string,
     players: GolfPlayer[],
+    sitOutBySlot?: Map<number, boolean>,
   ): GolfTourFourball {
     this.assertHost(actorId);
     this.assertMutable();
     const fourball = this.requireFourball(fourballId);
-    fourball.assignPlayers(players);
+    fourball.assignPlayers(players, sitOutBySlot);
     this.touch();
     return fourball;
+  }
+
+  setFourballSitOut(
+    actorId: string,
+    fourballId: string,
+    sitOut: boolean,
+  ): GolfTourFourball {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const fourball = this.requireFourball(fourballId);
+    fourball.setSitOut(sitOut);
+    this.touch();
+    return fourball;
+  }
+
+  setFourballPlayerSitOuts(
+    actorId: string,
+    fourballId: string,
+    updates: Map<number, boolean>,
+  ): GolfTourFourball {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const fourball = this.requireFourball(fourballId);
+    fourball.setPlayerSitOuts(updates);
+    this.touch();
+    return fourball;
+  }
+
+  addRosterMember(
+    actorId: string,
+    campId: string,
+    props: { userId?: string | null; displayName: unknown; isGuest: unknown },
+  ): GolfTourRosterMember {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const camp = this.requireCamp(campId);
+    const member = GolfTourRosterMember.create({
+      id: randomUUID(),
+      campId: camp.id,
+      userId: props.userId,
+      displayName: props.displayName,
+      isGuest: props.isGuest,
+    });
+    camp.addMember(member);
+    this.touch();
+    return member;
+  }
+
+  updateRosterMember(
+    actorId: string,
+    campId: string,
+    memberId: string,
+    details: {
+      userId?: string | null;
+      displayName?: unknown;
+      isGuest?: unknown;
+    },
+  ): GolfTourRosterMember {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const camp = this.requireCamp(campId);
+    if (
+      details.displayName === undefined &&
+      !("userId" in details) &&
+      details.isGuest === undefined
+    ) {
+      throw new DomainError("At least one field is required");
+    }
+    const member = camp.updateMember(memberId, details);
+    this.touch();
+    return member;
+  }
+
+  removeRosterMember(
+    actorId: string,
+    campId: string,
+    memberId: string,
+  ): GolfTourRosterMember {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const camp = this.requireCamp(campId);
+    const member = camp.removeMember(memberId);
+    this.touch();
+    return member;
+  }
+
+  addStandingFourball(
+    actorId: string,
+    props: {
+      campId: string;
+      name?: string | null;
+      players?: GolfPlayer[];
+      sortOrder?: number;
+    },
+  ): GolfTourStandingFourball {
+    this.assertHost(actorId);
+    this.assertMutable();
+    this.requireCamp(props.campId);
+    const sortOrder =
+      props.sortOrder ??
+      this.standingFourballsValue.reduce(
+        (max, template) => Math.max(max, template.sortOrder),
+        -1,
+      ) + 1;
+    const template = GolfTourStandingFourball.create({
+      id: randomUUID(),
+      campId: props.campId,
+      name: props.name,
+      sortOrder,
+      players: props.players,
+    });
+    this.standingFourballsValue = [...this.standingFourballsValue, template];
+    this.touch();
+    return template;
+  }
+
+  updateStandingFourball(
+    actorId: string,
+    templateId: string,
+    details: {
+      campId?: string;
+      name?: string | null;
+      players?: GolfPlayer[];
+    },
+  ): GolfTourStandingFourball {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const template = this.requireStandingFourball(templateId);
+    if (
+      !details.campId &&
+      !("name" in details) &&
+      details.players === undefined
+    ) {
+      throw new DomainError("At least one field is required");
+    }
+    if (details.campId) this.requireCamp(details.campId);
+    template.update(details);
+    this.touch();
+    return template;
+  }
+
+  removeStandingFourball(
+    actorId: string,
+    templateId: string,
+  ): GolfTourStandingFourball {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const template = this.requireStandingFourball(templateId);
+    for (const fourball of this.fourballsValue) {
+      if (fourball.standingFourballId === template.id) {
+        fourball.detachStandingTemplate();
+      }
+    }
+    this.standingFourballsValue = this.standingFourballsValue.filter(
+      (row) => row.id !== template.id,
+    );
+    this.touch();
+    return template;
+  }
+
+  prepareRound(actorId: string, roundId: string): GolfTourFourball[] {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const created = this.spawnInstancesFromTemplates(roundId);
+    this.touch();
+    return created;
+  }
+
+  copyRoundInstances(
+    actorId: string,
+    targetRoundId: string,
+    sourceRoundId: string,
+  ): GolfTourFourball[] {
+    this.assertHost(actorId);
+    this.assertMutable();
+    const target = this.requireRound(targetRoundId);
+    const source = this.requireRound(sourceRoundId);
+    if (target.id === source.id) {
+      throw new DomainError("Cannot copy a round onto itself");
+    }
+
+    const createdOrUpdated: GolfTourFourball[] = [];
+    const sources = this.fourballsValue.filter(
+      (fourball) =>
+        fourball.roundId === source.id && !fourball.status.isCancelled,
+    );
+
+    for (const sourceFourball of sources) {
+      const clonedPlayers = sourceFourball.players.map((player) =>
+        GolfPlayer.from(player.toSnapshot()),
+      );
+      const existing = this.findCopyTarget(target.id, sourceFourball);
+      if (existing) {
+        if (existing.status.isPending) {
+          existing.assignPlayers(clonedPlayers);
+        }
+        createdOrUpdated.push(existing);
+        continue;
+      }
+
+      const copy = GolfTourFourball.create({
+        id: randomUUID(),
+        roundId: target.id,
+        campId: sourceFourball.campId,
+        players: clonedPlayers,
+        standingFourballId: sourceFourball.standingFourballId,
+      });
+      this.fourballsValue = [...this.fourballsValue, copy];
+      createdOrUpdated.push(copy);
+    }
+
+    this.touch();
+    return createdOrUpdated;
   }
 
   moveFourballCamp(
@@ -416,7 +664,7 @@ export class GolfTour {
 
   shouldAutoComplete(): boolean {
     const playable = this.fourballsValue.filter(
-      (fourball) => !fourball.status.isCancelled,
+      (fourball) => !fourball.status.isCancelled && !fourball.sitOut,
     );
     if (playable.length === 0) return false;
     return playable.every((fourball) => fourball.status.isLocked);
@@ -435,6 +683,9 @@ export class GolfTour {
       camps: this.campsValue.map((camp) => camp.toSnapshot()),
       rounds: this.roundsValue.map((round) => round.toSnapshot()),
       fourballs: this.fourballsValue.map((fourball) => fourball.toSnapshot()),
+      standingFourballs: this.standingFourballsValue.map((template) =>
+        template.toSnapshot(),
+      ),
     };
   }
 
@@ -454,6 +705,57 @@ export class GolfTour {
     const fourball = this.fourballById(fourballId.trim());
     if (!fourball) throw new GolfTourFourballNotFoundError();
     return fourball;
+  }
+
+  private requireStandingFourball(
+    templateId: string,
+  ): GolfTourStandingFourball {
+    const template = this.standingFourballById(templateId.trim());
+    if (!template) throw new GolfTourStandingFourballNotFoundError();
+    return template;
+  }
+
+  private spawnInstancesFromTemplates(roundId: string): GolfTourFourball[] {
+    this.requireRound(roundId);
+    const created: GolfTourFourball[] = [];
+    for (const template of this.standingFourballsValue) {
+      const existing = this.fourballsValue.find(
+        (fourball) =>
+          fourball.roundId === roundId &&
+          fourball.standingFourballId === template.id,
+      );
+      if (existing) continue;
+      const fourball = GolfTourFourball.create({
+        id: randomUUID(),
+        roundId,
+        campId: template.campId,
+        players: template.clonedPlayers(),
+        standingFourballId: template.id,
+      });
+      this.fourballsValue = [...this.fourballsValue, fourball];
+      created.push(fourball);
+    }
+    return created;
+  }
+
+  private findCopyTarget(
+    targetRoundId: string,
+    sourceFourball: GolfTourFourball,
+  ): GolfTourFourball | undefined {
+    if (sourceFourball.standingFourballId) {
+      return this.fourballsValue.find(
+        (fourball) =>
+          fourball.roundId === targetRoundId &&
+          fourball.standingFourballId === sourceFourball.standingFourballId,
+      );
+    }
+    const sourceKeys = playerKeys(sourceFourball);
+    return this.fourballsValue.find((fourball) => {
+      if (fourball.roundId !== targetRoundId) return false;
+      if (fourball.standingFourballId) return false;
+      if (fourball.campId !== sourceFourball.campId) return false;
+      return playerKeys(fourball) === sourceKeys;
+    });
   }
 
   private assertMutable(): void {
@@ -477,4 +779,17 @@ function assertDateRange(start: TourDate, end: TourDate): void {
   if (end.isBefore(start)) {
     throw new DomainError("endDate must be on or after startDate");
   }
+}
+
+function playerKeys(fourball: GolfTourFourball): string {
+  return fourball.players
+    .map((player) => {
+      const snapshot = player.toSnapshot();
+      const key =
+        !snapshot.isGuest && snapshot.userId
+          ? `user:${snapshot.userId}`
+          : `guest:${snapshot.displayName.trim().toLowerCase()}`;
+      return `${snapshot.slot}:${key}`;
+    })
+    .join("|");
 }

--- a/src/modules/golf-tours/index.ts
+++ b/src/modules/golf-tours/index.ts
@@ -18,17 +18,26 @@ import { LockGolfTourFourballOnScorecardLock } from "./services/lock-fourball-on
 import {
   AddGolfTourCamp,
   AddGolfTourFourball,
+  AddGolfTourRosterMember,
   AddGolfTourRound,
+  AddGolfTourStandingFourball,
   CompleteGolfTour,
+  CopyGolfTourRoundInstances,
   CreateGolfTour,
   GetGolfTour,
   GetGolfTourLeaderboard,
+  ListGolfTourRoster,
   ListMyGolfTours,
+  PrepareGolfTourRound,
+  RemoveGolfTourRosterMember,
+  RemoveGolfTourStandingFourball,
   StartGolfTourFourball,
   UpdateGolfTour,
   UpdateGolfTourCamp,
   UpdateGolfTourFourball,
+  UpdateGolfTourRosterMember,
   UpdateGolfTourRound,
+  UpdateGolfTourStandingFourball,
 } from "./services/golf-tours.service";
 
 export type CreateGolfToursModuleParams = {
@@ -77,6 +86,19 @@ export function createGolfToursModule({
       golfTourRepository,
       new GetGolfRoundById(golfRoundRepository),
     ),
+    listRoster: new ListGolfTourRoster(golfTourRepository),
+    addRosterMember: new AddGolfTourRosterMember(golfTourRepository),
+    updateRosterMember: new UpdateGolfTourRosterMember(golfTourRepository),
+    removeRosterMember: new RemoveGolfTourRosterMember(golfTourRepository),
+    addStandingFourball: new AddGolfTourStandingFourball(golfTourRepository),
+    updateStandingFourball: new UpdateGolfTourStandingFourball(
+      golfTourRepository,
+    ),
+    removeStandingFourball: new RemoveGolfTourStandingFourball(
+      golfTourRepository,
+    ),
+    prepareRound: new PrepareGolfTourRound(golfTourRepository),
+    copyRoundInstances: new CopyGolfTourRoundInstances(golfTourRepository),
     tryGetSessionUserId,
   });
 
@@ -98,17 +120,26 @@ export { LockGolfTourFourballOnScorecardLock } from "./services/lock-fourball-on
 export {
   AddGolfTourCamp,
   AddGolfTourFourball,
+  AddGolfTourRosterMember,
   AddGolfTourRound,
+  AddGolfTourStandingFourball,
   CompleteGolfTour,
+  CopyGolfTourRoundInstances,
   CreateGolfTour,
   GetGolfTour,
   GetGolfTourLeaderboard,
+  ListGolfTourRoster,
   ListMyGolfTours,
+  PrepareGolfTourRound,
+  RemoveGolfTourRosterMember,
+  RemoveGolfTourStandingFourball,
   StartGolfTourFourball,
   UpdateGolfTour,
   UpdateGolfTourCamp,
   UpdateGolfTourFourball,
+  UpdateGolfTourRosterMember,
   UpdateGolfTourRound,
+  UpdateGolfTourStandingFourball,
 } from "./services/golf-tours.service";
 export type {
   PublicGolfTour,

--- a/src/modules/golf-tours/repositories/prisma-golf-tour.repository.ts
+++ b/src/modules/golf-tours/repositories/prisma-golf-tour.repository.ts
@@ -9,7 +9,9 @@ import { GolfTourFourball } from "../entities/golf-tour-fourball";
 import { GolfTourFourballStatus } from "../entities/golf-tour-fourball-status";
 import { GolfTourName } from "../entities/golf-tour-name";
 import { GolfTourPersistenceError } from "../entities/golf-tour-persistence-error";
+import { GolfTourRosterMember } from "../entities/golf-tour-roster-member";
 import { GolfTourRound } from "../entities/golf-tour-round";
+import { GolfTourStandingFourball } from "../entities/golf-tour-standing-fourball";
 import { GolfTourStatus } from "../entities/golf-tour-status";
 import { TourDate } from "../entities/tour-date";
 import { GolfTourRepository } from "./golf-tour.repository";
@@ -19,6 +21,7 @@ type PlayerRow = {
   userId: string | null;
   displayName: string;
   isGuest: boolean;
+  sitOut?: boolean;
 };
 
 type FourballRow = {
@@ -26,8 +29,18 @@ type FourballRow = {
   roundId: string;
   campId: string;
   golfRoundId: string | null;
+  standingFourballId?: string | null;
+  sitOut?: boolean;
   status: "pending" | "live" | "locked" | "cancelled";
   players: PlayerRow[];
+};
+
+type RosterRow = {
+  id: string;
+  campId: string;
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
 };
 
 type CampRow = {
@@ -35,6 +48,22 @@ type CampRow = {
   name: string;
   color: string | null;
   sortOrder: number;
+  roster?: RosterRow[];
+};
+
+type StandingPlayerRow = {
+  slot: number;
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+};
+
+type StandingFourballRow = {
+  id: string;
+  campId: string;
+  name: string | null;
+  sortOrder: number;
+  players: StandingPlayerRow[];
 };
 
 type RoundRow = {
@@ -57,13 +86,21 @@ type TourRow = {
   camps: CampRow[];
   rounds: RoundRow[];
   fourballs: FourballRow[];
+  standingFourballs?: StandingFourballRow[];
 };
 
 const includeRelations = {
-  camps: { orderBy: { sortOrder: "asc" as const } },
+  camps: {
+    orderBy: { sortOrder: "asc" as const },
+    include: { roster: { orderBy: { createdAt: "asc" as const } } },
+  },
   rounds: { orderBy: { date: "asc" as const } },
   fourballs: {
     orderBy: { createdAt: "asc" as const },
+    include: { players: { orderBy: { slot: "asc" as const } } },
+  },
+  standingFourballs: {
+    orderBy: { sortOrder: "asc" as const },
     include: { players: { orderBy: { slot: "asc" as const } } },
   },
 };
@@ -84,6 +121,15 @@ function toDomain(row: TourRow): GolfTour {
         name: GolfTourCampName.from(camp.name),
         color: camp.color,
         sortOrder: camp.sortOrder,
+        roster: (camp.roster ?? []).map((member) =>
+          GolfTourRosterMember.rehydrate({
+            id: member.id,
+            campId: member.campId,
+            userId: member.userId,
+            displayName: member.displayName,
+            isGuest: member.isGuest,
+          }),
+        ),
       }),
     ),
     rounds: row.rounds.map((round) =>
@@ -102,7 +148,28 @@ function toDomain(row: TourRow): GolfTour {
         campId: fourball.campId,
         golfRoundId: fourball.golfRoundId,
         status: GolfTourFourballStatus.from(fourball.status),
+        standingFourballId: fourball.standingFourballId ?? null,
+        sitOut: fourball.sitOut === true,
+        sitOutSlots: fourball.players
+          .filter((player) => player.sitOut)
+          .map((player) => player.slot),
         players: fourball.players.map((player) =>
+          GolfPlayer.from({
+            slot: player.slot,
+            userId: player.userId,
+            displayName: player.displayName,
+            isGuest: player.isGuest,
+          }),
+        ),
+      }),
+    ),
+    standingFourballs: (row.standingFourballs ?? []).map((template) =>
+      GolfTourStandingFourball.rehydrate({
+        id: template.id,
+        campId: template.campId,
+        name: template.name,
+        sortOrder: template.sortOrder,
+        players: template.players.map((player) =>
           GolfPlayer.from({
             slot: player.slot,
             userId: player.userId,
@@ -210,6 +277,72 @@ export class PrismaGolfTourRepository implements GolfTourRepository {
               sortOrder: camp.sortOrder,
             },
           });
+
+          const memberIds = camp.roster.map((member) => member.id);
+          await tx.golfTourCampMember.deleteMany({
+            where: {
+              campId: camp.id,
+              id: { notIn: memberIds },
+            },
+          });
+          for (const member of camp.roster) {
+            await tx.golfTourCampMember.upsert({
+              where: { id: member.id },
+              create: {
+                id: member.id,
+                campId: camp.id,
+                userId: member.userId,
+                displayName: member.displayName,
+                isGuest: member.isGuest,
+              },
+              update: {
+                userId: member.userId,
+                displayName: member.displayName,
+                isGuest: member.isGuest,
+              },
+            });
+          }
+        }
+
+        const templateIds = snapshot.standingFourballs.map(
+          (template) => template.id,
+        );
+        await tx.golfTourStandingFourball.deleteMany({
+          where: {
+            tourId: snapshot.id,
+            id: { notIn: templateIds },
+          },
+        });
+        for (const template of snapshot.standingFourballs) {
+          await tx.golfTourStandingFourball.upsert({
+            where: { id: template.id },
+            create: {
+              id: template.id,
+              tourId: snapshot.id,
+              campId: template.campId,
+              name: template.name,
+              sortOrder: template.sortOrder,
+            },
+            update: {
+              campId: template.campId,
+              name: template.name,
+              sortOrder: template.sortOrder,
+            },
+          });
+          await tx.golfTourStandingFourballPlayer.deleteMany({
+            where: { templateId: template.id },
+          });
+          if (template.players.length > 0) {
+            await tx.golfTourStandingFourballPlayer.createMany({
+              data: template.players.map((player) => ({
+                templateId: template.id,
+                slot: player.slot,
+                userId: player.userId,
+                displayName: player.displayName,
+                isGuest: player.isGuest,
+              })),
+            });
+          }
         }
 
         for (const round of snapshot.rounds) {
@@ -249,11 +382,15 @@ export class PrismaGolfTourRepository implements GolfTourRepository {
               roundId: fourball.roundId,
               campId: fourball.campId,
               golfRoundId: fourball.golfRoundId,
+              standingFourballId: fourball.standingFourballId,
+              sitOut: fourball.sitOut,
               status: fourball.status,
             },
             update: {
               campId: fourball.campId,
               golfRoundId: fourball.golfRoundId,
+              standingFourballId: fourball.standingFourballId,
+              sitOut: fourball.sitOut,
               status: fourball.status,
             },
           });
@@ -269,6 +406,7 @@ export class PrismaGolfTourRepository implements GolfTourRepository {
                 userId: player.userId,
                 displayName: player.displayName,
                 isGuest: player.isGuest,
+                sitOut: player.sitOut,
               })),
             });
           }
@@ -307,7 +445,15 @@ export class PrismaGolfTourRepository implements GolfTourRepository {
     try {
       const rows = await this.prisma.golfTour.findMany({
         where: {
-          fourballs: { some: { players: { some: { userId } } } },
+          OR: [
+            { fourballs: { some: { players: { some: { userId } } } } },
+            { camps: { some: { roster: { some: { userId } } } } },
+            {
+              standingFourballs: {
+                some: { players: { some: { userId } } },
+              },
+            },
+          ],
         },
         include: includeRelations,
         orderBy: { updatedAt: "desc" },

--- a/src/modules/golf-tours/routes/golf-tours.routes.ts
+++ b/src/modules/golf-tours/routes/golf-tours.routes.ts
@@ -90,5 +90,77 @@ export function createGolfToursRoutes(
     },
   );
 
+  router.get(
+    "/api/golf-tours/:id/camps/:campId/roster",
+    options.requireAuth,
+    (req, res) => {
+      void controller.listRoster(req, res);
+    },
+  );
+
+  router.post(
+    "/api/golf-tours/:id/camps/:campId/roster",
+    options.requireAuth,
+    (req, res) => {
+      void controller.addRosterMember(req, res);
+    },
+  );
+
+  router.patch(
+    "/api/golf-tours/:id/camps/:campId/roster/:memberId",
+    options.requireAuth,
+    (req, res) => {
+      void controller.updateRosterMember(req, res);
+    },
+  );
+
+  router.delete(
+    "/api/golf-tours/:id/camps/:campId/roster/:memberId",
+    options.requireAuth,
+    (req, res) => {
+      void controller.removeRosterMember(req, res);
+    },
+  );
+
+  router.post(
+    "/api/golf-tours/:id/standing-fourballs",
+    options.requireAuth,
+    (req, res) => {
+      void controller.addStandingFourball(req, res);
+    },
+  );
+
+  router.patch(
+    "/api/golf-tours/:id/standing-fourballs/:templateId",
+    options.requireAuth,
+    (req, res) => {
+      void controller.updateStandingFourball(req, res);
+    },
+  );
+
+  router.delete(
+    "/api/golf-tours/:id/standing-fourballs/:templateId",
+    options.requireAuth,
+    (req, res) => {
+      void controller.removeStandingFourball(req, res);
+    },
+  );
+
+  router.post(
+    "/api/golf-tours/:id/rounds/:roundId/prepare",
+    options.requireAuth,
+    (req, res) => {
+      void controller.prepareRound(req, res);
+    },
+  );
+
+  router.post(
+    "/api/golf-tours/:id/rounds/:roundId/copy-from/:sourceRoundId",
+    options.requireAuth,
+    (req, res) => {
+      void controller.copyFromRound(req, res);
+    },
+  );
+
   return router;
 }

--- a/src/modules/golf-tours/services/golf-tours.service.test.ts
+++ b/src/modules/golf-tours/services/golf-tours.service.test.ts
@@ -399,7 +399,7 @@ describe("golf tours application", () => {
     await ctx.lockGolf.execute({
       roundId: started.golfRoundId,
       lockedByUserId: "user-host",
-      score: scoreForSlots([1, 2], 4),
+      score: scoreForSlots([1], 4),
     });
 
     const { leaderboard } = await ctx.leaderboard.execute({

--- a/src/modules/golf-tours/services/golf-tours.service.test.ts
+++ b/src/modules/golf-tours/services/golf-tours.service.test.ts
@@ -14,13 +14,18 @@ import { InMemoryGolfTourRepository } from "../repositories/in-memory-golf-tour.
 import { LockGolfTourFourballOnScorecardLock } from "./lock-fourball-on-scorecard-lock";
 import {
   AddGolfTourFourball,
+  AddGolfTourRosterMember,
   AddGolfTourRound,
+  AddGolfTourStandingFourball,
   CompleteGolfTour,
+  CopyGolfTourRoundInstances,
   CreateGolfTour,
   GetGolfTour,
   GetGolfTourLeaderboard,
+  PrepareGolfTourRound,
   StartGolfTourFourball,
   UpdateGolfTour,
+  UpdateGolfTourFourball,
 } from "./golf-tours.service";
 
 const COURSE = "sanity-course-1";
@@ -64,6 +69,11 @@ describe("golf tours application", () => {
       complete: new CompleteGolfTour(tours),
       addRound: new AddGolfTourRound(tours, venues),
       addFourball: new AddGolfTourFourball(tours),
+      addRoster: new AddGolfTourRosterMember(tours),
+      addStanding: new AddGolfTourStandingFourball(tours),
+      updateFourball: new UpdateGolfTourFourball(tours),
+      prepare: new PrepareGolfTourRound(tours),
+      copyFrom: new CopyGolfTourRoundInstances(tours),
       start: new StartGolfTourFourball(tours, createGolfRound),
       leaderboard: new GetGolfTourLeaderboard(tours, new GetGolfRoundById(golf)),
       lockGolf,
@@ -266,5 +276,207 @@ describe("golf tours application", () => {
         venueCmsId: COURSE,
       }),
     ).rejects.toBeInstanceOf(DomainError);
+  });
+
+  test("roster CRUD is host-only and rejects duplicate members", async () => {
+    const ctx = await setup();
+    const { tour } = await ctx.create.execute({
+      userId: "user-host",
+      name: "Friends Cup",
+      startDate: "2026-09-12",
+      endDate: "2026-09-14",
+    });
+    const campId = tour.camps[0]!.id;
+
+    await expect(
+      ctx.addRoster.execute({
+        userId: "user-other",
+        tourId: tour.id,
+        campId,
+        displayName: "Alex",
+        isGuest: false,
+        memberUserId: "user-alex",
+      }),
+    ).rejects.toBeInstanceOf(GolfTourForbiddenError);
+
+    const added = await ctx.addRoster.execute({
+      userId: "user-host",
+      tourId: tour.id,
+      campId,
+      displayName: "Alex",
+      isGuest: false,
+      memberUserId: "user-alex",
+    });
+    expect(added.tour.camps[0]!.roster).toHaveLength(1);
+    expect(added.member.displayName).toBe("Alex");
+
+    await expect(
+      ctx.addRoster.execute({
+        userId: "user-host",
+        tourId: tour.id,
+        campId,
+        displayName: "Alex Two",
+        isGuest: false,
+        memberUserId: "user-alex",
+      }),
+    ).rejects.toBeInstanceOf(DomainError);
+  });
+
+  test("prepare is idempotent; sit-out is excluded from leaderboard; custom does not mutate template", async () => {
+    const ctx = await setup();
+    const created = await ctx.create.execute({
+      userId: "user-host",
+      name: "Friends Cup",
+      startDate: "2026-09-12",
+      endDate: "2026-09-14",
+    });
+    const tourId = created.tour.id;
+    const campId = created.tour.camps[0]!.id;
+
+    const standing = await ctx.addStanding.execute({
+      userId: "user-host",
+      tourId,
+      campId,
+      name: "Group 1",
+      players: [
+        { slot: 1, displayName: "Alex", isGuest: false, userId: "user-host" },
+        { slot: 2, displayName: "Pat", isGuest: true, userId: null },
+      ],
+    });
+
+    const withRound = await ctx.addRound.execute({
+      userId: "user-host",
+      tourId,
+      date: "2026-09-12",
+      venueCmsId: COURSE,
+    });
+    expect(withRound.tour.fourballs).toHaveLength(1);
+    const fourballId = withRound.tour.fourballs[0]!.id;
+    expect(withRound.tour.fourballs[0]!.standingFourballId).toBe(
+      standing.standingFourball.id,
+    );
+
+    const prepared = await ctx.prepare.execute({
+      userId: "user-host",
+      tourId,
+      roundId: withRound.tour.rounds[0]!.id,
+    });
+    expect(prepared.createdIds).toEqual([]);
+    expect(prepared.tour.fourballs).toHaveLength(1);
+
+    await ctx.updateFourball.execute({
+      userId: "user-host",
+      tourId,
+      fourballId,
+      players: [
+        { slot: 1, displayName: "Sam", isGuest: false, userId: "user-sam" },
+        { slot: 2, displayName: "Pat", isGuest: true, userId: null, sitOut: true },
+      ],
+    });
+    const afterCustom = await ctx.get.execute({ userId: "user-host", tourId });
+    expect(afterCustom.tour.fourballs[0]!.players[0]!.displayName).toBe("Sam");
+    expect(afterCustom.tour.fourballs[0]!.players[1]!.sitOut).toBe(true);
+    expect(afterCustom.tour.standingFourballs[0]!.players[0]!.displayName).toBe(
+      "Alex",
+    );
+
+    await ctx.addFourball.execute({
+      userId: "user-host",
+      tourId,
+      roundId: withRound.tour.rounds[0]!.id,
+      campId,
+      players: [
+        { slot: 1, displayName: "Keep open", isGuest: false, userId: "user-open" },
+      ],
+    });
+
+    const started = await ctx.start.execute({
+      userId: "user-host",
+      tourId,
+      fourballId,
+      teeName: "White",
+    });
+    await ctx.lockGolf.execute({
+      roundId: started.golfRoundId,
+      lockedByUserId: "user-host",
+      score: scoreForSlots([1, 2], 4),
+    });
+
+    const { leaderboard } = await ctx.leaderboard.execute({
+      userId: "user-host",
+      tourId,
+    });
+    const camp = leaderboard.camps.find((row) => row.campId === campId)!;
+    expect(camp.players.map((player) => player.playerKey)).toEqual([
+      "user:user-sam",
+    ]);
+    expect(camp.players[0]!.playerRoundsCounted).toBe(1);
+
+    await ctx.updateFourball.execute({
+      userId: "user-host",
+      tourId,
+      fourballId,
+      sitOut: true,
+    });
+    const sitting = await ctx.leaderboard.execute({
+      userId: "user-host",
+      tourId,
+    });
+    expect(
+      sitting.leaderboard.camps.find((row) => row.campId === campId)!.players,
+    ).toEqual([]);
+  });
+
+  test("copy from previous round creates pending instances from source groups", async () => {
+    const ctx = await setup();
+    const created = await ctx.create.execute({
+      userId: "user-host",
+      name: "Friends Cup",
+      startDate: "2026-09-12",
+      endDate: "2026-09-14",
+    });
+    const tourId = created.tour.id;
+    const first = await ctx.addRound.execute({
+      userId: "user-host",
+      tourId,
+      date: "2026-09-12",
+      venueCmsId: COURSE,
+    });
+    await ctx.addFourball.execute({
+      userId: "user-host",
+      tourId,
+      roundId: first.tour.rounds[0]!.id,
+      campId: created.tour.camps[0]!.id,
+      players: [
+        { slot: 1, displayName: "Alex", isGuest: false, userId: "user-host" },
+      ],
+    });
+    const second = await ctx.addRound.execute({
+      userId: "user-host",
+      tourId,
+      date: "2026-09-13",
+      venueCmsId: COURSE,
+    });
+    const copied = await ctx.copyFrom.execute({
+      userId: "user-host",
+      tourId,
+      roundId: second.tour.rounds[1]!.id,
+      sourceRoundId: first.tour.rounds[0]!.id,
+    });
+    const targetGroups = copied.tour.fourballs.filter(
+      (fourball) => fourball.roundId === second.tour.rounds[1]!.id,
+    );
+    expect(targetGroups).toHaveLength(1);
+    expect(targetGroups[0]!.players[0]!.displayName).toBe("Alex");
+    expect(targetGroups[0]!.status).toBe("pending");
+
+    await expect(
+      ctx.copyFrom.execute({
+        userId: "user-other",
+        tourId,
+        roundId: second.tour.rounds[1]!.id,
+        sourceRoundId: first.tour.rounds[0]!.id,
+      }),
+    ).rejects.toBeInstanceOf(GolfTourForbiddenError);
   });
 });

--- a/src/modules/golf-tours/services/golf-tours.service.ts
+++ b/src/modules/golf-tours/services/golf-tours.service.ts
@@ -7,10 +7,15 @@ import { CmsId } from "../../venue/entities/cms-id";
 import { VenueRepository } from "../../venue/repositories/venue.repository";
 import { GolfTour } from "../entities/golf-tour";
 import { GolfTourCampName } from "../entities/golf-tour-camp-name";
+import { GolfTourCampNotFoundError } from "../entities/golf-tour-camp-not-found-error";
 import { GolfTourFormat } from "../entities/golf-tour-format";
+import { GolfTourRosterMemberNotFoundError } from "../entities/golf-tour-roster-member-not-found-error";
+import { GolfTourStandingFourballNotFoundError } from "../entities/golf-tour-standing-fourball-not-found-error";
 import {
   golfRoundPath,
   parseFourballPlayers,
+  parseFourballSeats,
+  parsePlayerSitOuts,
 } from "../entities/golf-tour-fourball";
 import { GolfTourName } from "../entities/golf-tour-name";
 import { GolfTourNotFoundError } from "../entities/golf-tour-not-found-error";
@@ -28,6 +33,28 @@ export type PublicGolfTourPlayer = {
   userId: string | null;
   displayName: string;
   isGuest: boolean;
+  sitOut: boolean;
+};
+
+export type PublicGolfTourRosterMember = {
+  id: string;
+  campId: string;
+  userId: string | null;
+  displayName: string;
+  isGuest: boolean;
+};
+
+export type PublicGolfTourStandingFourball = {
+  id: string;
+  campId: string;
+  name: string | null;
+  sortOrder: number;
+  players: Array<{
+    slot: 1 | 2 | 3 | 4;
+    userId: string | null;
+    displayName: string;
+    isGuest: boolean;
+  }>;
 };
 
 export type PublicGolfTourFourball = {
@@ -37,6 +64,8 @@ export type PublicGolfTourFourball = {
   status: "pending" | "live" | "locked" | "cancelled";
   golfRoundId: string | null;
   path: string | null;
+  standingFourballId: string | null;
+  sitOut: boolean;
   players: PublicGolfTourPlayer[];
 };
 
@@ -45,6 +74,7 @@ export type PublicGolfTourCamp = {
   name: string;
   color: string | null;
   sortOrder: number;
+  roster: PublicGolfTourRosterMember[];
 };
 
 export type PublicGolfTourRound = {
@@ -66,6 +96,7 @@ export type PublicGolfTour = {
   camps: PublicGolfTourCamp[];
   rounds: PublicGolfTourRound[];
   fourballs: PublicGolfTourFourball[];
+  standingFourballs: PublicGolfTourStandingFourball[];
   createdAt: string;
   updatedAt: string;
 };
@@ -103,8 +134,11 @@ function toPublicTour(tour: GolfTour, userId: string): PublicGolfTour {
       status: fourball.status,
       golfRoundId: fourball.golfRoundId,
       path: fourball.golfRoundId ? golfRoundPath(fourball.golfRoundId) : null,
+      standingFourballId: fourball.standingFourballId,
+      sitOut: fourball.sitOut,
       players: fourball.players,
     })),
+    standingFourballs: snapshot.standingFourballs,
     createdAt: snapshot.createdAt,
     updatedAt: snapshot.updatedAt,
   };
@@ -405,21 +439,40 @@ export class UpdateGolfTourFourball {
     players?: unknown;
     campId?: unknown;
     status?: unknown;
+    sitOut?: unknown;
+    playerSitOuts?: unknown;
   }) {
     const userId = requiredTrimmed(input.userId, "userId");
     const tour = await requireHostTour(this.tours, input.tourId, userId);
     if (
       input.players === undefined &&
       input.campId === undefined &&
-      input.status === undefined
+      input.status === undefined &&
+      input.sitOut === undefined &&
+      input.playerSitOuts === undefined
     ) {
       throw new DomainError("At least one field is required");
     }
     if (input.players !== undefined) {
+      const seats = parseFourballSeats(input.players);
       tour.assignFourballPlayers(
         userId,
         input.fourballId,
-        parseFourballPlayers(input.players),
+        seats.players,
+        seats.sitOutBySlot,
+      );
+    }
+    if (input.sitOut !== undefined) {
+      if (typeof input.sitOut !== "boolean") {
+        throw new DomainError("sitOut must be a boolean");
+      }
+      tour.setFourballSitOut(userId, input.fourballId, input.sitOut);
+    }
+    if (input.playerSitOuts !== undefined) {
+      tour.setFourballPlayerSitOuts(
+        userId,
+        input.fourballId,
+        parsePlayerSitOuts(input.playerSitOuts),
       );
     }
     if (input.campId !== undefined) {
@@ -484,7 +537,7 @@ export class StartGolfTourFourball {
 
     const players =
       input.players ??
-      fourball.players.map((player) => player.toSnapshot());
+      fourball.scoringPlayers().map((player) => player.toSnapshot());
     const holesPlayed = input.holesPlayed ?? 9;
     const course =
       input.course ??
@@ -538,4 +591,246 @@ export class GetGolfTourLeaderboard {
     }
     return { leaderboard: buildLeaderboard(tour, lockedRounds) };
   }
+}
+
+export class ListGolfTourRoster {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: { userId: string; tourId: string; campId: string }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireReadableTour(this.tours, input.tourId, userId);
+    const camp = tour.campById(input.campId.trim());
+    if (!camp) throw new GolfTourCampNotFoundError();
+    return {
+      roster: camp.toSnapshot().roster,
+    };
+  }
+}
+
+export class AddGolfTourRosterMember {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    campId: string;
+    displayName: unknown;
+    isGuest: unknown;
+    memberUserId?: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    const member = tour.addRosterMember(userId, input.campId, {
+      userId:
+        input.memberUserId === undefined
+          ? undefined
+          : (input.memberUserId as string | null),
+      displayName: input.displayName,
+      isGuest: input.isGuest,
+    });
+    const saved = await this.tours.persist(tour);
+    return {
+      tour: toPublicTour(saved, userId),
+      member: member.toSnapshot(),
+    };
+  }
+}
+
+export class UpdateGolfTourRosterMember {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    campId: string;
+    memberId: string;
+    displayName?: unknown;
+    isGuest?: unknown;
+    memberUserId?: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    const details: {
+      displayName?: unknown;
+      isGuest?: unknown;
+      userId?: string | null;
+    } = {};
+    if (input.displayName !== undefined) details.displayName = input.displayName;
+    if (input.isGuest !== undefined) details.isGuest = input.isGuest;
+    if ("memberUserId" in input) {
+      details.userId = input.memberUserId as string | null;
+    }
+    tour.updateRosterMember(userId, input.campId, input.memberId, details);
+    const saved = await this.tours.persist(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+export class RemoveGolfTourRosterMember {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    campId: string;
+    memberId: string;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    tour.removeRosterMember(userId, input.campId, input.memberId);
+    const saved = await this.tours.persist(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+export class AddGolfTourStandingFourball {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    campId: unknown;
+    name?: unknown;
+    players?: unknown;
+    sortOrder?: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    const campId = requiredTrimmed(input.campId, "campId");
+    const template = tour.addStandingFourball(userId, {
+      campId,
+      name: input.name as string | null | undefined,
+      players: resolveStandingPlayers(tour, campId, input.players),
+      sortOrder:
+        typeof input.sortOrder === "number" ? input.sortOrder : undefined,
+    });
+    const saved = await this.tours.persist(tour);
+    return {
+      tour: toPublicTour(saved, userId),
+      standingFourball: toPublicTour(saved, userId).standingFourballs.find(
+        (row) => row.id === template.id,
+      )!,
+    };
+  }
+}
+
+export class UpdateGolfTourStandingFourball {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    templateId: string;
+    campId?: unknown;
+    name?: unknown;
+    players?: unknown;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    const details: {
+      campId?: string;
+      name?: string | null;
+      players?: ReturnType<typeof resolveStandingPlayers>;
+    } = {};
+    if (input.campId !== undefined) {
+      details.campId = requiredTrimmed(input.campId, "campId");
+    }
+    if ("name" in input) details.name = input.name as string | null;
+    if (input.players !== undefined) {
+      const campId = details.campId ?? tour.standingFourballById(input.templateId)?.campId;
+      if (!campId) throw new GolfTourStandingFourballNotFoundError();
+      details.players = resolveStandingPlayers(tour, campId, input.players);
+    }
+    tour.updateStandingFourball(userId, input.templateId, details);
+    const saved = await this.tours.persist(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+export class RemoveGolfTourStandingFourball {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    templateId: string;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    tour.removeStandingFourball(userId, input.templateId);
+    const saved = await this.tours.persist(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+export class PrepareGolfTourRound {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: { userId: string; tourId: string; roundId: string }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    const created = tour.prepareRound(userId, input.roundId);
+    const saved = await this.tours.persist(tour);
+    const publicTour = toPublicTour(saved, userId);
+    return {
+      tour: publicTour,
+      createdIds: created.map((fourball) => fourball.id),
+      fourballs: publicTour.fourballs.filter(
+        (fourball) => fourball.roundId === input.roundId.trim(),
+      ),
+    };
+  }
+}
+
+export class CopyGolfTourRoundInstances {
+  constructor(private readonly tours: GolfTourRepository) {}
+
+  async execute(input: {
+    userId: string;
+    tourId: string;
+    roundId: string;
+    sourceRoundId: string;
+  }) {
+    const userId = requiredTrimmed(input.userId, "userId");
+    const tour = await requireHostTour(this.tours, input.tourId, userId);
+    tour.copyRoundInstances(userId, input.roundId, input.sourceRoundId);
+    const saved = await this.tours.persist(tour);
+    return { tour: toPublicTour(saved, userId) };
+  }
+}
+
+function resolveStandingPlayers(
+  tour: GolfTour,
+  campId: string,
+  raw: unknown,
+) {
+  if (raw == null) return parseFourballPlayers(raw);
+  if (!Array.isArray(raw)) {
+    throw new DomainError("players must be an array");
+  }
+  const camp = tour.campById(campId);
+  if (!camp) throw new GolfTourCampNotFoundError();
+  const resolved = raw.map((row) => {
+    if (
+      row &&
+      typeof row === "object" &&
+      "rosterMemberId" in row &&
+      (row as { rosterMemberId?: unknown }).rosterMemberId
+    ) {
+      const rosterMemberId = requiredTrimmed(
+        (row as { rosterMemberId: unknown }).rosterMemberId,
+        "rosterMemberId",
+      );
+      const member = camp.rosterMemberById(rosterMemberId);
+      if (!member) throw new GolfTourRosterMemberNotFoundError();
+      return {
+        slot: (row as { slot: unknown }).slot,
+        userId: member.userId,
+        displayName: member.displayName,
+        isGuest: member.isGuest,
+      };
+    }
+    return row;
+  });
+  return parseFourballPlayers(resolved);
 }

--- a/src/modules/golf-tours/services/leaderboard.ts
+++ b/src/modules/golf-tours/services/leaderboard.ts
@@ -70,7 +70,9 @@ export function buildLeaderboard(
     const byKey = new Map<string, Accumulator>();
     const fourballs = tour.fourballs.filter(
       (fourball) =>
-        fourball.campId === camp.id && fourball.status.isLocked,
+        fourball.campId === camp.id &&
+        fourball.status.isLocked &&
+        !fourball.sitOut,
     );
 
     for (const fourball of fourballs) {
@@ -115,6 +117,7 @@ function addLockedFourball(
 
   const gross = grossStrokesBySlot(round.score);
   for (const player of fourball.players) {
+    if (fourball.playerSitsOut(player.slot)) continue;
     const strokes = gross.get(player.slot);
     if (strokes == null) continue;
     const playerKey = playerIdentityKey(player);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #56.

Roster-first golf tour setup plus standing fourball templates so hosts do not rebuild pairings every round. Additive on the shipped v1 tour/camp/round/fourball + golf scorecard flow. Existing per-round fourball endpoints stay working.

## What shipped

- **Camp roster** — host CRUD (`userId` and/or guest display name)
- **Standing fourball templates** — tour-scoped, optional name, camp, up to 4 members (`rosterMemberId` or inline guests)
- **Prepare** — spawn pending fourball instances per template × round. Auto-runs when a round is added; `POST .../prepare` is idempotent and does not overwrite custom players
- **Sit-out** — instance or player×round; excluded from leaderboard averages; template unchanged
- **Copy from previous round** — create/edit target instances from source groups (sit-out not copied)
- **Custom this round** — `PATCH` instance players without writing back to the template (“also update standing” is out / future)
- Leaderboard avg gross on **locked, non-sit-out** player-rounds only
- Format remains **stroke-only**

## Setup v2 flow

1. Host creates a tour (still defaults to two camps).
2. Host adds a camp roster.
3. Host creates standing fourball templates.
4. Host adds a round — auto-prepares one pending instance per template.
5. Host may `POST .../rounds/:roundId/prepare` later (idempotent).
6. Per instance: sit out, custom this-round players, or start the existing scorecard.
7. `POST .../rounds/:roundId/copy-from/:sourceRoundId` clones/edits groups from a prior round.

## Migration

`20260909180000_golf_tour_setup_v2`

Applied on merge via Railway `preDeployCommand`. **Do not merge until ready to migrate.**

## Tests

All 430 tests passing, including roster CRUD, standing templates, prepare idempotent, sit-out excluded from leaderboard, copy from previous round, custom override does not mutate template, and host permissions.

## Out of scope

Scramble, handicaps, booking, Frontend.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f945c3b-007d-4455-a199-c5ac77f3383b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f945c3b-007d-4455-a199-c5ac77f3383b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

