### PR TITLE
feat: Golf handicaps (HI + WHS-style CH/PH snapshots)

### DIFF
--- a/prisma/migrations/20260909200000_golf_handicap/migration.sql
+++ b/prisma/migrations/20260909200000_golf_handicap/migration.sql
@@ -1,0 +1,15 @@
+-- Player Handicap Index on Profile, plus golf-round tee / handicap snapshots.
+-- Additive only: existing Profile, GolfRound, and GolfRoundPlayer rows stay valid.
+
+ALTER TABLE "Profile" ADD COLUMN "golfHandicapIndex" DECIMAL(4,1);
+
+ALTER TABLE "GolfRound" ADD COLUMN "teeId" TEXT;
+ALTER TABLE "GolfRound" ADD COLUMN "courseRating" DECIMAL(4,1);
+ALTER TABLE "GolfRound" ADD COLUMN "slopeRating" INTEGER;
+ALTER TABLE "GolfRound" ADD COLUMN "teePar" INTEGER;
+
+ALTER TABLE "GolfRoundPlayer" ADD COLUMN "handicapIndexUsed" DECIMAL(4,1);
+ALTER TABLE "GolfRoundPlayer" ADD COLUMN "courseHandicap" INTEGER;
+ALTER TABLE "GolfRoundPlayer" ADD COLUMN "playingHandicap" INTEGER;
+ALTER TABLE "GolfRoundPlayer" ADD COLUMN "grossTotal" INTEGER;
+ALTER TABLE "GolfRoundPlayer" ADD COLUMN "netTotal" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,7 @@ model Profile {
   activeSportSlug        String?
   onboardingCompletedAt  DateTime?
   onboardingSkippedAt    DateTime?
+  golfHandicapIndex      Decimal?  @db.Decimal(4, 1)
 
   user User @relation(fields: [userId], references: [id])
 }
@@ -610,6 +611,10 @@ model GolfRound {
   holesPlayed  Int
   startingHole Int             @default(1)
   teeName      String?
+  teeId        String?
+  courseRating Decimal?        @db.Decimal(4, 1)
+  slopeRating  Int?
+  teePar       Int?
   course       Json
   score        Json?
   lockedAt     DateTime?
@@ -628,9 +633,14 @@ model GolfRoundPlayer {
   roundId     String
   round       GolfRound @relation(fields: [roundId], references: [id], onDelete: Cascade)
   slot        Int
-  userId      String?
-  displayName String
-  isGuest     Boolean
+  userId            String?
+  displayName       String
+  isGuest           Boolean
+  handicapIndexUsed Decimal? @db.Decimal(4, 1)
+  courseHandicap    Int?
+  playingHandicap   Int?
+  grossTotal        Int?
+  netTotal          Int?
 
   @@unique([roundId, slot])
   @@index([userId])

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import {
 } from "./modules/darts";
 import {
   createGolfRoundModule,
+  GolfHandicapIndexLookup,
   GolfRoundRepository,
 } from "./modules/golf-round";
 import { createIdentityModule } from "./modules/identity";
@@ -104,6 +105,7 @@ export type CreateAppDependencies = {
   friendProfileLookup?: FriendProfileLookup;
   matchRepository?: MatchRepository;
   golfRoundRepository?: GolfRoundRepository;
+  golfHandicapIndexLookup?: GolfHandicapIndexLookup;
   dartsMatchRepository?: DartsMatchRepository;
   badgeAwardRepository?: BadgeAwardRepository;
   preferencesRepository?: PreferencesRepository;
@@ -194,6 +196,7 @@ export async function createApp(
     prisma,
     venueRepository: venue.venueRepository,
     golfRoundRepository: dependencies.golfRoundRepository,
+    golfHandicapIndexLookup: dependencies.golfHandicapIndexLookup,
     tryGetSessionUserId: identity.tryGetSessionUserId,
     onScorecardLocked,
   });

--- a/src/modules/golf-round/README.md
+++ b/src/modules/golf-round/README.md
@@ -1,0 +1,88 @@
+# Golf rounds + handicaps
+
+Live / locked golf scorecards. Handicap math is **estimated WHS-style**, **not official WHS certified**. Missing Handicap Index or missing tee ratings never blocks play — the round stays gross-only.
+
+## Formula (v1)
+
+Course Handicap (round half up, `.5` toward +∞):
+
+```
+CH = HI × (Slope / 113) + (CourseRating − Par)
+```
+
+Playing Handicap v1 is 100%:
+
+```
+PH = CH
+```
+
+Net:
+
+- Stroke indexes present on every hole → allocate PH strokes (hardest SI first; extras wrap). Hole net = hole gross − strokes received. Round net = sum of hole nets.
+- Stroke indexes missing → no per-hole nets; round net = gross − PH.
+- Plus handicaps (negative PH) apply negative strokes to the easiest holes so net = gross − PH still holds.
+
+## Profile
+
+| Method | Path | Body | Notes |
+| --- | --- | --- | --- |
+| `GET` | `/api/auth/me` | — | Includes `golfHandicapIndex` (`number \| null`, 1 decimal, −10.0…54.0) |
+| `PATCH` | `/api/auth/me` | `{ golfHandicapIndex: number \| null }` | Same payload as profile |
+| `GET` | `/api/me/profile` | — | Same document as `/api/auth/me` |
+| `PATCH` | `/api/me/profile` | `{ golfHandicapIndex: number \| null }` | Clears HI when `null` |
+
+## Round create — tee ratings from the client (Sanity)
+
+`POST /api/golf-rounds` and `POST /api/golf-rounds/capture` accept ratings as top-level fields **or** a nested `tee` object. All optional.
+
+```json
+{
+  "teeName": "White",
+  "teeId": "tee-white",
+  "courseRating": 71.2,
+  "slopeRating": 129,
+  "teePar": 72,
+  "tee": {
+    "id": "tee-white",
+    "courseRating": 71.2,
+    "slopeRating": 129,
+    "par": 72
+  }
+}
+```
+
+Nested `tee` wins when both are sent. If `teePar` / `tee.par` is omitted, the server sums `course.holes[].par`. Slope must be an integer 55–155; course rating 25–90 (9- or 18-hole).
+
+Server looks up `golfHandicapIndex` for each **seated `userId`** and computes CH/PH. Guests and players without HI stay gross-only.
+
+## Snapshot fields
+
+Returned on create, get, lock, capture, and locked history.
+
+| Field | Where | When |
+| --- | --- | --- |
+| `teeName` | round | always (required at create) |
+| `teeId` | round | when the client sent it |
+| `courseRating` | round | when the client sent it |
+| `slopeRating` | round | when the client sent it |
+| `teePar` | round | client value or sum of hole pars |
+| `handicapDisclaimer` | round | always |
+| `players[].handicapIndexUsed` | player | HI + CR + slope + par present |
+| `players[].courseHandicap` | player | same |
+| `players[].playingHandicap` | player | same (equals CH in v1) |
+| `players[].grossTotal` | player | after lock / capture |
+| `players[].netTotal` | player | after lock / capture, when PH was snapshotted |
+| `score.holes[].strokes` | hole | gross (unchanged) |
+| `score.holes[].netStrokes` | hole | lock / capture, when PH **and** stroke indexes exist |
+
+HI/CH/PH are snapshotted at create (or capture) and are not recalculated from the live profile on lock.
+
+## Migration
+
+`20260909200000_golf_handicap`
+
+Applied on merge via Railway `preDeployCommand` (`prisma migrate deploy`).
+
+## Out of scope
+
+Scramble / best ball, tour-camp pairing UI, inventing Sanity tee content, Frontend.

--- a/src/modules/golf-round/controllers/golf-round.controller.ts
+++ b/src/modules/golf-round/controllers/golf-round.controller.ts
@@ -29,6 +29,26 @@ const courseHoleSchema = z.object({
   strokeIndex: z.number(),
 });
 
+const teeObjectSchema = z
+  .object({
+    id: z.string().nullable().optional(),
+    teeId: z.string().nullable().optional(),
+    name: z.string().optional(),
+    courseRating: z.number().nullable().optional(),
+    slopeRating: z.number().nullable().optional(),
+    teePar: z.number().nullable().optional(),
+    par: z.number().nullable().optional(),
+  })
+  .optional();
+
+const teeRatingsSchema = {
+  teeId: z.string().nullable().optional(),
+  courseRating: z.number().nullable().optional(),
+  slopeRating: z.number().nullable().optional(),
+  teePar: z.number().nullable().optional(),
+  tee: teeObjectSchema,
+};
+
 const createGolfRoundBodySchema = z.object({
   venueCmsId: z.string(),
   startsAt: z.string(),
@@ -40,6 +60,7 @@ const createGolfRoundBodySchema = z.object({
     holes: z.array(courseHoleSchema).min(1),
   }),
   players: z.array(playerSchema).min(1).max(4),
+  ...teeRatingsSchema,
 });
 
 const golfRoundIdParamSchema = z.object({
@@ -78,6 +99,7 @@ const captureGolfRoundBodySchema = z.object({
   }),
   players: z.array(playerSchema).min(1).max(4),
   score: lockGolfRoundBodySchema.shape.score,
+  ...teeRatingsSchema,
 });
 
 export function createGolfRoundController(deps: {

--- a/src/modules/golf-round/controllers/golf-rounds.http.test.ts
+++ b/src/modules/golf-round/controllers/golf-rounds.http.test.ts
@@ -12,6 +12,7 @@ import { Venue } from "../../venue/entities/venue";
 import { VenueName } from "../../venue/entities/venue-name";
 import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
 import { GolfRoundPersistenceError } from "../entities/golf-round-persistence-error";
+import { InMemoryGolfHandicapIndexLookup } from "../repositories/golf-handicap-index.lookup";
 import { InMemoryGolfRoundRepository } from "../repositories/in-memory-golf-round.repository";
 
 function makeConfig(): Config {
@@ -146,14 +147,24 @@ describe("golf rounds HTTP", () => {
       startingHole: 1,
       teeName: "White",
       players: [
-        { slot: 1, displayName: "Alex", isGuest: true, userId: null },
-        { slot: 2, displayName: "Sam", isGuest: true, userId: null },
-        {
+        expect.objectContaining({
+          slot: 1,
+          displayName: "Alex",
+          isGuest: true,
+          userId: null,
+        }),
+        expect.objectContaining({
+          slot: 2,
+          displayName: "Sam",
+          isGuest: true,
+          userId: null,
+        }),
+        expect.objectContaining({
           slot: 3,
           displayName: "Riley",
           isGuest: true,
           userId: null,
-        },
+        }),
       ],
     });
 
@@ -197,6 +208,11 @@ describe("golf rounds HTTP", () => {
       displayName: "Riley",
       isGuest: false,
       userId: "user-riley",
+      handicapIndexUsed: null,
+      courseHandicap: null,
+      playingHandicap: null,
+      grossTotal: null,
+      netTotal: null,
     });
 
     const locked = await fetch(
@@ -642,5 +658,152 @@ describe("golf rounds HTTP", () => {
 
     expect(response.status).toBe(503);
     expect(await response.json()).toEqual({ error: "Unable to save golf round" });
+  });
+
+  test("create + lock snapshots WHS-style CH/PH and net when HI + ratings exist", async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+    const handicaps = new InMemoryGolfHandicapIndexLookup();
+    handicaps.seed("user-riley", 10.4);
+    app = await createApp(config, {
+      venueRepository: venues,
+      golfRoundRepository: rounds,
+      golfHandicapIndexLookup: handicaps,
+    });
+    server = await listen(app);
+
+    const created = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        courseRating: 71.2,
+        slopeRating: 129,
+        teePar: 72,
+        teeId: "tee-white",
+        players: [
+          { slot: 1, displayName: "Alex", isGuest: true, userId: null },
+          { slot: 3, displayName: "Riley", isGuest: false, userId: null },
+        ],
+      }),
+    });
+    const createdBody = (await created.json()) as {
+      id: string;
+      teeId: string;
+      courseRating: number;
+      players: {
+        userId: string | null;
+        playingHandicap: number | null;
+        courseHandicap: number | null;
+        handicapIndexUsed: number | null;
+      }[];
+    };
+
+    expect(created.status).toBe(201);
+    expect(createdBody.teeId).toBe("tee-white");
+    expect(createdBody.courseRating).toBe(71.2);
+    expect(createdBody.players.find((player) => player.userId === "user-riley")).toEqual(
+      expect.objectContaining({
+        handicapIndexUsed: 10.4,
+        courseHandicap: 11,
+        playingHandicap: 11,
+        grossTotal: null,
+        netTotal: null,
+      }),
+    );
+
+    const locked = await fetch(
+      `${server.url}/api/golf-rounds/${createdBody.id}/lock`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: sessionCookie("user-riley"),
+        },
+        body: JSON.stringify({
+          score: scoreForPlayers(
+            courseHoles9.map((hole) => hole.number),
+            [1, 3],
+            4,
+          ),
+        }),
+      },
+    );
+    const lockedBody = (await locked.json()) as {
+      handicapDisclaimer: string;
+      players: {
+        userId: string | null;
+        playingHandicap: number | null;
+        grossTotal: number | null;
+        netTotal: number | null;
+      }[];
+      score: { holes: { netStrokes?: Record<string, number> }[] };
+    };
+
+    expect(locked.status).toBe(200);
+    expect(lockedBody.handicapDisclaimer).toContain("Not official WHS certified");
+    expect(
+      lockedBody.players.find((player) => player.userId === "user-riley"),
+    ).toEqual(
+      expect.objectContaining({
+        playingHandicap: 11,
+        grossTotal: 36,
+        netTotal: 25,
+      }),
+    );
+    expect(lockedBody.score.holes[0].netStrokes).toEqual({ "3": 2 });
+  });
+
+  test("missing HI or ratings stays gross-only", async () => {
+    const created = await fetch(`${server.url}/api/golf-rounds`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: sessionCookie("user-riley"),
+      },
+      body: JSON.stringify({
+        ...createBody,
+        players: [
+          { slot: 3, displayName: "Riley", isGuest: false, userId: null },
+        ],
+      }),
+    });
+    const createdBody = (await created.json()) as {
+      id: string;
+      players: { playingHandicap: number | null }[];
+    };
+    expect(created.status).toBe(201);
+    expect(createdBody.players[0].playingHandicap).toBeNull();
+
+    const locked = await fetch(
+      `${server.url}/api/golf-rounds/${createdBody.id}/lock`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: sessionCookie("user-riley"),
+        },
+        body: JSON.stringify({
+          score: scoreForPlayers(
+            courseHoles9.map((hole) => hole.number),
+            [3],
+            4,
+          ),
+        }),
+      },
+    );
+    const lockedBody = (await locked.json()) as {
+      players: { grossTotal: number | null; netTotal: number | null }[];
+      score: { holes: { netStrokes?: Record<string, number> }[] };
+    };
+    expect(locked.status).toBe(200);
+    expect(lockedBody.players[0]).toMatchObject({
+      grossTotal: 36,
+      netTotal: null,
+    });
+    expect(lockedBody.score.holes[0].netStrokes).toBeUndefined();
   });
 });

--- a/src/modules/golf-round/entities/golf-player.ts
+++ b/src/modules/golf-round/entities/golf-player.ts
@@ -1,4 +1,8 @@
 import { DomainError, requiredTrimmed } from "../../../lib/domain-error";
+import {
+  EMPTY_PLAYER_HANDICAP,
+  PlayerHandicapSnapshot,
+} from "./handicap";
 
 export type GolfPlayerSlot = 1 | 2 | 3 | 4;
 
@@ -14,6 +18,11 @@ export type GolfPlayerSnapshot = {
   userId: string | null;
   displayName: string;
   isGuest: boolean;
+  handicapIndexUsed: number | null;
+  courseHandicap: number | null;
+  playingHandicap: number | null;
+  grossTotal: number | null;
+  netTotal: number | null;
 };
 
 export class GolfPlayer {
@@ -22,6 +31,7 @@ export class GolfPlayer {
     readonly userId: string | null,
     readonly displayName: string,
     readonly isGuest: boolean,
+    private handicapValue: PlayerHandicapSnapshot,
   ) {}
 
   static from(input: GolfPlayerInput): GolfPlayer {
@@ -40,7 +50,7 @@ export class GolfPlayer {
         );
       }
 
-      return new GolfPlayer(slot, null, displayName, true);
+      return new GolfPlayer(slot, null, displayName, true, EMPTY_PLAYER_HANDICAP);
     }
 
     if (userId === null) {
@@ -49,7 +59,7 @@ export class GolfPlayer {
       );
     }
 
-    return new GolfPlayer(slot, userId, displayName, false);
+    return new GolfPlayer(slot, userId, displayName, false, EMPTY_PLAYER_HANDICAP);
   }
 
   static fromPlayers(inputs: GolfPlayerInput[]): GolfPlayer[] {
@@ -66,8 +76,49 @@ export class GolfPlayer {
     return [...players].sort((a, b) => a.slot - b.slot);
   }
 
+  static rehydrate(snapshot: GolfPlayerSnapshot): GolfPlayer {
+    const player = GolfPlayer.from({
+      slot: snapshot.slot,
+      userId: snapshot.userId,
+      displayName: snapshot.displayName,
+      isGuest: snapshot.isGuest,
+    });
+    player.handicapValue = {
+      handicapIndexUsed: snapshot.handicapIndexUsed,
+      courseHandicap: snapshot.courseHandicap,
+      playingHandicap: snapshot.playingHandicap,
+      grossTotal: snapshot.grossTotal,
+      netTotal: snapshot.netTotal,
+    };
+    return player;
+  }
+
+  get handicap(): PlayerHandicapSnapshot {
+    return { ...this.handicapValue };
+  }
+
   hasUserId(userId: string): boolean {
     return this.userId === userId;
+  }
+
+  applyHandicap(snapshot: Pick<
+    PlayerHandicapSnapshot,
+    "handicapIndexUsed" | "courseHandicap" | "playingHandicap"
+  >): void {
+    this.handicapValue = {
+      ...this.handicapValue,
+      handicapIndexUsed: snapshot.handicapIndexUsed,
+      courseHandicap: snapshot.courseHandicap,
+      playingHandicap: snapshot.playingHandicap,
+    };
+  }
+
+  applyLockTotals(grossTotal: number, netTotal: number | null): void {
+    this.handicapValue = {
+      ...this.handicapValue,
+      grossTotal,
+      netTotal,
+    };
   }
 
   toSnapshot(): GolfPlayerSnapshot {
@@ -76,6 +127,7 @@ export class GolfPlayer {
       userId: this.userId,
       displayName: this.displayName,
       isGuest: this.isGuest,
+      ...this.handicapValue,
     };
   }
 }

--- a/src/modules/golf-round/entities/golf-round.test.ts
+++ b/src/modules/golf-round/entities/golf-round.test.ts
@@ -1,6 +1,7 @@
 import { DomainError } from "../../../lib/domain-error";
 import { CmsId } from "../../venue/entities/cms-id";
 import { GolfRound, TEE_NAME_MAX_LENGTH } from "./golf-round";
+import { GolfScore } from "./golf-score";
 import { StartsAt } from "./starts-at";
 
 const courseHoles9 = Array.from({ length: 9 }, (_, index) => ({
@@ -75,5 +76,109 @@ describe(GolfRound, () => {
     });
     expect(round.lockedByUserId).toBe("user-1");
     expect(round.hasPlayerUserId("user-1")).toBe(true);
+  });
+
+  test("create snapshots CH/PH per seated user when HI + ratings exist", () => {
+    const round = GolfRound.create({
+      ...createProps,
+      tee: {
+        teeId: "tee-white",
+        courseRating: 71.2,
+        slopeRating: 129,
+        teePar: 72,
+      },
+      handicapIndexes: new Map([["user-1", 10.4]]),
+    });
+    const snapshot = round.toSnapshot();
+    expect(snapshot.teeId).toBe("tee-white");
+    expect(snapshot.courseRating).toBe(71.2);
+    expect(snapshot.slopeRating).toBe(129);
+    expect(snapshot.teePar).toBe(72);
+    expect(snapshot.players[0]).toMatchObject({
+      userId: "user-1",
+      handicapIndexUsed: 10.4,
+      courseHandicap: 11,
+      playingHandicap: 11,
+      grossTotal: null,
+      netTotal: null,
+    });
+    expect(snapshot.players[1]).toMatchObject({
+      isGuest: true,
+      handicapIndexUsed: null,
+      courseHandicap: null,
+      playingHandicap: null,
+    });
+    expect(snapshot.handicapDisclaimer).toContain("Not official WHS certified");
+  });
+
+  test("nested tee object supplies ratings", () => {
+    const round = GolfRound.create({
+      ...createProps,
+      tee: {
+        tee: {
+          id: "white-tees",
+          courseRating: 71.2,
+          slopeRating: 129,
+          par: 72,
+        },
+      },
+      handicapIndexes: new Map([["user-1", 10.4]]),
+    });
+    expect(round.toSnapshot()).toMatchObject({
+      teeId: "white-tees",
+      courseRating: 71.2,
+      slopeRating: 129,
+      teePar: 72,
+      players: [
+        expect.objectContaining({ playingHandicap: 11 }),
+        expect.objectContaining({ playingHandicap: null }),
+      ],
+    });
+  });
+
+  test("missing HI or ratings stays gross-only and does not block create", () => {
+    const noHi = GolfRound.create({
+      ...createProps,
+      tee: { courseRating: 71.2, slopeRating: 129, teePar: 36 },
+    });
+    expect(noHi.toSnapshot().players[0].playingHandicap).toBeNull();
+
+    const noRatings = GolfRound.create({
+      ...createProps,
+      handicapIndexes: new Map([["user-1", 10.4]]),
+    });
+    expect(noRatings.toSnapshot().players[0].playingHandicap).toBeNull();
+    expect(noRatings.toSnapshot().courseRating).toBeNull();
+  });
+
+  test("lock writes gross + net and hole net strokes when SI + PH exist", () => {
+    const round = GolfRound.create({
+      ...createProps,
+      tee: { courseRating: 72, slopeRating: 113, teePar: 72 },
+      handicapIndexes: new Map([["user-1", 2]]),
+    });
+    const lockedScore = GolfScore.from(score, {
+      holeNumbers: courseHoles9.map((hole) => hole.number),
+      playerSlots: [1, 2],
+    });
+    round.lock(lockedScore, new Date("2026-09-04T12:00:00.000Z"), "user-1");
+
+    const snapshot = round.toSnapshot();
+    expect(snapshot.players[0]).toMatchObject({
+      playingHandicap: 2,
+      grossTotal: 36,
+      netTotal: 34,
+    });
+    expect(snapshot.players[1]).toMatchObject({
+      playingHandicap: null,
+      grossTotal: 45,
+      netTotal: null,
+    });
+    expect(snapshot.score?.holes[0]).toMatchObject({
+      number: 1,
+      strokes: { "1": 4, "2": 5 },
+      netStrokes: { "1": 3 },
+    });
+    expect(snapshot.score?.holes[2]?.netStrokes).toEqual({ "1": 4 });
   });
 });

--- a/src/modules/golf-round/entities/golf-round.ts
+++ b/src/modules/golf-round/entities/golf-round.ts
@@ -8,10 +8,25 @@ import {
 } from "./course-snapshot";
 import { GolfPlayer, GolfPlayerInput, GolfPlayerSnapshot } from "./golf-player";
 import { GolfRoundLockConflictError } from "./golf-round-lock-conflict-error";
-import { GolfScore, GolfScoreSnapshot } from "./golf-score";
+import { GolfScore, GolfScoreSnapshot, HoleScoreSnapshot } from "./golf-score";
+import {
+  computeCourseHandicap,
+  computePlayingHandicap,
+  computeRoundNet,
+  GOLF_HANDICAP_DISCLAIMER,
+} from "./handicap";
 import { StartsAt } from "./starts-at";
+import { TeeRatings, TeeRatingsInput, TeeRatingsSnapshot } from "./tee-ratings";
 
 export type GolfRoundStatusValue = "live" | "locked";
+
+export type ApiHoleScoreSnapshot = HoleScoreSnapshot & {
+  netStrokes?: Record<string, number>;
+};
+
+export type ApiGolfScoreSnapshot = {
+  holes: ApiHoleScoreSnapshot[];
+};
 
 export type GolfRoundSnapshot = {
   id: string;
@@ -21,10 +36,15 @@ export type GolfRoundSnapshot = {
   holesPlayed: number;
   startingHole: number;
   teeName: string | null;
+  teeId: string | null;
+  courseRating: number | null;
+  slopeRating: number | null;
+  teePar: number | null;
   course: CourseSnapshotData;
   players: GolfPlayerSnapshot[];
-  score: GolfScoreSnapshot | null;
+  score: ApiGolfScoreSnapshot | null;
   lockedAt: string | null;
+  handicapDisclaimer: string;
 };
 
 export const TEE_NAME_MAX_LENGTH = 40;
@@ -37,6 +57,8 @@ export type CreateGolfRoundProps = {
   teeName: unknown;
   course: unknown;
   players: GolfPlayerInput[];
+  tee?: TeeRatingsInput;
+  handicapIndexes?: ReadonlyMap<string, number | null>;
 };
 
 export class GolfRound {
@@ -48,6 +70,7 @@ export class GolfRound {
     readonly holesPlayed: number,
     readonly startingHole: number,
     readonly teeName: string | null,
+    readonly tee: TeeRatings,
     readonly course: CourseSnapshot,
     readonly players: readonly GolfPlayer[],
     private scoreValue: GolfScore | null,
@@ -64,6 +87,9 @@ export class GolfRound {
       startingHole,
     });
     const players = GolfPlayer.fromPlayers(props.players);
+    const holeParTotal = course.holes.reduce((sum, hole) => sum + hole.par, 0);
+    const tee = TeeRatings.from(props.tee ?? {}).withParFallback(holeParTotal);
+    applyPlayerHandicaps(players, tee, props.handicapIndexes);
 
     return new GolfRound(
       randomUUID(),
@@ -73,6 +99,7 @@ export class GolfRound {
       holesPlayed,
       startingHole,
       teeName,
+      tee,
       course,
       players,
       null,
@@ -105,6 +132,7 @@ export class GolfRound {
     holesPlayed: number;
     startingHole: number;
     teeName: string | null;
+    tee?: TeeRatings;
     course: CourseSnapshot;
     players: GolfPlayer[];
     score: GolfScore | null;
@@ -119,6 +147,7 @@ export class GolfRound {
       props.holesPlayed,
       props.startingHole,
       props.teeName,
+      props.tee ?? TeeRatings.empty(),
       props.course,
       props.players,
       props.score,
@@ -147,6 +176,22 @@ export class GolfRound {
     return this.statusValue === "locked";
   }
 
+  get teeId(): string | null {
+    return this.tee.teeId;
+  }
+
+  get courseRating(): number | null {
+    return this.tee.courseRating;
+  }
+
+  get slopeRating(): number | null {
+    return this.tee.slopeRating;
+  }
+
+  get teePar(): number | null {
+    return this.tee.teePar;
+  }
+
   playerSlots() {
     return this.players.map((player) => player.slot);
   }
@@ -172,6 +217,7 @@ export class GolfRound {
     this.scoreValue = score;
     this.lockedAtValue = lockedAt;
     this.lockedByUserIdValue = normalizeLockedByUserId(lockedByUserId);
+    this.applyLockTotals(score);
   }
 
   hasSameScore(score: GolfScore): boolean {
@@ -194,6 +240,7 @@ export class GolfRound {
   }
 
   toSnapshot(): GolfRoundSnapshot {
+    const tee = this.tee.toSnapshot();
     return {
       id: this.id,
       venueCmsId: this.venueCmsId.value,
@@ -202,11 +249,113 @@ export class GolfRound {
       holesPlayed: this.holesPlayed,
       startingHole: this.startingHole,
       teeName: this.teeName,
+      teeId: tee.teeId,
+      courseRating: tee.courseRating,
+      slopeRating: tee.slopeRating,
+      teePar: tee.teePar,
       course: this.course.toSnapshot(),
       players: this.players.map((player) => player.toSnapshot()),
-      score: this.scoreValue?.toSnapshot() ?? null,
+      score: this.scoreSnapshot(),
       lockedAt: this.lockedAtValue?.toISOString() ?? null,
+      handicapDisclaimer: GOLF_HANDICAP_DISCLAIMER,
     };
+  }
+
+  private applyLockTotals(score: GolfScore): void {
+    for (const player of this.players) {
+      const result = computeRoundNet({
+        playingHandicap: player.handicap.playingHandicap,
+        holes: score.holes.map((hole) => ({
+          number: hole.number,
+          strokeIndex: this.course.holes.find(
+            (courseHole) => courseHole.number === hole.number,
+          )?.strokeIndex,
+          gross: hole.strokes[String(player.slot)] ?? 0,
+        })),
+      });
+      player.applyLockTotals(result.grossTotal, result.netTotal);
+    }
+  }
+
+  private scoreSnapshot(): ApiGolfScoreSnapshot | null {
+    if (!this.scoreValue) {
+      return null;
+    }
+
+    const gross = this.scoreValue.toSnapshot();
+    const holeNetsBySlot = this.holeNetsBySlot(this.scoreValue);
+    if (!holeNetsBySlot) {
+      return gross;
+    }
+
+    return {
+      holes: gross.holes.map((hole) => {
+        const netStrokes = holeNetsBySlot.get(hole.number);
+        return netStrokes ? { ...hole, netStrokes } : hole;
+      }),
+    };
+  }
+
+  private holeNetsBySlot(
+    score: GolfScore,
+  ): Map<number, Record<string, number>> | null {
+    const byHole = new Map<number, Record<string, number>>();
+    let anyNet = false;
+
+    for (const player of this.players) {
+      const result = computeRoundNet({
+        playingHandicap: player.handicap.playingHandicap,
+        holes: score.holes.map((hole) => ({
+          number: hole.number,
+          strokeIndex: this.course.holes.find(
+            (courseHole) => courseHole.number === hole.number,
+          )?.strokeIndex,
+          gross: hole.strokes[String(player.slot)] ?? 0,
+        })),
+      });
+      if (!result.holeNets) {
+        continue;
+      }
+      anyNet = true;
+      for (const hole of result.holeNets) {
+        const current = byHole.get(hole.number) ?? {};
+        current[String(player.slot)] = hole.netStrokes;
+        byHole.set(hole.number, current);
+      }
+    }
+
+    return anyNet ? byHole : null;
+  }
+}
+
+function applyPlayerHandicaps(
+  players: GolfPlayer[],
+  tee: TeeRatings,
+  handicapIndexes?: ReadonlyMap<string, number | null>,
+): void {
+  if (!tee.canComputeHandicap || !handicapIndexes) {
+    return;
+  }
+
+  for (const player of players) {
+    if (!player.userId) {
+      continue;
+    }
+    const handicapIndex = handicapIndexes.get(player.userId);
+    if (handicapIndex === undefined || handicapIndex === null) {
+      continue;
+    }
+    const courseHandicap = computeCourseHandicap({
+      handicapIndex,
+      slopeRating: tee.slopeRating as number,
+      courseRating: tee.courseRating as number,
+      par: tee.teePar as number,
+    });
+    player.applyHandicap({
+      handicapIndexUsed: handicapIndex,
+      courseHandicap,
+      playingHandicap: computePlayingHandicap(courseHandicap),
+    });
   }
 }
 
@@ -243,3 +392,5 @@ export function parseRequiredTeeName(raw: unknown): string {
   }
   return value;
 }
+
+export type { GolfScoreSnapshot, TeeRatingsSnapshot };

--- a/src/modules/golf-round/entities/handicap.test.ts
+++ b/src/modules/golf-round/entities/handicap.test.ts
@@ -1,0 +1,146 @@
+import { DomainError } from "../../../lib/domain-error";
+import {
+  allocateHoleStrokes,
+  computeCourseHandicap,
+  computePlayingHandicap,
+  computeRoundNet,
+  parseGolfHandicapIndex,
+  roundHalfUp,
+} from "./handicap";
+
+describe("WHS-style handicap formula", () => {
+  test("roundHalfUp rounds .5 toward +∞", () => {
+    expect(roundHalfUp(10.5)).toBe(11);
+    expect(roundHalfUp(10.4)).toBe(10);
+    expect(roundHalfUp(0.5)).toBe(1);
+    expect(roundHalfUp(-1.5)).toBe(-1);
+    expect(roundHalfUp(-1.6)).toBe(-2);
+    expect(roundHalfUp(0)).toBe(0);
+  });
+
+  test("CH = HI × (Slope/113) + (CourseRating − Par), half up", () => {
+    expect(
+      computeCourseHandicap({
+        handicapIndex: 10.4,
+        slopeRating: 129,
+        courseRating: 71.2,
+        par: 72,
+      }),
+    ).toBe(11);
+
+    // 12.0 × (113/113) + (72 − 72) = 12.0 → 12
+    expect(
+      computeCourseHandicap({
+        handicapIndex: 12,
+        slopeRating: 113,
+        courseRating: 72,
+        par: 72,
+      }),
+    ).toBe(12);
+
+    // 10.0 × (124.3/113) + (70.5 − 72) = 11.0 − 1.5 = 9.5 → 10
+    expect(
+      computeCourseHandicap({
+        handicapIndex: 10,
+        slopeRating: 124.3 as unknown as number,
+        courseRating: 70.5,
+        par: 72,
+      }),
+    ).toBe(
+      roundHalfUp(10 * (124.3 / 113) + (70.5 - 72)),
+    );
+
+    // Exact half-up boundary: 8 × (113/113) + (72.5 − 72) = 8.5 → 9
+    expect(
+      computeCourseHandicap({
+        handicapIndex: 8,
+        slopeRating: 113,
+        courseRating: 72.5,
+        par: 72,
+      }),
+    ).toBe(9);
+
+    // Plus handicap: −2.0 × (113/113) + (72 − 72) = −2
+    expect(
+      computeCourseHandicap({
+        handicapIndex: -2,
+        slopeRating: 113,
+        courseRating: 72,
+        par: 72,
+      }),
+    ).toBe(-2);
+  });
+
+  test("Playing Handicap v1 is 100% of Course Handicap", () => {
+    expect(computePlayingHandicap(14)).toBe(14);
+    expect(computePlayingHandicap(-1)).toBe(-1);
+  });
+
+  test("parseGolfHandicapIndex accepts null and WHS-range decimals", () => {
+    expect(parseGolfHandicapIndex(null)).toBeNull();
+    expect(parseGolfHandicapIndex(undefined)).toBeNull();
+    expect(parseGolfHandicapIndex(12.4)).toBe(12.4);
+    expect(parseGolfHandicapIndex(12.44)).toBe(12.4);
+    expect(parseGolfHandicapIndex(-10)).toBe(-10);
+    expect(parseGolfHandicapIndex(54)).toBe(54);
+    expect(() => parseGolfHandicapIndex(54.1)).toThrow(DomainError);
+    expect(() => parseGolfHandicapIndex(-10.1)).toThrow(DomainError);
+    expect(() => parseGolfHandicapIndex("12")).toThrow(DomainError);
+  });
+
+  test("hole strokes go to lowest SI first; extras wrap the nine/eighteen", () => {
+    const holes = [1, 2, 3, 4, 5, 6, 7, 8, 9].map((number) => ({
+      number,
+      strokeIndex: number,
+    }));
+
+    const twelve = allocateHoleStrokes(12, holes);
+    expect(twelve.get(1)).toBe(2);
+    expect(twelve.get(2)).toBe(2);
+    expect(twelve.get(3)).toBe(2);
+    expect(twelve.get(4)).toBe(1);
+    expect(twelve.get(9)).toBe(1);
+    expect([...twelve.values()].reduce((sum, value) => sum + value, 0)).toBe(12);
+
+    const plusTwo = allocateHoleStrokes(-2, holes);
+    expect(plusTwo.get(9)).toBe(-1);
+    expect(plusTwo.get(8)).toBe(-1);
+    expect(plusTwo.get(1)).toBe(0);
+    expect([...plusTwo.values()].reduce((sum, value) => sum + value, 0)).toBe(-2);
+  });
+
+  test("round net uses hole nets when SI present, else gross − PH", () => {
+    const withSi = computeRoundNet({
+      playingHandicap: 2,
+      holes: [
+        { number: 1, strokeIndex: 1, gross: 5 },
+        { number: 2, strokeIndex: 2, gross: 4 },
+        { number: 3, strokeIndex: 3, gross: 4 },
+      ],
+    });
+    expect(withSi.grossTotal).toBe(13);
+    expect(withSi.netTotal).toBe(11);
+    expect(withSi.holeNets).toEqual([
+      { number: 1, strokesReceived: 1, netStrokes: 4 },
+      { number: 2, strokesReceived: 1, netStrokes: 3 },
+      { number: 3, strokesReceived: 0, netStrokes: 4 },
+    ]);
+
+    const withoutSi = computeRoundNet({
+      playingHandicap: 8,
+      holes: [
+        { number: 1, gross: 5 },
+        { number: 2, gross: 4 },
+      ],
+    });
+    expect(withoutSi.grossTotal).toBe(9);
+    expect(withoutSi.netTotal).toBe(1);
+    expect(withoutSi.holeNets).toBeNull();
+
+    const noPh = computeRoundNet({
+      playingHandicap: null,
+      holes: [{ number: 1, strokeIndex: 1, gross: 4 }],
+    });
+    expect(noPh).toEqual({ grossTotal: 4, netTotal: null, holeNets: null });
+  });
+});

--- a/src/modules/golf-round/entities/handicap.ts
+++ b/src/modules/golf-round/entities/handicap.ts
@@ -1,0 +1,191 @@
+import { DomainError } from "../../../lib/domain-error";
+
+/**
+ * Estimated WHS-style Course / Playing Handicap. Not official WHS certified.
+ */
+export const GOLF_HANDICAP_DISCLAIMER =
+  "Estimated WHS-style Course Handicap. Not official WHS certified.";
+
+export const GOLF_HANDICAP_INDEX_MIN = -10;
+export const GOLF_HANDICAP_INDEX_MAX = 54;
+
+export type CourseHandicapInput = {
+  handicapIndex: number;
+  slopeRating: number;
+  courseRating: number;
+  par: number;
+};
+
+export type PlayerHandicapSnapshot = {
+  handicapIndexUsed: number | null;
+  courseHandicap: number | null;
+  playingHandicap: number | null;
+  grossTotal: number | null;
+  netTotal: number | null;
+};
+
+export const EMPTY_PLAYER_HANDICAP: PlayerHandicapSnapshot = {
+  handicapIndexUsed: null,
+  courseHandicap: null,
+  playingHandicap: null,
+  grossTotal: null,
+  netTotal: null,
+};
+
+/**
+ * Round half up (towards +∞): 10.5 → 11, −1.5 → −1.
+ * WHS Course Handicap uses this rounding.
+ */
+export function roundHalfUp(value: number): number {
+  if (!Number.isFinite(value)) {
+    throw new DomainError("Cannot round a non-finite value");
+  }
+  return Math.floor(value + 0.5);
+}
+
+/**
+ * CH = HI × (Slope / 113) + (CourseRating − Par), then round half up.
+ * Playing Handicap v1 is 100%: PH = CH.
+ */
+export function computeCourseHandicap(input: CourseHandicapInput): number {
+  const raw =
+    input.handicapIndex * (input.slopeRating / 113) +
+    (input.courseRating - input.par);
+  return roundHalfUp(raw);
+}
+
+export function computePlayingHandicap(courseHandicap: number): number {
+  return courseHandicap;
+}
+
+export function parseGolfHandicapIndex(raw: unknown): number | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    throw new DomainError("golfHandicapIndex must be a number or null");
+  }
+  if (raw < GOLF_HANDICAP_INDEX_MIN || raw > GOLF_HANDICAP_INDEX_MAX) {
+    throw new DomainError(
+      `golfHandicapIndex must be between ${GOLF_HANDICAP_INDEX_MIN}.0 and ${GOLF_HANDICAP_INDEX_MAX}.0`,
+    );
+  }
+  return Math.round(raw * 10) / 10;
+}
+
+export type HoleStrokeAllocation = {
+  number: number;
+  strokeIndex: number;
+};
+
+export type HoleNetResult = {
+  number: number;
+  strokesReceived: number;
+  netStrokes: number;
+};
+
+export type RoundNetResult = {
+  grossTotal: number;
+  netTotal: number | null;
+  holeNets: HoleNetResult[] | null;
+};
+
+/**
+ * Allocate playing-handicap strokes across played holes.
+ * Hardest holes (lowest SI) receive positive strokes first; plus handicaps
+ * apply negative strokes to the easiest holes (highest SI) so
+ * sum(strokesReceived) === playingHandicap.
+ */
+export function allocateHoleStrokes(
+  playingHandicap: number,
+  holes: readonly HoleStrokeAllocation[],
+): Map<number, number> {
+  const allocated = new Map<number, number>();
+  for (const hole of holes) {
+    allocated.set(hole.number, 0);
+  }
+  if (playingHandicap === 0 || holes.length === 0) {
+    return allocated;
+  }
+
+  const count = Math.abs(playingHandicap);
+  const ordered =
+    playingHandicap > 0
+      ? [...holes].sort(compareHardestFirst)
+      : [...holes].sort(compareEasiestFirst);
+  const delta = playingHandicap > 0 ? 1 : -1;
+
+  for (let index = 0; index < count; index++) {
+    const hole = ordered[index % ordered.length];
+    allocated.set(hole.number, (allocated.get(hole.number) ?? 0) + delta);
+  }
+
+  return allocated;
+}
+
+export function computeRoundNet(input: {
+  playingHandicap: number | null;
+  holes: readonly {
+    number: number;
+    strokeIndex?: number;
+    gross: number;
+  }[];
+}): RoundNetResult {
+  const grossTotal = input.holes.reduce((sum, hole) => sum + hole.gross, 0);
+  if (input.playingHandicap === null) {
+    return { grossTotal, netTotal: null, holeNets: null };
+  }
+
+  const strokeIndexesProvided = input.holes.every(
+    (hole) =>
+      typeof hole.strokeIndex === "number" &&
+      Number.isInteger(hole.strokeIndex),
+  );
+
+  if (!strokeIndexesProvided) {
+    return {
+      grossTotal,
+      netTotal: grossTotal - input.playingHandicap,
+      holeNets: null,
+    };
+  }
+
+  const allocations = allocateHoleStrokes(
+    input.playingHandicap,
+    input.holes.map((hole) => ({
+      number: hole.number,
+      strokeIndex: hole.strokeIndex as number,
+    })),
+  );
+
+  const holeNets = input.holes.map((hole) => {
+    const strokesReceived = allocations.get(hole.number) ?? 0;
+    return {
+      number: hole.number,
+      strokesReceived,
+      netStrokes: hole.gross - strokesReceived,
+    };
+  });
+
+  return {
+    grossTotal,
+    netTotal: holeNets.reduce((sum, hole) => sum + hole.netStrokes, 0),
+    holeNets,
+  };
+}
+
+function compareHardestFirst(
+  a: HoleStrokeAllocation,
+  b: HoleStrokeAllocation,
+): number {
+  if (a.strokeIndex !== b.strokeIndex) return a.strokeIndex - b.strokeIndex;
+  return a.number - b.number;
+}
+
+function compareEasiestFirst(
+  a: HoleStrokeAllocation,
+  b: HoleStrokeAllocation,
+): number {
+  if (a.strokeIndex !== b.strokeIndex) return b.strokeIndex - a.strokeIndex;
+  return a.number - b.number;
+}

--- a/src/modules/golf-round/entities/tee-ratings.ts
+++ b/src/modules/golf-round/entities/tee-ratings.ts
@@ -1,0 +1,179 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const TEE_ID_MAX_LENGTH = 80;
+
+export type TeeRatingsSnapshot = {
+  teeId: string | null;
+  courseRating: number | null;
+  slopeRating: number | null;
+  teePar: number | null;
+};
+
+export type TeeRatingsInput = {
+  teeId?: unknown;
+  courseRating?: unknown;
+  slopeRating?: unknown;
+  teePar?: unknown;
+  tee?: unknown;
+};
+
+/**
+ * Client-supplied tee ratings (from Sanity). All fields optional — missing
+ * CR/slope/par means the round stays gross-only.
+ */
+export class TeeRatings {
+  private constructor(
+    readonly teeId: string | null,
+    readonly courseRating: number | null,
+    readonly slopeRating: number | null,
+    readonly teePar: number | null,
+  ) {}
+
+  static empty(): TeeRatings {
+    return new TeeRatings(null, null, null, null);
+  }
+
+  static from(input: TeeRatingsInput = {}): TeeRatings {
+    const nested = parseNestedTee(input.tee);
+    const teeId = parseOptionalTeeId(nested.teeId ?? input.teeId);
+    const courseRating = parseOptionalCourseRating(
+      firstDefined(nested.courseRating, input.courseRating),
+    );
+    const slopeRating = parseOptionalSlope(
+      firstDefined(nested.slopeRating, input.slopeRating),
+    );
+    const teePar = parseOptionalTeePar(
+      firstDefined(nested.teePar, nested.par, input.teePar),
+    );
+
+    return new TeeRatings(teeId, courseRating, slopeRating, teePar);
+  }
+
+  static rehydrate(snapshot: TeeRatingsSnapshot): TeeRatings {
+    return new TeeRatings(
+      snapshot.teeId,
+      snapshot.courseRating,
+      snapshot.slopeRating,
+      snapshot.teePar,
+    );
+  }
+
+  withParFallback(par: number | null): TeeRatings {
+    if (this.teePar !== null || par === null) {
+      return this;
+    }
+    return new TeeRatings(this.teeId, this.courseRating, this.slopeRating, par);
+  }
+
+  get canComputeHandicap(): boolean {
+    return (
+      this.courseRating !== null &&
+      this.slopeRating !== null &&
+      this.teePar !== null
+    );
+  }
+
+  toSnapshot(): TeeRatingsSnapshot {
+    return {
+      teeId: this.teeId,
+      courseRating: this.courseRating,
+      slopeRating: this.slopeRating,
+      teePar: this.teePar,
+    };
+  }
+}
+
+function firstDefined(...values: unknown[]): unknown {
+  for (const value of values) {
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function parseNestedTee(raw: unknown): {
+  teeId?: unknown;
+  courseRating?: unknown;
+  slopeRating?: unknown;
+  teePar?: unknown;
+  par?: unknown;
+} {
+  if (raw === undefined || raw === null) {
+    return {};
+  }
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new DomainError("tee must be an object");
+  }
+  const tee = raw as {
+    id?: unknown;
+    teeId?: unknown;
+    courseRating?: unknown;
+    slopeRating?: unknown;
+    teePar?: unknown;
+    par?: unknown;
+  };
+  return {
+    teeId: firstDefined(tee.id, tee.teeId),
+    courseRating: tee.courseRating,
+    slopeRating: tee.slopeRating,
+    teePar: tee.teePar,
+    par: tee.par,
+  };
+}
+
+function parseOptionalTeeId(raw: unknown): string | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+  if (typeof raw !== "string") {
+    throw new DomainError("teeId must be a string");
+  }
+  const value = raw.trim();
+  if (value.length === 0) {
+    return null;
+  }
+  if (value.length > TEE_ID_MAX_LENGTH) {
+    throw new DomainError(`teeId must be at most ${TEE_ID_MAX_LENGTH} characters`);
+  }
+  return value;
+}
+
+function parseOptionalCourseRating(raw: unknown): number | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+  if (typeof raw !== "number" || !Number.isFinite(raw)) {
+    throw new DomainError("courseRating must be a number");
+  }
+  if (raw < 25 || raw > 90) {
+    throw new DomainError("courseRating must be between 25 and 90");
+  }
+  return Math.round(raw * 10) / 10;
+}
+
+function parseOptionalSlope(raw: unknown): number | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+  if (typeof raw !== "number" || !Number.isInteger(raw)) {
+    throw new DomainError("slopeRating must be an integer");
+  }
+  if (raw < 55 || raw > 155) {
+    throw new DomainError("slopeRating must be an integer between 55 and 155");
+  }
+  return raw;
+}
+
+function parseOptionalTeePar(raw: unknown): number | null {
+  if (raw === undefined || raw === null) {
+    return null;
+  }
+  if (typeof raw !== "number" || !Number.isInteger(raw)) {
+    throw new DomainError("teePar must be an integer");
+  }
+  if (raw < 27 || raw > 84) {
+    throw new DomainError("teePar must be an integer between 27 and 84");
+  }
+  return raw;
+}

--- a/src/modules/golf-round/index.ts
+++ b/src/modules/golf-round/index.ts
@@ -4,7 +4,12 @@ import { PrismaClient } from "../../generated/prisma/client";
 import { OnScorecardLocked } from "../scorecards/on-scorecard-locked";
 import { VenueRepository } from "../venue/repositories/venue.repository";
 import { createGolfRoundController } from "./controllers/golf-round.controller";
+import {
+  emptyGolfHandicapIndexLookup,
+  GolfHandicapIndexLookup,
+} from "./repositories/golf-handicap-index.lookup";
 import { GolfRoundRepository } from "./repositories/golf-round.repository";
+import { PrismaGolfHandicapIndexLookup } from "./repositories/prisma-golf-handicap-index.lookup";
 import { PrismaGolfRoundRepository } from "./repositories/prisma-golf-round.repository";
 import { createGolfRoundRoutes } from "./routes/golf-round.routes";
 import { CaptureFinishedGolfRound } from "./services/capture-finished-golf-round.service";
@@ -20,6 +25,7 @@ export type CreateGolfRoundModuleParams = {
   prisma: PrismaClient;
   venueRepository: VenueRepository;
   golfRoundRepository?: GolfRoundRepository;
+  golfHandicapIndexLookup?: GolfHandicapIndexLookup;
   tryGetSessionUserId: (req: Request) => string | null;
   onScorecardLocked?: OnScorecardLocked;
 };
@@ -33,17 +39,28 @@ export function createGolfRoundModule({
   prisma,
   venueRepository,
   golfRoundRepository: golfRoundRepositoryOverride,
+  golfHandicapIndexLookup: golfHandicapIndexLookupOverride,
   tryGetSessionUserId,
   onScorecardLocked,
 }: CreateGolfRoundModuleParams): GolfRoundModule {
   const golfRoundRepository =
     golfRoundRepositoryOverride ?? new PrismaGolfRoundRepository(prisma);
+  const golfHandicapIndexLookup =
+    golfHandicapIndexLookupOverride ??
+    (golfRoundRepositoryOverride
+      ? emptyGolfHandicapIndexLookup
+      : new PrismaGolfHandicapIndexLookup(prisma));
 
   const controller = createGolfRoundController({
-    createGolfRound: new CreateGolfRound(golfRoundRepository, venueRepository),
+    createGolfRound: new CreateGolfRound(
+      golfRoundRepository,
+      venueRepository,
+      golfHandicapIndexLookup,
+    ),
     captureFinishedGolfRound: new CaptureFinishedGolfRound(
       golfRoundRepository,
       venueRepository,
+      golfHandicapIndexLookup,
     ),
     getGolfRoundById: new GetGolfRoundById(golfRoundRepository),
     lockGolfRound: new LockGolfRound(golfRoundRepository, onScorecardLocked),
@@ -69,6 +86,11 @@ export { GolfRound } from "./entities/golf-round";
 export { InMemoryGolfRoundRepository } from "./repositories/in-memory-golf-round.repository";
 export { PrismaGolfRoundRepository } from "./repositories/prisma-golf-round.repository";
 export type { GolfRoundRepository } from "./repositories/golf-round.repository";
+export type { GolfHandicapIndexLookup } from "./repositories/golf-handicap-index.lookup";
+export {
+  InMemoryGolfHandicapIndexLookup,
+  emptyGolfHandicapIndexLookup,
+} from "./repositories/golf-handicap-index.lookup";
 export { CaptureFinishedGolfRound } from "./services/capture-finished-golf-round.service";
 export { CreateGolfRound } from "./services/create-golf-round.service";
 export { GetGolfRoundById } from "./services/get-golf-round-by-id.service";

--- a/src/modules/golf-round/repositories/golf-handicap-index.lookup.ts
+++ b/src/modules/golf-round/repositories/golf-handicap-index.lookup.ts
@@ -1,0 +1,45 @@
+export interface GolfHandicapIndexLookup {
+  findByUserIds(userIds: string[]): Promise<Map<string, number | null>>;
+}
+
+export const emptyGolfHandicapIndexLookup: GolfHandicapIndexLookup = {
+  async findByUserIds(userIds: string[]) {
+    return new Map(userIds.map((userId) => [userId, null]));
+  },
+};
+
+export class InMemoryGolfHandicapIndexLookup implements GolfHandicapIndexLookup {
+  private readonly byUserId = new Map<string, number | null>();
+
+  seed(userId: string, handicapIndex: number | null): void {
+    this.byUserId.set(userId, handicapIndex);
+  }
+
+  async findByUserIds(userIds: string[]): Promise<Map<string, number | null>> {
+    const found = new Map<string, number | null>();
+    for (const userId of userIds) {
+      found.set(userId, this.byUserId.get(userId) ?? null);
+    }
+    return found;
+  }
+}
+
+export function decimalToNumber(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "toNumber" in value &&
+    typeof (value as { toNumber: unknown }).toNumber === "function"
+  ) {
+    const n = (value as { toNumber: () => number }).toNumber();
+    return Number.isFinite(n) ? n : null;
+  }
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}

--- a/src/modules/golf-round/repositories/in-memory-golf-round.repository.ts
+++ b/src/modules/golf-round/repositories/in-memory-golf-round.repository.ts
@@ -1,4 +1,5 @@
 import { CmsId } from "../../venue/entities/cms-id";
+import { GolfPlayer } from "../entities/golf-player";
 import { GolfRound } from "../entities/golf-round";
 import { GolfRoundLockConflictError } from "../entities/golf-round-lock-conflict-error";
 import { GolfRoundRepository } from "./golf-round.repository";
@@ -75,8 +76,9 @@ function clone(round: GolfRound | null): GolfRound | null {
     holesPlayed: round.holesPlayed,
     startingHole: round.startingHole,
     teeName: round.teeName,
+    tee: round.tee,
     course: round.course,
-    players: [...round.players],
+    players: snapshot.players.map((player) => GolfPlayer.rehydrate(player)),
     score: round.score,
     lockedAt: round.lockedAt,
     lockedByUserId: round.lockedByUserId,

--- a/src/modules/golf-round/repositories/prisma-golf-handicap-index.lookup.ts
+++ b/src/modules/golf-round/repositories/prisma-golf-handicap-index.lookup.ts
@@ -1,0 +1,29 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import {
+  decimalToNumber,
+  GolfHandicapIndexLookup,
+} from "./golf-handicap-index.lookup";
+
+export class PrismaGolfHandicapIndexLookup implements GolfHandicapIndexLookup {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findByUserIds(userIds: string[]): Promise<Map<string, number | null>> {
+    const found = new Map<string, number | null>();
+    const unique = [...new Set(userIds.map((id) => id.trim()).filter(Boolean))];
+    for (const userId of unique) {
+      found.set(userId, null);
+    }
+    if (unique.length === 0) {
+      return found;
+    }
+
+    const rows = await this.prisma.profile.findMany({
+      where: { userId: { in: unique } },
+      select: { userId: true, golfHandicapIndex: true },
+    });
+    for (const row of rows) {
+      found.set(row.userId, decimalToNumber(row.golfHandicapIndex));
+    }
+    return found;
+  }
+}

--- a/src/modules/golf-round/repositories/prisma-golf-round.repository.ts
+++ b/src/modules/golf-round/repositories/prisma-golf-round.repository.ts
@@ -8,6 +8,8 @@ import { GolfRoundPersistenceError } from "../entities/golf-round-persistence-er
 import { GolfRoundVenueNotFoundError } from "../entities/golf-round-venue-not-found-error";
 import { GolfScore } from "../entities/golf-score";
 import { StartsAt } from "../entities/starts-at";
+import { TeeRatings } from "../entities/tee-ratings";
+import { decimalToNumber } from "./golf-handicap-index.lookup";
 import { GolfRoundRepository } from "./golf-round.repository";
 
 type GolfRoundPlayerRow = {
@@ -15,6 +17,11 @@ type GolfRoundPlayerRow = {
   userId: string | null;
   displayName: string;
   isGuest: boolean;
+  handicapIndexUsed: unknown;
+  courseHandicap: number | null;
+  playingHandicap: number | null;
+  grossTotal: number | null;
+  netTotal: number | null;
 };
 
 type GolfRoundRow = {
@@ -25,6 +32,10 @@ type GolfRoundRow = {
   holesPlayed: number;
   startingHole: number;
   teeName: string | null;
+  teeId: string | null;
+  courseRating: unknown;
+  slopeRating: number | null;
+  teePar: number | null;
   course: Prisma.JsonValue;
   score: Prisma.JsonValue | null;
   lockedAt: Date | null;
@@ -60,16 +71,25 @@ export class PrismaGolfRoundRepository implements GolfRoundRepository {
           holesPlayed: snapshot.holesPlayed,
           startingHole: snapshot.startingHole,
           teeName: snapshot.teeName,
+          teeId: snapshot.teeId,
+          courseRating: snapshot.courseRating,
+          slopeRating: snapshot.slopeRating,
+          teePar: snapshot.teePar,
           course: snapshot.course,
           lockedAt: round.lockedAt,
           lockedByUserId: round.lockedByUserId,
-          score: snapshot.score === null ? undefined : snapshot.score,
+          score: round.score === null ? undefined : round.score.toSnapshot(),
           players: {
-            create: round.players.map((player) => ({
+            create: snapshot.players.map((player) => ({
               slot: player.slot,
               userId: player.userId,
               displayName: player.displayName,
               isGuest: player.isGuest,
+              handicapIndexUsed: player.handicapIndexUsed,
+              courseHandicap: player.courseHandicap,
+              playingHandicap: player.playingHandicap,
+              grossTotal: player.grossTotal,
+              netTotal: player.netTotal,
             })),
           },
         },
@@ -96,11 +116,25 @@ export class PrismaGolfRoundRepository implements GolfRoundRepository {
           status: "locked",
           lockedAt: round.lockedAt,
           lockedByUserId: round.lockedByUserId,
-          score: snapshot.score === null ? Prisma.JsonNull : snapshot.score,
+          score:
+            round.score === null ? Prisma.JsonNull : round.score.toSnapshot(),
         },
       });
 
       if (updated.count === 1) {
+        await this.prisma.$transaction(
+          snapshot.players.map((player) =>
+            this.prisma.golfRoundPlayer.update({
+              where: {
+                roundId_slot: { roundId: round.id, slot: player.slot },
+              },
+              data: {
+                grossTotal: player.grossTotal,
+                netTotal: player.netTotal,
+              },
+            }),
+          ),
+        );
         const locked = await this.findById(round.id);
         if (!locked) {
           throw new GolfRoundPersistenceError("Unable to load golf round");
@@ -184,14 +218,21 @@ export class PrismaGolfRoundRepository implements GolfRoundRepository {
 }
 
 function toDomain(row: GolfRoundRow): GolfRound {
-  const players = GolfPlayer.fromPlayers(
-    row.players.map((player) => ({
-      slot: player.slot,
-      userId: player.userId,
-      displayName: player.displayName,
-      isGuest: player.isGuest,
-    })),
-  );
+  const players = row.players
+    .map((player) =>
+      GolfPlayer.rehydrate({
+        slot: player.slot as 1 | 2 | 3 | 4,
+        userId: player.userId,
+        displayName: player.displayName,
+        isGuest: player.isGuest,
+        handicapIndexUsed: decimalToNumber(player.handicapIndexUsed),
+        courseHandicap: player.courseHandicap,
+        playingHandicap: player.playingHandicap,
+        grossTotal: player.grossTotal,
+        netTotal: player.netTotal,
+      }),
+    )
+    .sort((a, b) => a.slot - b.slot);
   const course = CourseSnapshot.from(row.course, {
     holesPlayed: row.holesPlayed,
     startingHole: row.startingHole,
@@ -205,6 +246,12 @@ function toDomain(row: GolfRoundRow): GolfRound {
     holesPlayed: row.holesPlayed,
     startingHole: row.startingHole,
     teeName: row.teeName,
+    tee: TeeRatings.rehydrate({
+      teeId: row.teeId,
+      courseRating: decimalToNumber(row.courseRating),
+      slopeRating: row.slopeRating,
+      teePar: row.teePar,
+    }),
     course,
     players,
     score: row.score

--- a/src/modules/golf-round/services/capture-finished-golf-round.service.ts
+++ b/src/modules/golf-round/services/capture-finished-golf-round.service.ts
@@ -3,8 +3,14 @@ import { VenueRepository } from "../../venue/repositories/venue.repository";
 import { GolfPlayerInput } from "../entities/golf-player";
 import { GolfRound } from "../entities/golf-round";
 import { GolfRoundVenueNotFoundError } from "../entities/golf-round-venue-not-found-error";
+import { TeeRatingsInput } from "../entities/tee-ratings";
 import { StartsAt } from "../entities/starts-at";
+import {
+  emptyGolfHandicapIndexLookup,
+  GolfHandicapIndexLookup,
+} from "../repositories/golf-handicap-index.lookup";
 import { GolfRoundRepository } from "../repositories/golf-round.repository";
+import { loadHandicapIndexes } from "./create-golf-round.service";
 
 export type CaptureFinishedGolfRoundInput = {
   venueCmsId: string;
@@ -16,12 +22,13 @@ export type CaptureFinishedGolfRoundInput = {
   players: GolfPlayerInput[];
   score: unknown;
   lockedByUserId: string;
-};
+} & TeeRatingsInput;
 
 export class CaptureFinishedGolfRound {
   constructor(
     private readonly rounds: GolfRoundRepository,
     private readonly venues: VenueRepository,
+    private readonly handicaps: GolfHandicapIndexLookup = emptyGolfHandicapIndexLookup,
   ) {}
 
   async execute(input: CaptureFinishedGolfRoundInput): Promise<GolfRound> {
@@ -30,6 +37,11 @@ export class CaptureFinishedGolfRound {
     if (!venue) {
       throw new GolfRoundVenueNotFoundError();
     }
+
+    const handicapIndexes = await loadHandicapIndexes(
+      this.handicaps,
+      input.players,
+    );
 
     const round = GolfRound.captureFinished({
       venueCmsId,
@@ -40,6 +52,8 @@ export class CaptureFinishedGolfRound {
       teeName: input.teeName,
       course: input.course,
       players: input.players,
+      tee: input,
+      handicapIndexes,
       score: input.score,
       lockedByUserId: input.lockedByUserId,
     });

--- a/src/modules/golf-round/services/create-golf-round.service.ts
+++ b/src/modules/golf-round/services/create-golf-round.service.ts
@@ -3,7 +3,12 @@ import { VenueRepository } from "../../venue/repositories/venue.repository";
 import { GolfPlayerInput } from "../entities/golf-player";
 import { GolfRound } from "../entities/golf-round";
 import { GolfRoundVenueNotFoundError } from "../entities/golf-round-venue-not-found-error";
+import { TeeRatingsInput } from "../entities/tee-ratings";
 import { StartsAt } from "../entities/starts-at";
+import {
+  emptyGolfHandicapIndexLookup,
+  GolfHandicapIndexLookup,
+} from "../repositories/golf-handicap-index.lookup";
 import { GolfRoundRepository } from "../repositories/golf-round.repository";
 
 export type CreateGolfRoundInput = {
@@ -14,12 +19,13 @@ export type CreateGolfRoundInput = {
   teeName: unknown;
   course: unknown;
   players: GolfPlayerInput[];
-};
+} & TeeRatingsInput;
 
 export class CreateGolfRound {
   constructor(
     private readonly rounds: GolfRoundRepository,
     private readonly venues: VenueRepository,
+    private readonly handicaps: GolfHandicapIndexLookup = emptyGolfHandicapIndexLookup,
   ) {}
 
   async execute(input: CreateGolfRoundInput): Promise<GolfRound> {
@@ -28,6 +34,11 @@ export class CreateGolfRound {
     if (!venue) {
       throw new GolfRoundVenueNotFoundError();
     }
+
+    const handicapIndexes = await loadHandicapIndexes(
+      this.handicaps,
+      input.players,
+    );
 
     const round = GolfRound.create({
       venueCmsId,
@@ -38,8 +49,36 @@ export class CreateGolfRound {
       teeName: input.teeName,
       course: input.course,
       players: input.players,
+      tee: input,
+      handicapIndexes,
     });
 
     return this.rounds.create(round);
   }
+}
+
+export async function loadHandicapIndexes(
+  lookup: GolfHandicapIndexLookup,
+  players: GolfPlayerInput[],
+): Promise<Map<string, number | null>> {
+  try {
+    return await lookup.findByUserIds(seatedUserIds(players));
+  } catch {
+    // Missing HI / profile store must never block a round.
+    return new Map();
+  }
+}
+
+export function seatedUserIds(players: GolfPlayerInput[]): string[] {
+  const ids: string[] = [];
+  for (const player of players) {
+    if (player.isGuest === true || typeof player.userId !== "string") {
+      continue;
+    }
+    const userId = player.userId.trim();
+    if (userId.length > 0) {
+      ids.push(userId);
+    }
+  }
+  return ids;
 }

--- a/src/modules/golf-round/services/golf-round-history-item.ts
+++ b/src/modules/golf-round/services/golf-round-history-item.ts
@@ -1,7 +1,7 @@
 import { GolfRoundSnapshot } from "../entities/golf-round";
 import { GolfPlayerSnapshot } from "../entities/golf-player";
 import { CourseSnapshotData } from "../entities/course-snapshot";
-import { GolfScoreSnapshot } from "../entities/golf-score";
+import { ApiGolfScoreSnapshot } from "../entities/golf-round";
 
 export type GolfRoundHistoryItem = {
   id: string;
@@ -12,9 +12,14 @@ export type GolfRoundHistoryItem = {
   holesPlayed: number;
   startingHole: number;
   teeName: string | null;
+  teeId: string | null;
+  courseRating: number | null;
+  slopeRating: number | null;
+  teePar: number | null;
   course: CourseSnapshotData;
   players: GolfPlayerSnapshot[];
-  score: GolfScoreSnapshot | null;
+  score: ApiGolfScoreSnapshot | null;
+  handicapDisclaimer: string;
 };
 
 export function toHistoryItem(
@@ -30,8 +35,13 @@ export function toHistoryItem(
     holesPlayed: snapshot.holesPlayed,
     startingHole: snapshot.startingHole,
     teeName: snapshot.teeName,
+    teeId: snapshot.teeId,
+    courseRating: snapshot.courseRating,
+    slopeRating: snapshot.slopeRating,
+    teePar: snapshot.teePar,
     course: snapshot.course,
     players: snapshot.players,
     score: snapshot.score,
+    handicapDisclaimer: snapshot.handicapDisclaimer,
   };
 }

--- a/src/modules/golf-tours/index.ts
+++ b/src/modules/golf-tours/index.ts
@@ -7,6 +7,7 @@ import {
 
 import { PrismaClient } from "../../generated/prisma/client";
 import { GolfRoundRepository } from "../golf-round/repositories/golf-round.repository";
+import { PrismaGolfHandicapIndexLookup } from "../golf-round/repositories/prisma-golf-handicap-index.lookup";
 import { CreateGolfRound } from "../golf-round/services/create-golf-round.service";
 import { GetGolfRoundById } from "../golf-round/services/get-golf-round-by-id.service";
 import { VenueRepository } from "../venue/repositories/venue.repository";
@@ -80,7 +81,11 @@ export function createGolfToursModule({
     updateFourball: new UpdateGolfTourFourball(golfTourRepository),
     startFourball: new StartGolfTourFourball(
       golfTourRepository,
-      new CreateGolfRound(golfRoundRepository, venueRepository),
+      new CreateGolfRound(
+        golfRoundRepository,
+        venueRepository,
+        new PrismaGolfHandicapIndexLookup(prisma),
+      ),
     ),
     getLeaderboard: new GetGolfTourLeaderboard(
       golfTourRepository,

--- a/src/modules/identity/controllers/identity.controller.ts
+++ b/src/modules/identity/controllers/identity.controller.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from "express";
+import { z } from "zod";
 
+import { DomainError } from "../../../lib/domain-error";
 import { IdentityConfig } from "../config";
 import { AuthService } from "../services/auth.service";
 import {
@@ -8,6 +10,12 @@ import {
 } from "../utils/cookie";
 import { makeAuthenticationTokenParser } from "../utils/jwt";
 import { resolvePostAuthRedirect } from "../utils/post-auth-redirect";
+
+const patchProfileBodySchema = z
+  .object({
+    golfHandicapIndex: z.union([z.number(), z.null()]),
+  })
+  .strict();
 
 export type IdentityControllerDeps = {
   config: IdentityConfig;
@@ -57,6 +65,35 @@ export class IdentityController {
     }
 
     res.status(200).json(user);
+  }
+
+  async getProfile(req: Request, res: Response): Promise<void> {
+    await this.me(req, res);
+  }
+
+  async patchProfile(req: Request, res: Response): Promise<void> {
+    try {
+      const { userId } = this.parseAuthenticationToken(req.cookies.token);
+      const body = z.parse(patchProfileBodySchema, req.body ?? {});
+      const user = await this.authService.updateMeProfile(userId, body);
+
+      if (!user) {
+        res.status(401).json({ error: "Unauthorized" });
+        return;
+      }
+
+      res.status(200).json(user);
+    } catch (error) {
+      if (error instanceof DomainError) {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      if (error instanceof z.ZodError) {
+        res.status(400).json({ error: "Invalid profile payload" });
+        return;
+      }
+      throw error;
+    }
   }
 
   async logout(_req: Request, res: Response): Promise<void> {

--- a/src/modules/identity/repositories/profile.repository.ts
+++ b/src/modules/identity/repositories/profile.repository.ts
@@ -43,6 +43,13 @@ export class ProfileRepository {
     });
   }
 
+  async updateGolfHandicapIndex(userId: string, golfHandicapIndex: number | null) {
+    return this.prisma.profile.update({
+      where: { userId },
+      data: { golfHandicapIndex },
+    });
+  }
+
   async isHandleTaken(handle: string, excludeUserId?: string) {
     const existing = await this.prisma.profile.findUnique({
       where: { handle },

--- a/src/modules/identity/routes/identity.routes.ts
+++ b/src/modules/identity/routes/identity.routes.ts
@@ -23,6 +23,18 @@ export function createIdentityRoutes(
     void controller.me(req, res);
   });
 
+  router.patch("/api/auth/me", authorizationMiddleware, (req, res) => {
+    void controller.patchProfile(req, res);
+  });
+
+  router.get("/api/me/profile", authorizationMiddleware, (req, res) => {
+    void controller.getProfile(req, res);
+  });
+
+  router.patch("/api/me/profile", authorizationMiddleware, (req, res) => {
+    void controller.patchProfile(req, res);
+  });
+
   router.post("/api/auth/logout", authorizationMiddleware, (req, res) => {
     void controller.logout(req, res);
   });

--- a/src/modules/identity/services/auth.service.test.ts
+++ b/src/modules/identity/services/auth.service.test.ts
@@ -24,6 +24,15 @@ describe("AuthService.getMeUser", () => {
       })),
       getProfileByUserId: jest.fn(),
       isHandleTaken: jest.fn(),
+      updateGolfHandicapIndex: jest.fn(async (_userId: string, golfHandicapIndex: number | null) => ({
+        userId: "user-1",
+        firstName: "Alex",
+        lastName: "Johnson",
+        email: "alex@example.com",
+        handle: "alexj",
+        avatarUrl: null,
+        golfHandicapIndex,
+      })),
     };
 
     const service = new AuthService({
@@ -47,6 +56,7 @@ describe("AuthService.getMeUser", () => {
         email: "alex@example.com",
         handle: "alexj",
         avatarUrl: "https://example.com/a.png",
+        golfHandicapIndex: 12.4,
       },
     });
 
@@ -57,6 +67,7 @@ describe("AuthService.getMeUser", () => {
       email: "alex@example.com",
       handle: "alexj",
       avatarUrl: "https://example.com/a.png",
+      golfHandicapIndex: 12.4,
     });
   });
 
@@ -72,5 +83,30 @@ describe("AuthService.getMeUser", () => {
     expect(profileRepository.createProfile).toHaveBeenCalled();
     expect(me?.handle).toBe("alexj");
     expect(me?.id).toBe("user-1");
+    expect(me?.golfHandicapIndex).toBeNull();
+  });
+
+  test("updateMeProfile writes golfHandicapIndex", async () => {
+    const { service, profileRepository } = makeService({
+      id: "user-1",
+      profile: {
+        firstName: "Alex",
+        lastName: "Johnson",
+        email: "alex@example.com",
+        handle: "alexj",
+        avatarUrl: null,
+        golfHandicapIndex: null,
+      },
+    });
+
+    const updated = await service.updateMeProfile("user-1", {
+      golfHandicapIndex: 8.2,
+    });
+
+    expect(profileRepository.updateGolfHandicapIndex).toHaveBeenCalledWith(
+      "user-1",
+      8.2,
+    );
+    expect(updated?.golfHandicapIndex).toBe(8.2);
   });
 });

--- a/src/modules/identity/services/auth.service.ts
+++ b/src/modules/identity/services/auth.service.ts
@@ -1,4 +1,6 @@
 import { GoogleOauthService, GoogleUserService } from "../../google-oauth";
+import { parseGolfHandicapIndex } from "../../golf-round/entities/handicap";
+import { decimalToNumber } from "../../golf-round/repositories/golf-handicap-index.lookup";
 import { IdentityConfig } from "../config";
 import { AccountRepository } from "../repositories/account.repository";
 import { PlayerRepository } from "../repositories/player.repository";
@@ -21,6 +23,7 @@ export type AuthMeUser = {
   email: string;
   handle: string;
   avatarUrl: string | null;
+  golfHandicapIndex: number | null;
 };
 
 type GoogleUserInfo = {
@@ -152,6 +155,24 @@ export class AuthService {
       email: profile.email || "",
       handle: profile.handle,
       avatarUrl: profile.avatarUrl ?? null,
+      golfHandicapIndex: decimalToNumber(profile.golfHandicapIndex),
     };
+  }
+
+  async updateMeProfile(
+    userId: string,
+    patch: { golfHandicapIndex: unknown },
+  ): Promise<AuthMeUser | null> {
+    const existing = await this.getMeUser(userId);
+    if (!existing) {
+      return null;
+    }
+
+    const golfHandicapIndex = parseGolfHandicapIndex(patch.golfHandicapIndex);
+    await this.profileRepository.updateGolfHandicapIndex(
+      userId,
+      golfHandicapIndex,
+    );
+    return { ...existing, golfHandicapIndex };
   }
 }

--- a/src/modules/organised-games/index.ts
+++ b/src/modules/organised-games/index.ts
@@ -11,6 +11,7 @@ import {
   FriendshipRepository,
 } from "../friends/repositories/friendship.repository";
 import { GolfRoundRepository } from "../golf-round/repositories/golf-round.repository";
+import { PrismaGolfHandicapIndexLookup } from "../golf-round/repositories/prisma-golf-handicap-index.lookup";
 import { CreateGolfRound } from "../golf-round/services/create-golf-round.service";
 import { MatchRepository } from "../match/repositories/match.repository";
 import { CreateMatch } from "../match/services/create-match.service";
@@ -114,7 +115,11 @@ export function createOrganisedGamesModule({
       organisedGameRepository,
       friendProfileLookup,
       new CreateMatch(matchRepository, venueRepository),
-      new CreateGolfRound(golfRoundRepository, venueRepository),
+      new CreateGolfRound(
+        golfRoundRepository,
+        venueRepository,
+        new PrismaGolfHandicapIndexLookup(prisma),
+      ),
     ),
     tryGetSessionUserId,
   });

--- a/src/modules/team-matches/index.ts
+++ b/src/modules/team-matches/index.ts
@@ -11,6 +11,7 @@ import { CreateDartsMatch } from "../darts/services/create-darts-match.service";
 import { GetDartsMatchById } from "../darts/services/get-darts-match-by-id.service";
 import { FriendProfileLookup } from "../friends/repositories/friendship.repository";
 import { GolfRoundRepository } from "../golf-round/repositories/golf-round.repository";
+import { PrismaGolfHandicapIndexLookup } from "../golf-round/repositories/prisma-golf-handicap-index.lookup";
 import { CreateGolfRound } from "../golf-round/services/create-golf-round.service";
 import { GetGolfRoundById } from "../golf-round/services/get-golf-round-by-id.service";
 import { MatchRepository } from "../match/repositories/match.repository";
@@ -120,7 +121,11 @@ export function createTeamMatchesModule({
       friendProfileLookup,
       venueRepository,
       new CreateMatch(matchRepository, venueRepository),
-      new CreateGolfRound(golfRoundRepository, venueRepository),
+      new CreateGolfRound(
+        golfRoundRepository,
+        venueRepository,
+        new PrismaGolfHandicapIndexLookup(prisma),
+      ),
       new CreateDartsMatch(dartsMatchRepository, venueRepository),
     ),
     cancelTeamMatch: new CancelTeamMatch(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #58.

Estimated WHS-style Course / Playing Handicap on golf rounds. **Not official WHS certified.** Missing Handicap Index or missing tee ratings never blocks play (gross-only).

## Formula (v1)

```
CH = HI × (Slope / 113) + (CourseRating − Par)   // round half up
PH = CH                                          // 100%
```

- Stroke indexes present → hole nets (hardest SI first; extras wrap). Round net = sum of hole nets.
- Stroke indexes missing → no per-hole nets; round net = `gross − PH`.

## Migration

`20260909200000_golf_handicap`

Adds `Profile.golfHandicapIndex` and snapshot columns on `GolfRound` / `GolfRoundPlayer`.

## Frontend contract

### Profile

| Method | Path | Body | Response |
| --- | --- | --- | --- |
| `GET` | `/api/auth/me` | — | Existing identity fields **plus** `golfHandicapIndex: number \| null` |
| `PATCH` | `/api/auth/me` | `{ golfHandicapIndex: number \| null }` | Same document as GET |
| `GET` | `/api/me/profile` | — | Same document as `/api/auth/me` |
| `PATCH` | `/api/me/profile` | `{ golfHandicapIndex: number \| null }` | Same document as GET |

- Range: **−10.0 … 54.0**, stored to 1 decimal. `null` clears.
- Auth cookie required (same as `/api/auth/me`).

### Golf round create / capture

`POST /api/golf-rounds` and `POST /api/golf-rounds/capture` accept optional Sanity tee ratings as **top-level fields or nested `tee`**:

```json
{
  "teeName": "White",
  "teeId": "tee-white",
  "courseRating": 71.2,
  "slopeRating": 129,
  "teePar": 72,
  "tee": {
    "id": "tee-white",
    "courseRating": 71.2,
    "slopeRating": 129,
    "par": 72
  }
}
```

Nested `tee` wins when both are sent. If `teePar` / `par` is omitted, the API sums `course.holes[].par`. Slope 55–155 integer; course rating 25–90 (9- or 18-hole).

Server looks up HI for each **seated `userId`** and computes CH/PH. Guests / no HI / no CR+slope → gross-only.

### Snapshot fields (create, GET, lock, capture, history)

| Field | Where |
| --- | --- |
| `teeName`, `teeId`, `courseRating`, `slopeRating`, `teePar` | round |
| `handicapDisclaimer` | round (always) |
| `players[].handicapIndexUsed`, `courseHandicap`, `playingHandicap` | player (when HI + ratings present) |
| `players[].grossTotal`, `netTotal` | player after lock/capture (`netTotal` only when PH was snapshotted) |
| `score.holes[].strokes` | gross (unchanged) |
| `score.holes[].netStrokes` | lock/capture, when PH **and** stroke indexes exist |

HI/CH/PH are snapshotted at create/capture and are **not** recalculated from the live profile on lock.

`handicapDisclaimer`: `"Estimated WHS-style Course Handicap. Not official WHS certified."`

## Out of scope

Scramble / best ball, tour camps, Sanity content, Frontend UI.

## Docs

See `src/modules/golf-round/README.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bbd6616-bea4-4d0e-a4e4-4e7c92636449?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bbd6616-bea4-4d0e-a4e4-4e7c92636449&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

