### PR TITLE
feat: Venue leaderboards v1 (#61)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:coverage": "jest --coverage",
     "prisma:deploy": "prisma migrate deploy",
     "roadmap:seed": "ts-node src/modules/roadmap/cli/seed.ts",
-    "roadmap:ship": "ts-node src/modules/roadmap/cli/ship.ts"
+    "roadmap:ship": "ts-node src/modules/roadmap/cli/ship.ts",
+    "leaderboards:reconcile": "ts-node src/modules/venue-leaderboards/cli/reconcile.ts"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.2.0",

--- a/prisma/migrations/20260912120000_venue_leaderboard/migration.sql
+++ b/prisma/migrations/20260912120000_venue_leaderboard/migration.sql
@@ -1,0 +1,57 @@
+-- Venue leaderboards v1: Profile opt-out + durable event facts + board snapshots.
+
+ALTER TABLE "Profile" ADD COLUMN "appearOnVenueLeaderboards" BOOLEAN NOT NULL DEFAULT true;
+
+CREATE TYPE "VenueLeaderboardSport" AS ENUM ('padel', 'golf', 'darts');
+CREATE TYPE "VenueLeaderboardBoard" AS ENUM ('records', 'potm', 'grinder', 'streak');
+
+CREATE TABLE "VenueLeaderboardEventFact" (
+    "id" TEXT NOT NULL,
+    "venueCmsId" TEXT NOT NULL,
+    "sport" "VenueLeaderboardSport" NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "lockedAt" TIMESTAMP(3) NOT NULL,
+    "won" BOOLEAN,
+    "golfGross" INTEGER,
+    "golfNet" INTEGER,
+    "golfTeeId" TEXT,
+    "golfTeeName" TEXT,
+    "golfHolesPlayed" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "VenueLeaderboardEventFact_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "VenueLeaderboardSnapshot" (
+    "id" TEXT NOT NULL,
+    "venueCmsId" TEXT NOT NULL,
+    "board" "VenueLeaderboardBoard" NOT NULL,
+    "windowKey" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "computedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "VenueLeaderboardSnapshot_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "VenueLeaderboardEventFact_venueCmsId_sport_eventId_userId_key"
+    ON "VenueLeaderboardEventFact"("venueCmsId", "sport", "eventId", "userId");
+CREATE INDEX "VenueLeaderboardEventFact_venueCmsId_sport_idx"
+    ON "VenueLeaderboardEventFact"("venueCmsId", "sport");
+CREATE INDEX "VenueLeaderboardEventFact_userId_idx"
+    ON "VenueLeaderboardEventFact"("userId");
+CREATE INDEX "VenueLeaderboardEventFact_venueCmsId_lockedAt_idx"
+    ON "VenueLeaderboardEventFact"("venueCmsId", "lockedAt");
+
+CREATE UNIQUE INDEX "VenueLeaderboardSnapshot_venueCmsId_board_windowKey_key"
+    ON "VenueLeaderboardSnapshot"("venueCmsId", "board", "windowKey");
+CREATE INDEX "VenueLeaderboardSnapshot_venueCmsId_idx"
+    ON "VenueLeaderboardSnapshot"("venueCmsId");
+
+ALTER TABLE "VenueLeaderboardEventFact"
+    ADD CONSTRAINT "VenueLeaderboardEventFact_venueCmsId_fkey"
+    FOREIGN KEY ("venueCmsId") REFERENCES "Venue"("cmsId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "VenueLeaderboardSnapshot"
+    ADD CONSTRAINT "VenueLeaderboardSnapshot_venueCmsId_fkey"
+    FOREIGN KEY ("venueCmsId") REFERENCES "Venue"("cmsId") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model Profile {
   onboardingCompletedAt  DateTime?
   onboardingSkippedAt    DateTime?
   golfHandicapIndex      Decimal?  @db.Decimal(4, 1)
+  appearOnVenueLeaderboards Boolean @default(true)
 
   user User @relation(fields: [userId], references: [id])
 }
@@ -70,8 +71,10 @@ model Venue {
   golfRounds      GolfRound[]
   dartsMatches    DartsMatch[]
   follows         VenueFollow[]
-  organisedGames  OrganisedGame[]
-  golfTourRounds  GolfTourRound[]
+  organisedGames         OrganisedGame[]
+  golfTourRounds         GolfTourRound[]
+  leaderboardFacts       VenueLeaderboardEventFact[]
+  leaderboardSnapshots   VenueLeaderboardSnapshot[]
 }
 
 model VenueFollow {
@@ -1085,4 +1088,55 @@ model GolfTourFourballPlayer {
   @@unique([fourballId, slot])
   @@index([userId])
   @@index([fourballId])
+}
+
+enum VenueLeaderboardSport {
+  padel
+  golf
+  darts
+}
+
+enum VenueLeaderboardBoard {
+  records
+  potm
+  grinder
+  streak
+}
+
+// One signed-in player × locked event at a venue. Lock hooks upsert; nightly
+// reconcile rebuilds from locked padel / golf / darts scorecards.
+model VenueLeaderboardEventFact {
+  id              String                @id @default(uuid())
+  venueCmsId      String
+  venue           Venue                 @relation(fields: [venueCmsId], references: [cmsId])
+  sport           VenueLeaderboardSport
+  eventId         String
+  userId          String
+  lockedAt        DateTime
+  won             Boolean?
+  golfGross       Int?
+  golfNet         Int?
+  golfTeeId       String?
+  golfTeeName     String?
+  golfHolesPlayed Int?
+  createdAt       DateTime              @default(now())
+
+  @@unique([venueCmsId, sport, eventId, userId])
+  @@index([venueCmsId, sport])
+  @@index([userId])
+  @@index([venueCmsId, lockedAt])
+}
+
+// Computed board payload for a venue + board + window (YYYY-MM or "all").
+model VenueLeaderboardSnapshot {
+  id         String                @id @default(uuid())
+  venueCmsId String
+  venue      Venue                 @relation(fields: [venueCmsId], references: [cmsId])
+  board      VenueLeaderboardBoard
+  windowKey  String
+  payload    Json
+  computedAt DateTime
+
+  @@unique([venueCmsId, board, windowKey])
+  @@index([venueCmsId])
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -101,6 +101,10 @@ import {
   createOpenF1Module,
   OpenF1Client,
 } from "./modules/openf1";
+import {
+  createVenueLeaderboardsModule,
+  VenueLeaderboardRepository,
+} from "./modules/venue-leaderboards";
 
 export type CreateAppDependencies = {
   venueRepository?: VenueRepository;
@@ -130,6 +134,7 @@ export type CreateAppDependencies = {
   lobbyRepository?: LobbyRepository;
   golfTourRepository?: GolfTourRepository;
   openF1Client?: OpenF1Client;
+  venueLeaderboardRepository?: VenueLeaderboardRepository;
 };
 
 export async function createApp(
@@ -185,9 +190,12 @@ export async function createApp(
   const lockFourballOnScorecardLock = new LockGolfTourFourballOnScorecardLock(
     golfTourRepository,
   );
+  let ingestVenueLeaderboard: (event: ScorecardLockedEvent) => Promise<void> =
+    async () => {};
   const onScorecardLocked = async (event: ScorecardLockedEvent) => {
     await completeOnLock.execute(event);
     await lockFourballOnScorecardLock.execute(event);
+    await ingestVenueLeaderboard(event);
   };
 
   const match = createMatchModule({
@@ -348,6 +356,20 @@ export async function createApp(
     config,
     openF1Client: dependencies.openF1Client,
   });
+  const venueLeaderboards = createVenueLeaderboardsModule({
+    prisma,
+    venueRepository: venue.venueRepository,
+    matchRepository: match.matchRepository,
+    golfRoundRepository: golfRound.golfRoundRepository,
+    dartsMatchRepository: darts.dartsMatchRepository,
+    venueLeaderboardRepository: dependencies.venueLeaderboardRepository,
+    useInMemoryLeaderboards: Boolean(
+      dependencies.venueRepository || dependencies.venueLeaderboardRepository,
+    ),
+    tryGetSessionUserId: identity.tryGetSessionUserId,
+    requireAuth: identity.authorizationMiddleware,
+  });
+  ingestVenueLeaderboard = venueLeaderboards.onScorecardLocked;
 
   app.use(identity.router);
   app.use(venue.router);
@@ -371,6 +393,7 @@ export async function createApp(
   app.use(lobby.router);
   app.use(golfTours.router);
   app.use(openF1.router);
+  app.use(venueLeaderboards.router);
 
   app.use(
     (

--- a/src/modules/darts/index.ts
+++ b/src/modules/darts/index.ts
@@ -47,6 +47,7 @@ export function createDartsModule({
     captureFinishedDartsMatch: new CaptureFinishedDartsMatch(
       dartsMatchRepository,
       venueRepository,
+      onScorecardLocked,
     ),
     getDartsMatchById: new GetDartsMatchById(dartsMatchRepository),
     submitDartsTurn: new SubmitDartsTurn(

--- a/src/modules/darts/services/capture-finished-darts-match.service.ts
+++ b/src/modules/darts/services/capture-finished-darts-match.service.ts
@@ -1,3 +1,4 @@
+import { OnScorecardLocked } from "../../scorecards/on-scorecard-locked";
 import { VenueRepository } from "../../venue/repositories/venue.repository";
 import { DartsMatch } from "../entities/darts-match";
 import { DartsMatchVenueNotFoundError } from "../entities/darts-match-venue-not-found-error";
@@ -22,6 +23,7 @@ export class CaptureFinishedDartsMatch {
   constructor(
     private readonly matches: DartsMatchRepository,
     private readonly venues: VenueRepository,
+    private readonly onScorecardLocked?: OnScorecardLocked,
   ) {}
 
   async execute(input: CaptureFinishedDartsMatchInput): Promise<DartsMatch> {
@@ -44,6 +46,14 @@ export class CaptureFinishedDartsMatch {
       lockedByUserId: input.lockedByUserId,
     });
 
-    return this.matches.create(match);
+    const persisted = await this.matches.create(match);
+    if (persisted.isLocked && this.onScorecardLocked) {
+      await this.onScorecardLocked({
+        sport: "darts",
+        scorecardId: persisted.id,
+        dartsWinnerUserId: persisted.toSnapshot().winnerUserId,
+      });
+    }
+    return persisted;
   }
 }

--- a/src/modules/golf-round/index.ts
+++ b/src/modules/golf-round/index.ts
@@ -61,6 +61,7 @@ export function createGolfRoundModule({
       golfRoundRepository,
       venueRepository,
       golfHandicapIndexLookup,
+      onScorecardLocked,
     ),
     getGolfRoundById: new GetGolfRoundById(golfRoundRepository),
     lockGolfRound: new LockGolfRound(golfRoundRepository, onScorecardLocked),

--- a/src/modules/golf-round/services/capture-finished-golf-round.service.ts
+++ b/src/modules/golf-round/services/capture-finished-golf-round.service.ts
@@ -1,3 +1,4 @@
+import { OnScorecardLocked } from "../../scorecards/on-scorecard-locked";
 import { CmsId } from "../../venue/entities/cms-id";
 import { VenueRepository } from "../../venue/repositories/venue.repository";
 import { GolfPlayerInput } from "../entities/golf-player";
@@ -29,6 +30,7 @@ export class CaptureFinishedGolfRound {
     private readonly rounds: GolfRoundRepository,
     private readonly venues: VenueRepository,
     private readonly handicaps: GolfHandicapIndexLookup = emptyGolfHandicapIndexLookup,
+    private readonly onScorecardLocked?: OnScorecardLocked,
   ) {}
 
   async execute(input: CaptureFinishedGolfRoundInput): Promise<GolfRound> {
@@ -58,6 +60,20 @@ export class CaptureFinishedGolfRound {
       lockedByUserId: input.lockedByUserId,
     });
 
-    return this.rounds.create(round);
+    const persisted = await this.rounds.create(round);
+    if (persisted.isLocked && persisted.score && this.onScorecardLocked) {
+      await this.onScorecardLocked({
+        sport: "golf",
+        scorecardId: persisted.id,
+        golf: {
+          players: persisted.players.map((player) => ({
+            slot: player.slot,
+            userId: player.userId,
+          })),
+          holes: persisted.score.toSnapshot().holes,
+        },
+      });
+    }
+    return persisted;
   }
 }

--- a/src/modules/match/index.ts
+++ b/src/modules/match/index.ts
@@ -44,6 +44,7 @@ export function createMatchModule({
     captureFinishedMatch: new CaptureFinishedMatch(
       matchRepository,
       venueRepository,
+      onScorecardLocked,
     ),
     getMatchById: new GetMatchById(matchRepository),
     lockMatch: new LockMatch(matchRepository, onScorecardLocked),

--- a/src/modules/match/services/capture-finished-match.service.ts
+++ b/src/modules/match/services/capture-finished-match.service.ts
@@ -1,3 +1,4 @@
+import { OnScorecardLocked } from "../../scorecards/on-scorecard-locked";
 import { CmsId } from "../../venue/entities/cms-id";
 import { VenueRepository } from "../../venue/repositories/venue.repository";
 import { Match } from "../entities/match";
@@ -23,6 +24,7 @@ export class CaptureFinishedMatch {
   constructor(
     private readonly matches: MatchRepository,
     private readonly venues: VenueRepository,
+    private readonly onScorecardLocked?: OnScorecardLocked,
   ) {}
 
   async execute(input: CaptureFinishedMatchInput): Promise<Match> {
@@ -46,6 +48,14 @@ export class CaptureFinishedMatch {
       lockedByUserId: input.lockedByUserId,
     });
 
-    return this.matches.create(match);
+    const persisted = await this.matches.create(match);
+    if (persisted.isLocked && this.onScorecardLocked) {
+      await this.onScorecardLocked({
+        sport: "padel",
+        scorecardId: persisted.id,
+        padelWinner: persisted.winner?.value,
+      });
+    }
+    return persisted;
   }
 }

--- a/src/modules/preferences/controllers/preferences.controller.ts
+++ b/src/modules/preferences/controllers/preferences.controller.ts
@@ -14,13 +14,15 @@ const updateBodySchema = z
     activeSport: z.union([z.string(), z.null()]).optional(),
     completeOnboarding: z.boolean().optional(),
     skipOnboarding: z.boolean().optional(),
+    appearOnVenueLeaderboards: z.boolean().optional(),
   })
   .refine(
     (body) =>
       body.sports !== undefined ||
       body.activeSport !== undefined ||
       body.completeOnboarding === true ||
-      body.skipOnboarding === true,
+      body.skipOnboarding === true ||
+      body.appearOnVenueLeaderboards !== undefined,
     { message: "No preference fields to update" },
   );
 
@@ -58,6 +60,7 @@ export function createPreferencesController(deps: {
           activeSport: body.activeSport,
           completeOnboarding: body.completeOnboarding,
           skipOnboarding: body.skipOnboarding,
+          appearOnVenueLeaderboards: body.appearOnVenueLeaderboards,
         });
         return res.status(200).json(result);
       } catch (error) {

--- a/src/modules/preferences/repositories/in-memory-preferences.repository.ts
+++ b/src/modules/preferences/repositories/in-memory-preferences.repository.ts
@@ -11,6 +11,7 @@ function emptyPrefs(userId: string): UserPreferences {
     activeSport: null,
     onboardingCompletedAt: null,
     onboardingSkippedAt: null,
+    appearOnVenueLeaderboards: true,
   };
 }
 
@@ -50,6 +51,10 @@ export class InMemoryPreferencesRepository implements PreferencesRepository {
         input.onboardingSkippedAt !== undefined
           ? input.onboardingSkippedAt
           : current.onboardingSkippedAt,
+      appearOnVenueLeaderboards:
+        input.appearOnVenueLeaderboards !== undefined
+          ? input.appearOnVenueLeaderboards
+          : current.appearOnVenueLeaderboards,
     };
     this.byUserId.set(userId, next);
     return { ...next, sports: [...next.sports] };

--- a/src/modules/preferences/repositories/preferences.repository.ts
+++ b/src/modules/preferences/repositories/preferences.repository.ts
@@ -4,6 +4,7 @@ export type UserPreferences = {
   activeSport: string | null;
   onboardingCompletedAt: Date | null;
   onboardingSkippedAt: Date | null;
+  appearOnVenueLeaderboards: boolean;
 };
 
 export type UpdateUserPreferencesInput = {
@@ -11,6 +12,7 @@ export type UpdateUserPreferencesInput = {
   activeSport?: string | null;
   onboardingCompletedAt?: Date | null;
   onboardingSkippedAt?: Date | null;
+  appearOnVenueLeaderboards?: boolean;
 };
 
 export interface PreferencesRepository {

--- a/src/modules/preferences/repositories/prisma-preferences.repository.ts
+++ b/src/modules/preferences/repositories/prisma-preferences.repository.ts
@@ -13,6 +13,7 @@ function emptyPrefs(userId: string): UserPreferences {
     activeSport: null,
     onboardingCompletedAt: null,
     onboardingSkippedAt: null,
+    appearOnVenueLeaderboards: true,
   };
 }
 
@@ -28,6 +29,7 @@ export class PrismaPreferencesRepository implements PreferencesRepository {
             activeSportSlug: true,
             onboardingCompletedAt: true,
             onboardingSkippedAt: true,
+            appearOnVenueLeaderboards: true,
           },
         }),
         this.prisma.sportFollow.findMany({
@@ -47,6 +49,8 @@ export class PrismaPreferencesRepository implements PreferencesRepository {
         activeSport: profile?.activeSportSlug ?? null,
         onboardingCompletedAt: profile?.onboardingCompletedAt ?? null,
         onboardingSkippedAt: profile?.onboardingSkippedAt ?? null,
+        appearOnVenueLeaderboards:
+          profile?.appearOnVenueLeaderboards ?? true,
       };
     } catch (error) {
       throw new PreferencesPersistenceError("Failed to load preferences", {
@@ -75,6 +79,7 @@ export class PrismaPreferencesRepository implements PreferencesRepository {
           activeSportSlug?: string | null;
           onboardingCompletedAt?: Date | null;
           onboardingSkippedAt?: Date | null;
+          appearOnVenueLeaderboards?: boolean;
         } = {};
 
         if (input.activeSport !== undefined) {
@@ -85,6 +90,10 @@ export class PrismaPreferencesRepository implements PreferencesRepository {
         }
         if (input.onboardingSkippedAt !== undefined) {
           profileData.onboardingSkippedAt = input.onboardingSkippedAt;
+        }
+        if (input.appearOnVenueLeaderboards !== undefined) {
+          profileData.appearOnVenueLeaderboards =
+            input.appearOnVenueLeaderboards;
         }
 
         if (Object.keys(profileData).length > 0) {

--- a/src/modules/preferences/services/preferences.service.test.ts
+++ b/src/modules/preferences/services/preferences.service.test.ts
@@ -21,6 +21,7 @@ describe("preferences service", () => {
       activeSport: null,
       onboardingCompletedAt: null,
       onboardingSkippedAt: null,
+      appearOnVenueLeaderboards: true,
     });
   });
 
@@ -39,6 +40,7 @@ describe("preferences service", () => {
     expect(saved.activeSport).toBe("padel");
     expect(saved.onboardingCompletedAt).toEqual(expect.any(String));
     expect(saved.onboardingSkippedAt).toBeNull();
+    expect(saved.appearOnVenueLeaderboards).toBe(true);
 
     const loaded = await new GetPreferences(repo).execute({ userId: "u1" });
     expect(loaded).toEqual(saved);
@@ -51,5 +53,14 @@ describe("preferences service", () => {
       skipOnboarding: true,
     });
     expect(saved.onboardingSkippedAt).toEqual(expect.any(String));
+  });
+
+  test("updates appearOnVenueLeaderboards opt-out", async () => {
+    const repo = new InMemoryPreferencesRepository();
+    const saved = await new UpdatePreferences(repo).execute({
+      userId: "u1",
+      appearOnVenueLeaderboards: false,
+    });
+    expect(saved.appearOnVenueLeaderboards).toBe(false);
   });
 });

--- a/src/modules/preferences/services/preferences.service.ts
+++ b/src/modules/preferences/services/preferences.service.ts
@@ -12,6 +12,7 @@ export type PublicPreferences = {
   activeSport: string | null;
   onboardingCompletedAt: string | null;
   onboardingSkippedAt: string | null;
+  appearOnVenueLeaderboards: boolean;
 };
 
 export function toPublicPreferences(
@@ -22,6 +23,7 @@ export function toPublicPreferences(
     activeSport: prefs.activeSport,
     onboardingCompletedAt: prefs.onboardingCompletedAt?.toISOString() ?? null,
     onboardingSkippedAt: prefs.onboardingSkippedAt?.toISOString() ?? null,
+    appearOnVenueLeaderboards: prefs.appearOnVenueLeaderboards,
   };
 }
 
@@ -68,6 +70,7 @@ export type UpdatePreferencesInput = {
   activeSport?: string | null;
   completeOnboarding?: boolean;
   skipOnboarding?: boolean;
+  appearOnVenueLeaderboards?: boolean;
 };
 
 export class UpdatePreferences {
@@ -98,11 +101,16 @@ export class UpdatePreferences {
       patch.onboardingSkippedAt = new Date();
     }
 
+    if (input.appearOnVenueLeaderboards !== undefined) {
+      patch.appearOnVenueLeaderboards = input.appearOnVenueLeaderboards;
+    }
+
     if (
       patch.sports === undefined &&
       patch.activeSport === undefined &&
       patch.onboardingCompletedAt === undefined &&
-      patch.onboardingSkippedAt === undefined
+      patch.onboardingSkippedAt === undefined &&
+      patch.appearOnVenueLeaderboards === undefined
     ) {
       throw new DomainError("No preference fields to update");
     }

--- a/src/modules/venue-leaderboards/README.md
+++ b/src/modules/venue-leaderboards/README.md
@@ -1,0 +1,98 @@
+# Venue leaderboards v1
+
+Signed-in venue boards for locked padel, golf, and darts. Frontend hides empty tabs.
+
+Migration: `20260912120000_venue_leaderboard`.
+
+## Boards
+
+| `board` | Window | Rule |
+| --- | --- | --- |
+| `records` | all-time only | **Golf:** best locked **18-hole** gross and net per tee (snapshot `teeId` / `teeName`). Net only when a net total was computed. **Padel/darts:** most wins all-time; best win-streak record when streak ≥ 2. No most-improved. |
+| `potm` | current calendar month | Timezone **`Africa/Johannesburg`**. Padel/darts: most wins. Golf: best net average if any player has **≥3** locked 18-hole rounds with net; otherwise most locked rounds. Top 5 + `#1` (`first`). Tie-break: more events, then earlier first win/event. |
+| `grinder` | `month` or `all` | Most locked events at the venue. Appear only with **≥3** events. |
+| `streak` | current (all-time consecutive) | Padel/darts only. Current consecutive wins at the venue. Appear only if streak **≥2**. |
+
+Guests (`isGuest` / missing `userId`) never appear.
+
+## Gates
+
+- **Signed-in session required** (401 otherwise). Venue GETs stay public; this route does not.
+- Profile flag `appearOnVenueLeaderboards` (boolean, **default true**). When `false`, the user is excluded from every board.
+- Toggle: `PUT /api/me/preferences` `{ "appearOnVenueLeaderboards": false }`.
+- Public row: `userId`, `displayName` (first name + last initial), `avatarUrl?`, `stats`. **No email. No handicap index.** Golf records may include the net **score number**.
+
+## API (Frontend)
+
+```
+GET /api/venues/:idOrCmsId/leaderboards?board=records|potm|grinder|streak&window=month|all
+```
+
+- `:idOrCmsId` is the internal venue UUID **or** Sanity/cms id (same as other venue routes).
+- `board` is required.
+- `window` is required for meaning on **grinder**. Other boards ignore it and return their locked window (`records`/`streak` → `all`, `potm` → current `YYYY-MM`).
+- Empty boards are **200** with empty lists (`entries: []`, `first: null`, record lists `[]`) — not 404.
+- Unknown venue → 404 `{ "error": "Venue not found" }`.
+- Invalid query → 400 `{ "error": string }`.
+- Unauthenticated → 401 `{ "error": "Unauthorized" }`.
+
+### Response
+
+```json
+{
+  "venue": { "id": "…", "cmsId": "sanity-court-1", "name": "Padel Club" },
+  "board": "potm",
+  "window": "month",
+  "windowKey": "2026-09",
+  "timezone": "Africa/Johannesburg",
+  "computedAt": "2026-09-12T10:00:00.000Z",
+  "first": {
+    "rank": 1,
+    "userId": "…",
+    "displayName": "Alex P.",
+    "avatarUrl": null,
+    "stats": { "wins": 4, "events": 5 }
+  },
+  "entries": [],
+  "records": {
+    "golf": { "bestGrossByTee": [], "bestNetByTee": [] },
+    "padel": { "mostWins": [], "bestWinStreak": [] },
+    "darts": { "mostWins": [], "bestWinStreak": [] }
+  }
+}
+```
+
+`records` is present only when `board=records`. `stats` shapes:
+
+- POTM padel/darts: `{ wins, events }`
+- POTM golf (net): `{ netAverage, events, netRounds }`
+- POTM golf (fallback) / Grinder: `{ events }`
+- Streak / record streak: `{ streak }`
+- Golf tee record: `{ score, eventId, lockedAt }` — `score` is gross or net
+
+## Lock hooks + nightly reconcile
+
+On padel / golf / darts **lock** (and capture-finished) `onScorecardLocked` upserts `VenueLeaderboardEventFact` rows when a venue is present, then recomputes snapshots for that venue. Ingest errors are logged and **do not fail the lock**.
+
+Nightly (or anytime) rebuild from locked scorecards:
+
+```bash
+yarn leaderboards:reconcile
+yarn leaderboards:reconcile sanity-court-1
+```
+
+Ops: Railway cron / one-off `yarn leaderboards:reconcile`. Rebuilds facts from locked padel matches, golf rounds, and darts matches, then writes snapshots.
+
+## Cache
+
+Per `venueCmsId + board + windowKey`:
+
+1. In-memory TTL (30s)
+2. Durable `VenueLeaderboardSnapshot` row
+3. Live compute from facts if no snapshot yet
+
+Lock ingest invalidates the in-memory cache for that venue.
+
+## Out of scope
+
+Frontend, TV, inventing scores, ClubMaster, most improved.

--- a/src/modules/venue-leaderboards/cache/leaderboard-cache.ts
+++ b/src/modules/venue-leaderboards/cache/leaderboard-cache.ts
@@ -1,0 +1,41 @@
+import { VenueLeaderboardResponse } from "../entities/board-payload";
+
+const DEFAULT_TTL_MS = 30_000;
+
+export class LeaderboardMemoryCache {
+  private readonly entries = new Map<
+    string,
+    { value: VenueLeaderboardResponse; expiresAt: number }
+  >();
+
+  constructor(private readonly ttlMs = DEFAULT_TTL_MS) {}
+
+  key(venueCmsId: string, board: string, windowKey: string): string {
+    return `${venueCmsId}:${board}:${windowKey}`;
+  }
+
+  get(key: string): VenueLeaderboardResponse | null {
+    const stored = this.entries.get(key);
+    if (!stored) return null;
+    if (stored.expiresAt <= Date.now()) {
+      this.entries.delete(key);
+      return null;
+    }
+    return stored.value;
+  }
+
+  set(key: string, value: VenueLeaderboardResponse): void {
+    this.entries.set(key, {
+      value,
+      expiresAt: Date.now() + this.ttlMs,
+    });
+  }
+
+  invalidateVenue(venueCmsId: string): void {
+    for (const key of this.entries.keys()) {
+      if (key.startsWith(`${venueCmsId}:`)) {
+        this.entries.delete(key);
+      }
+    }
+  }
+}

--- a/src/modules/venue-leaderboards/cli/reconcile.ts
+++ b/src/modules/venue-leaderboards/cli/reconcile.ts
@@ -1,0 +1,48 @@
+import { getConfig } from "../../../config";
+import { createPrismaClient } from "../../../lib/prisma";
+import { PrismaDartsMatchRepository } from "../../darts/repositories/prisma-darts-match.repository";
+import { PrismaGolfRoundRepository } from "../../golf-round/repositories/prisma-golf-round.repository";
+import { PrismaMatchRepository } from "../../match/repositories/prisma-match.repository";
+import { PrismaVenueRepository } from "../../venue/repositories/prisma-venue.repository";
+import { LeaderboardMemoryCache } from "../cache/leaderboard-cache";
+import { PrismaVenueLeaderboardRepository } from "../repositories/prisma-venue-leaderboard.repository";
+import { RecomputeVenueLeaderboards } from "../services/recompute-venue-leaderboards.service";
+import { ReconcileVenueLeaderboards } from "../services/reconcile-venue-leaderboards.service";
+
+async function main() {
+  const config = getConfig();
+  const prisma = createPrismaClient(config);
+  const onlyCmsId = process.argv[2]?.trim();
+
+  const cache = new LeaderboardMemoryCache();
+  const leaderboards = new PrismaVenueLeaderboardRepository(prisma);
+  const recompute = new RecomputeVenueLeaderboards(leaderboards, cache);
+  const reconcile = new ReconcileVenueLeaderboards(
+    new PrismaVenueRepository(prisma),
+    new PrismaMatchRepository(prisma),
+    new PrismaGolfRoundRepository(prisma),
+    new PrismaDartsMatchRepository(prisma),
+    leaderboards,
+    recompute,
+  );
+
+  try {
+    if (onlyCmsId) {
+      await reconcile.execute(onlyCmsId);
+      console.log(`Reconciled venue leaderboards for ${onlyCmsId}`);
+    } else {
+      const venues = await prisma.venue.findMany({ select: { cmsId: true } });
+      const result = await reconcile.executeAll(venues.map((row) => row.cmsId));
+      console.log(
+        `Reconciled venue leaderboards for ${result.venues} venue(s)`,
+      );
+    }
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/modules/venue-leaderboards/controllers/venue-leaderboards.controller.ts
+++ b/src/modules/venue-leaderboards/controllers/venue-leaderboards.controller.ts
@@ -1,0 +1,67 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+
+import { DomainError } from "../../../lib/domain-error";
+import { VenueLeaderboardPersistenceError } from "../repositories/venue-leaderboard-persistence-error";
+import {
+  GetVenueLeaderboards,
+  VenueLeaderboardNotFoundError,
+} from "../services/get-venue-leaderboards.service";
+
+const idOrCmsIdParamSchema = z.object({
+  idOrCmsId: z.string().min(1),
+});
+
+const querySchema = z.object({
+  board: z.enum(["records", "potm", "grinder", "streak"]),
+  window: z.enum(["month", "all"]).optional(),
+});
+
+export function createVenueLeaderboardsController(deps: {
+  getVenueLeaderboards: GetVenueLeaderboards;
+  tryGetSessionUserId: (req: Request) => string | null;
+}) {
+  return {
+    async get(req: Request, res: Response) {
+      try {
+        const userId = deps.tryGetSessionUserId(req);
+        if (!userId) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+
+        const { idOrCmsId } = z.parse(idOrCmsIdParamSchema, req.params);
+        const query = z.parse(querySchema, req.query);
+        const result = await deps.getVenueLeaderboards.execute({
+          idOrCmsId,
+          board: query.board,
+          window: query.window,
+        });
+        return res.status(200).json(result);
+      } catch (error) {
+        return sendLeaderboardError(res, error);
+      }
+    },
+  };
+}
+
+function sendLeaderboardError(res: Response, error: unknown) {
+  if (error instanceof VenueLeaderboardNotFoundError) {
+    return res.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof DomainError) {
+    return res.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof z.ZodError) {
+    const message = error.issues[0]?.message ?? "Invalid leaderboard query";
+    return res.status(400).json({ error: message });
+  }
+
+  if (error instanceof VenueLeaderboardPersistenceError) {
+    return res.status(503).json({ error: error.message });
+  }
+
+  console.error(error);
+  return res.status(500).json({ error: "Internal server error" });
+}

--- a/src/modules/venue-leaderboards/controllers/venue-leaderboards.http.test.ts
+++ b/src/modules/venue-leaderboards/controllers/venue-leaderboards.http.test.ts
@@ -1,0 +1,355 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { Express } from "express";
+import jwt from "jsonwebtoken";
+
+import { createApp } from "../../../app";
+import { Config } from "../../../config";
+import { CmsId } from "../../venue/entities/cms-id";
+import { Slug } from "../../venue/entities/slug";
+import { Venue } from "../../venue/entities/venue";
+import { VenueName } from "../../venue/entities/venue-name";
+import { InMemoryVenueRepository } from "../../venue/repositories/in-memory-venue.repository";
+import { InMemoryMatchRepository } from "../../match/repositories/in-memory-match.repository";
+import { InMemoryPreferencesRepository } from "../../preferences/repositories/in-memory-preferences.repository";
+import { VenueEventFact } from "../entities/venue-event-fact";
+import { InMemoryVenueLeaderboardRepository } from "../repositories/in-memory-venue-leaderboard.repository";
+
+function makeConfig(): Config {
+  return {
+    PORT: 0,
+    DATABASE_URL: "postgresql://localhost/league",
+    NODE_ENV: "development",
+    GOOGLE_CLIENT_ID: "id",
+    GOOGLE_CLIENT_SECRET: "secret",
+    GOOGLE_REDIRECT_URI: "http://localhost:3000/callback",
+    JWT_SECRET: "jwt-test-secret",
+    FRONTEND_URL: "http://localhost:3001",
+    CORS_ORIGINS: ["http://localhost:3001"],
+  };
+}
+
+async function listen(app: Express) {
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+const pairings = {
+  teamA: [
+    { displayName: "Alex", isGuest: false, userId: "user-alex" },
+    { displayName: "Sam", isGuest: false, userId: "user-sam" },
+  ],
+  teamB: [
+    { displayName: "Jordan", isGuest: false, userId: "user-jordan" },
+    { displayName: "Riley", isGuest: false, userId: "user-riley" },
+  ],
+};
+
+describe("venue leaderboards HTTP", () => {
+  const config = makeConfig();
+  let venues: InMemoryVenueRepository;
+  let matches: InMemoryMatchRepository;
+  let leaderboards: InMemoryVenueLeaderboardRepository;
+  let preferences: InMemoryPreferencesRepository;
+  let venue: Venue;
+  let app: Express;
+  let server: { url: string; close: () => Promise<void> };
+
+  function cookie(userId: string) {
+    return `token=${jwt.sign({ userId }, config.JWT_SECRET)}`;
+  }
+
+  beforeEach(async () => {
+    venues = new InMemoryVenueRepository();
+    matches = new InMemoryMatchRepository();
+    leaderboards = new InMemoryVenueLeaderboardRepository();
+    preferences = new InMemoryPreferencesRepository();
+    const ensured = await venues.ensureFromCms(
+      Venue.registerFromCms(
+        CmsId.from("sanity-court-1"),
+        VenueName.from("Padel Club"),
+        Slug.from("padel-club"),
+      ),
+      { refreshDetails: false },
+    );
+    venue = ensured.venue;
+    leaderboards.seedProfile({
+      userId: "user-alex",
+      firstName: "Alex",
+      lastName: "Player",
+      avatarUrl: "https://example.com/a.png",
+    });
+    leaderboards.seedProfile({
+      userId: "user-blake",
+      firstName: "Blake",
+      lastName: "Golfer",
+      avatarUrl: null,
+    });
+
+    app = await createApp(config, {
+      venueRepository: venues,
+      matchRepository: matches,
+      venueLeaderboardRepository: leaderboards,
+      preferencesRepository: preferences,
+    });
+    server = await listen(app);
+  });
+
+  afterEach(async () => {
+    await server.close();
+    await app.locals.prisma?.$disconnect();
+  });
+
+  test("requires a signed-in session", async () => {
+    const response = await fetch(
+      `${server.url}/api/venues/sanity-court-1/leaderboards?board=potm`,
+    );
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Unauthorized" });
+  });
+
+  test("validates board and window with { error }", async () => {
+    const badBoard = await fetch(
+      `${server.url}/api/venues/sanity-court-1/leaderboards?board=improved`,
+      { headers: { Cookie: cookie("user-alex") } },
+    );
+    expect(badBoard.status).toBe(400);
+    expect(await badBoard.json()).toEqual(
+      expect.objectContaining({ error: expect.any(String) }),
+    );
+
+    const badWindow = await fetch(
+      `${server.url}/api/venues/sanity-court-1/leaderboards?board=grinder&window=week`,
+      { headers: { Cookie: cookie("user-alex") } },
+    );
+    expect(badWindow.status).toBe(400);
+    expect(await badWindow.json()).toEqual(
+      expect.objectContaining({ error: expect.any(String) }),
+    );
+  });
+
+  test("unknown venue is 404; empty boards are 200 lists", async () => {
+    const missing = await fetch(
+      `${server.url}/api/venues/no-such-venue/leaderboards?board=records`,
+      { headers: { Cookie: cookie("user-alex") } },
+    );
+    expect(missing.status).toBe(404);
+    expect(await missing.json()).toEqual({ error: "Venue not found" });
+
+    const empty = await fetch(
+      `${server.url}/api/venues/sanity-court-1/leaderboards?board=potm`,
+      { headers: { Cookie: cookie("user-alex") } },
+    );
+    expect(empty.status).toBe(200);
+    const body = (await empty.json()) as {
+      entries: unknown[];
+      first: unknown;
+      window: string;
+    };
+    expect(body.entries).toEqual([]);
+    expect(body.first).toBeNull();
+    expect(body.window).toBe("month");
+  });
+
+  test("resolves venue by internal id or cms id", async () => {
+    const byCms = await fetch(
+      `${server.url}/api/venues/sanity-court-1/leaderboards?board=grinder&window=all`,
+      { headers: { Cookie: cookie("user-alex") } },
+    );
+    const byId = await fetch(
+      `${server.url}/api/venues/${venue.id}/leaderboards?board=grinder&window=all`,
+      { headers: { Cookie: cookie("user-alex") } },
+    );
+    expect(byCms.status).toBe(200);
+    expect(byId.status).toBe(200);
+    expect(await byCms.json()).toMatchObject({
+      venue: { id: venue.id, cmsId: "sanity-court-1", name: "Padel Club" },
+    });
+    expect(await byId.json()).toMatchObject({
+      venue: { cmsId: "sanity-court-1" },
+    });
+  });
+
+  test("returns seeded potm / grinder / streak / records without email or HI", async () => {
+    const now = Date.now();
+    await leaderboards.upsertFacts([
+      VenueEventFact.create({
+        venueCmsId: "sanity-court-1",
+        sport: "padel",
+        eventId: "m1",
+        userId: "user-alex",
+        lockedAt: new Date(now - 172_800_000),
+        won: true,
+      }),
+      VenueEventFact.create({
+        venueCmsId: "sanity-court-1",
+        sport: "padel",
+        eventId: "m2",
+        userId: "user-alex",
+        lockedAt: new Date(now - 86_400_000),
+        won: true,
+      }),
+      VenueEventFact.create({
+        venueCmsId: "sanity-court-1",
+        sport: "padel",
+        eventId: "m3",
+        userId: "user-alex",
+        lockedAt: new Date(now),
+        won: true,
+      }),
+      VenueEventFact.create({
+        venueCmsId: "sanity-court-1",
+        sport: "golf",
+        eventId: "g1",
+        userId: "user-blake",
+        lockedAt: new Date("2026-09-01T08:00:00.000Z"),
+        golfGross: 72,
+        golfNet: 68,
+        golfTeeId: "tee-white",
+        golfTeeName: "White",
+        golfHolesPlayed: 18,
+      }),
+    ]);
+
+    const potm = await fetch(
+      `${server.url}/api/venues/sanity-court-1/leaderboards?board=potm`,
+      { headers: { Cookie: cookie("user-alex") } },
+    );
+    const potmBody = (await potm.json()) as {
+      first: { displayName: string; stats: Record<string, unknown> };
+      entries: Array<Record<string, unknown>>;
+    };
+    expect(potm.status).toBe(200);
+    expect(potmBody.first.displayName).toBe("Alex P.");
+    expect(potmBody.entries[0]).not.toHaveProperty("email");
+    expect(JSON.stringify(potmBody)).not.toContain("handicap");
+
+    const grinder = await fetch(
+      `${server.url}/api/venues/sanity-court-1/leaderboards?board=grinder&window=all`,
+      { headers: { Cookie: cookie("user-alex") } },
+    );
+    expect((await grinder.json()) as { entries: { userId: string }[] }).toEqual(
+      expect.objectContaining({
+        first: expect.objectContaining({ userId: "user-alex", stats: { events: 3 } }),
+      }),
+    );
+
+    const streak = await fetch(
+      `${server.url}/api/venues/sanity-court-1/leaderboards?board=streak`,
+      { headers: { Cookie: cookie("user-alex") } },
+    );
+    expect((await streak.json()) as { first: { stats: { streak: number } } }).toEqual(
+      expect.objectContaining({
+        first: expect.objectContaining({ stats: { streak: 3 } }),
+      }),
+    );
+
+    const records = await fetch(
+      `${server.url}/api/venues/sanity-court-1/leaderboards?board=records`,
+      { headers: { Cookie: cookie("user-alex") } },
+    );
+    const recordsBody = (await records.json()) as {
+      records: { golf: { bestNetByTee: Array<{ stats: { score: number } }> } };
+    };
+    expect(recordsBody.records.golf.bestNetByTee[0]?.stats.score).toBe(68);
+  });
+
+  test("opt-out excludes the user from boards", async () => {
+    const now = Date.now();
+    await leaderboards.upsertFacts([
+      VenueEventFact.create({
+        venueCmsId: "sanity-court-1",
+        sport: "padel",
+        eventId: "m1",
+        userId: "user-alex",
+        lockedAt: new Date(now - 172_800_000),
+        won: true,
+      }),
+      VenueEventFact.create({
+        venueCmsId: "sanity-court-1",
+        sport: "padel",
+        eventId: "m2",
+        userId: "user-alex",
+        lockedAt: new Date(now - 86_400_000),
+        won: true,
+      }),
+      VenueEventFact.create({
+        venueCmsId: "sanity-court-1",
+        sport: "padel",
+        eventId: "m3",
+        userId: "user-alex",
+        lockedAt: new Date(now),
+        won: true,
+      }),
+    ]);
+    leaderboards.setAppearOnBoards("user-alex", false);
+
+    const potm = await fetch(
+      `${server.url}/api/venues/sanity-court-1/leaderboards?board=potm`,
+      { headers: { Cookie: cookie("user-blake") } },
+    );
+    expect(await potm.json()).toMatchObject({ first: null, entries: [] });
+  });
+
+  test("lock ingest writes padel facts for signed-in players", async () => {
+    const created = await fetch(`${server.url}/api/matches`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-alex"),
+      },
+      body: JSON.stringify({
+        venueCmsId: "sanity-court-1",
+        startsAt: new Date().toISOString(),
+        ruleset: "golden_point",
+        pairings,
+        servingTeam: "A",
+      }),
+    });
+    const createdBody = (await created.json()) as { id: string };
+    expect(created.status).toBe(201);
+
+    const locked = await fetch(`${server.url}/api/matches/${createdBody.id}/lock`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: cookie("user-alex"),
+      },
+      body: JSON.stringify({
+        score: { sets: [{ gamesA: 6, gamesB: 4, winner: "A" }] },
+        winner: "A",
+      }),
+    });
+    expect(locked.status).toBe(200);
+
+    const streak = await fetch(
+      `${server.url}/api/venues/sanity-court-1/leaderboards?board=streak`,
+      { headers: { Cookie: cookie("user-alex") } },
+    );
+    const body = (await streak.json()) as {
+      entries: Array<{ userId: string; stats: { streak: number } }>;
+    };
+    expect(streak.status).toBe(200);
+    expect(body.entries).toEqual([]);
+
+    const potm = await fetch(
+      `${server.url}/api/venues/sanity-court-1/leaderboards?board=potm`,
+      { headers: { Cookie: cookie("user-alex") } },
+    );
+    const potmBody = (await potm.json()) as {
+      entries: Array<{ userId: string; stats: { wins: number } }>;
+    };
+    expect(potmBody.entries.map((row) => row.userId)).toEqual(["user-alex"]);
+  });
+});

--- a/src/modules/venue-leaderboards/entities/board-computer.test.ts
+++ b/src/modules/venue-leaderboards/entities/board-computer.test.ts
@@ -1,0 +1,417 @@
+import { VenueLeaderboardComputer, computeGrinder, computeHotStreak, computePotm } from "./board-computer";
+import { LeaderboardBoard } from "./leaderboard-board";
+import { LeaderboardWindow } from "./leaderboard-window";
+import { publicBoardDisplayName } from "./public-display-name";
+import { VenueEventFact } from "./venue-event-fact";
+
+const profiles = new Map([
+  ["alex", { userId: "alex", firstName: "Alex", lastName: "Player", avatarUrl: "a.png" }],
+  ["blake", { userId: "blake", firstName: "Blake", lastName: "Golfer", avatarUrl: null }],
+  ["casey", { userId: "casey", firstName: "Casey", lastName: "Padel", avatarUrl: null }],
+  ["drew", { userId: "drew", firstName: "Drew", lastName: "Darts", avatarUrl: null }],
+]);
+
+function fact(props: {
+  userId: string;
+  sport?: "padel" | "golf" | "darts";
+  eventId: string;
+  lockedAt: string;
+  won?: boolean | null;
+  golfGross?: number | null;
+  golfNet?: number | null;
+  golfTeeId?: string | null;
+  golfTeeName?: string | null;
+  golfHolesPlayed?: number | null;
+}): VenueEventFact {
+  return VenueEventFact.create({
+    venueCmsId: "sanity-venue-1",
+    sport: props.sport ?? "padel",
+    eventId: props.eventId,
+    userId: props.userId,
+    lockedAt: new Date(props.lockedAt),
+    won: props.won ?? null,
+    golfGross: props.golfGross ?? null,
+    golfNet: props.golfNet ?? null,
+    golfTeeId: props.golfTeeId ?? null,
+    golfTeeName: props.golfTeeName ?? null,
+    golfHolesPlayed: props.golfHolesPlayed ?? null,
+  });
+}
+
+describe("publicBoardDisplayName", () => {
+  test("uses first name and last initial", () => {
+    expect(publicBoardDisplayName("Alex", "Player")).toBe("Alex P.");
+  });
+});
+
+describe("POTM", () => {
+  test("padel/darts ranks by wins, then more events, then earlier first win", () => {
+    const facts = [
+      fact({ userId: "alex", eventId: "m1", lockedAt: "2026-09-02T08:00:00.000Z", won: true }),
+      fact({ userId: "blake", eventId: "m2", lockedAt: "2026-09-01T08:00:00.000Z", won: true }),
+      fact({ userId: "blake", eventId: "m3", lockedAt: "2026-09-03T08:00:00.000Z", won: false }),
+      fact({ userId: "casey", eventId: "m4", lockedAt: "2026-09-04T08:00:00.000Z", won: true }),
+    ];
+
+    const entries = computePotm(facts, profiles);
+    expect(entries.map((row) => row.userId)).toEqual(["blake", "alex", "casey"]);
+    expect(entries[0]).toMatchObject({
+      rank: 1,
+      displayName: "Blake G.",
+      stats: { wins: 1, events: 2 },
+    });
+    expect(entries[1]?.stats).toEqual({ wins: 1, events: 1 });
+    expect(entries[1]?.userId).toBe("alex");
+  });
+
+  test("golf uses net average when a player has ≥3 locked 18-hole nets", () => {
+    const facts = [
+      fact({
+        userId: "alex",
+        sport: "golf",
+        eventId: "g1",
+        lockedAt: "2026-09-01T08:00:00.000Z",
+        golfNet: 72,
+        golfGross: 80,
+        golfHolesPlayed: 18,
+        golfTeeName: "White",
+      }),
+      fact({
+        userId: "alex",
+        sport: "golf",
+        eventId: "g2",
+        lockedAt: "2026-09-02T08:00:00.000Z",
+        golfNet: 70,
+        golfGross: 78,
+        golfHolesPlayed: 18,
+        golfTeeName: "White",
+      }),
+      fact({
+        userId: "alex",
+        sport: "golf",
+        eventId: "g3",
+        lockedAt: "2026-09-03T08:00:00.000Z",
+        golfNet: 68,
+        golfGross: 76,
+        golfHolesPlayed: 18,
+        golfTeeName: "White",
+      }),
+      fact({
+        userId: "blake",
+        sport: "golf",
+        eventId: "g4",
+        lockedAt: "2026-09-01T09:00:00.000Z",
+        golfNet: 71,
+        golfGross: 79,
+        golfHolesPlayed: 18,
+        golfTeeName: "White",
+      }),
+      fact({
+        userId: "blake",
+        sport: "golf",
+        eventId: "g5",
+        lockedAt: "2026-09-02T09:00:00.000Z",
+        golfNet: 71,
+        golfGross: 79,
+        golfHolesPlayed: 18,
+        golfTeeName: "White",
+      }),
+    ];
+
+    const entries = computePotm(facts, profiles);
+    expect(entries.map((row) => row.userId)).toEqual(["alex"]);
+    expect(entries[0]?.stats).toEqual({
+      netAverage: 70,
+      events: 3,
+      netRounds: 3,
+    });
+  });
+
+  test("golf falls back to most rounds when nobody has ≥3 net 18-hole rounds", () => {
+    const facts = [
+      fact({
+        userId: "alex",
+        sport: "golf",
+        eventId: "g1",
+        lockedAt: "2026-09-02T08:00:00.000Z",
+        golfNet: 70,
+        golfHolesPlayed: 18,
+      }),
+      fact({
+        userId: "alex",
+        sport: "golf",
+        eventId: "g2",
+        lockedAt: "2026-09-03T08:00:00.000Z",
+        golfNet: 71,
+        golfHolesPlayed: 18,
+      }),
+      fact({
+        userId: "blake",
+        sport: "golf",
+        eventId: "g3",
+        lockedAt: "2026-09-01T08:00:00.000Z",
+        golfGross: 88,
+        golfHolesPlayed: 9,
+      }),
+    ];
+
+    const entries = computePotm(facts, profiles);
+    expect(entries.map((row) => row.userId)).toEqual(["alex", "blake"]);
+    expect(entries[0]?.stats).toEqual({ events: 2 });
+    expect(entries[1]?.stats).toEqual({ events: 1 });
+  });
+
+  test("golf net-average ties break on more events, then earlier first event", () => {
+    const facts = [
+      ...[1, 2, 3].map((n) =>
+        fact({
+          userId: "alex",
+          sport: "golf",
+          eventId: `a${n}`,
+          lockedAt: `2026-09-0${n + 1}T08:00:00.000Z`,
+          golfNet: 72,
+          golfHolesPlayed: 18,
+        }),
+      ),
+      ...[1, 2, 3, 4].map((n) =>
+        fact({
+          userId: "blake",
+          sport: "golf",
+          eventId: `b${n}`,
+          lockedAt: `2026-09-0${n}T10:00:00.000Z`,
+          golfNet: 72,
+          golfHolesPlayed: 18,
+        }),
+      ),
+    ];
+
+    const entries = computePotm(facts, profiles);
+    expect(entries[0]?.userId).toBe("blake");
+    expect(entries[0]?.stats.events).toBe(4);
+  });
+});
+
+describe("The Grinder", () => {
+  test("requires ≥3 locked events to appear", () => {
+    const facts = [
+      fact({ userId: "alex", eventId: "m1", lockedAt: "2026-09-01T08:00:00.000Z", won: true }),
+      fact({ userId: "alex", eventId: "m2", lockedAt: "2026-09-02T08:00:00.000Z", won: false }),
+      fact({ userId: "blake", eventId: "m3", lockedAt: "2026-09-01T08:00:00.000Z", won: true }),
+      fact({ userId: "blake", eventId: "m4", lockedAt: "2026-09-02T08:00:00.000Z", won: true }),
+      fact({ userId: "blake", eventId: "m5", lockedAt: "2026-09-03T08:00:00.000Z", won: false }),
+    ];
+
+    const entries = computeGrinder(facts, profiles);
+    expect(entries.map((row) => row.userId)).toEqual(["blake"]);
+    expect(entries[0]?.stats).toEqual({ events: 3 });
+  });
+});
+
+describe("Hot streak", () => {
+  test("includes only padel/darts current streaks of ≥2", () => {
+    const facts = [
+      fact({
+        userId: "alex",
+        sport: "padel",
+        eventId: "p1",
+        lockedAt: "2026-09-01T08:00:00.000Z",
+        won: true,
+      }),
+      fact({
+        userId: "alex",
+        sport: "padel",
+        eventId: "p2",
+        lockedAt: "2026-09-02T08:00:00.000Z",
+        won: true,
+      }),
+      fact({
+        userId: "blake",
+        sport: "darts",
+        eventId: "d1",
+        lockedAt: "2026-09-01T08:00:00.000Z",
+        won: true,
+      }),
+      fact({
+        userId: "casey",
+        sport: "golf",
+        eventId: "g1",
+        lockedAt: "2026-09-01T08:00:00.000Z",
+        golfGross: 72,
+        golfHolesPlayed: 18,
+      }),
+      fact({
+        userId: "drew",
+        sport: "padel",
+        eventId: "p3",
+        lockedAt: "2026-09-01T08:00:00.000Z",
+        won: true,
+      }),
+      fact({
+        userId: "drew",
+        sport: "padel",
+        eventId: "p4",
+        lockedAt: "2026-09-02T08:00:00.000Z",
+        won: false,
+      }),
+    ];
+
+    const entries = computeHotStreak(facts, profiles);
+    expect(entries.map((row) => row.userId)).toEqual(["alex"]);
+    expect(entries[0]?.stats).toEqual({ streak: 2 });
+  });
+
+  test("a loss resets the current streak even if older wins exist", () => {
+    const facts = [
+      fact({ userId: "alex", eventId: "m1", lockedAt: "2026-09-01T08:00:00.000Z", won: true }),
+      fact({ userId: "alex", eventId: "m2", lockedAt: "2026-09-02T08:00:00.000Z", won: true }),
+      fact({ userId: "alex", eventId: "m3", lockedAt: "2026-09-03T08:00:00.000Z", won: false }),
+    ];
+    expect(computeHotStreak(facts, profiles)).toEqual([]);
+  });
+});
+
+describe("Records golf per tee", () => {
+  test("tracks best locked 18-hole gross and net per tee; net only when computed", () => {
+    const facts = [
+      fact({
+        userId: "alex",
+        sport: "golf",
+        eventId: "g1",
+        lockedAt: "2026-09-01T08:00:00.000Z",
+        golfGross: 74,
+        golfNet: 70,
+        golfTeeId: "tee-white",
+        golfTeeName: "White",
+        golfHolesPlayed: 18,
+      }),
+      fact({
+        userId: "blake",
+        sport: "golf",
+        eventId: "g2",
+        lockedAt: "2026-09-02T08:00:00.000Z",
+        golfGross: 71,
+        golfNet: null,
+        golfTeeId: "tee-white",
+        golfTeeName: "White",
+        golfHolesPlayed: 18,
+      }),
+      fact({
+        userId: "casey",
+        sport: "golf",
+        eventId: "g3",
+        lockedAt: "2026-09-03T08:00:00.000Z",
+        golfGross: 68,
+        golfNet: 66,
+        golfTeeId: "tee-blue",
+        golfTeeName: "Blue",
+        golfHolesPlayed: 18,
+      }),
+      fact({
+        userId: "drew",
+        sport: "golf",
+        eventId: "g4",
+        lockedAt: "2026-09-04T08:00:00.000Z",
+        golfGross: 33,
+        golfNet: 31,
+        golfTeeName: "White",
+        golfHolesPlayed: 9,
+      }),
+    ];
+
+    const payload = VenueLeaderboardComputer.compute({
+      board: LeaderboardBoard.records,
+      window: LeaderboardWindow.all(),
+      facts,
+      profiles,
+      optedOutUserIds: new Set(),
+    });
+
+    expect(payload.records?.golf.bestGrossByTee).toEqual([
+      expect.objectContaining({
+        teeId: "tee-blue",
+        teeName: "Blue",
+        userId: "casey",
+        displayName: "Casey P.",
+        stats: expect.objectContaining({ score: 68, eventId: "g3" }),
+      }),
+      expect.objectContaining({
+        teeId: "tee-white",
+        teeName: "White",
+        userId: "blake",
+        displayName: "Blake G.",
+        stats: expect.objectContaining({ score: 71, eventId: "g2" }),
+      }),
+    ]);
+    expect(payload.records?.golf.bestNetByTee).toEqual([
+      expect.objectContaining({
+        teeId: "tee-blue",
+        userId: "casey",
+        stats: expect.objectContaining({ score: 66 }),
+      }),
+      expect.objectContaining({
+        teeId: "tee-white",
+        userId: "alex",
+        stats: expect.objectContaining({ score: 70 }),
+      }),
+    ]);
+  });
+});
+
+describe("Johannesburg month window", () => {
+  test("potm ignores wins outside the calendar month", () => {
+    const facts = [
+      fact({ userId: "alex", eventId: "old", lockedAt: "2026-08-31T21:00:00.000Z", won: true }),
+      fact({ userId: "blake", eventId: "in", lockedAt: "2026-08-31T22:30:00.000Z", won: true }),
+    ];
+    const payload = VenueLeaderboardComputer.compute({
+      board: LeaderboardBoard.potm,
+      window: LeaderboardWindow.month("2026-09"),
+      facts,
+      profiles,
+      optedOutUserIds: new Set(),
+    });
+    expect(payload.entries.map((row) => row.userId)).toEqual(["blake"]);
+  });
+});
+
+describe("opt-out", () => {
+  test("excludes the user from every board", () => {
+    const facts = [
+      fact({ userId: "alex", eventId: "m1", lockedAt: "2026-09-01T08:00:00.000Z", won: true }),
+      fact({ userId: "alex", eventId: "m2", lockedAt: "2026-09-02T08:00:00.000Z", won: true }),
+      fact({ userId: "alex", eventId: "m3", lockedAt: "2026-09-03T08:00:00.000Z", won: true }),
+      fact({ userId: "blake", eventId: "m4", lockedAt: "2026-09-01T08:00:00.000Z", won: true }),
+      fact({ userId: "blake", eventId: "m5", lockedAt: "2026-09-02T08:00:00.000Z", won: true }),
+      fact({ userId: "blake", eventId: "m6", lockedAt: "2026-09-03T08:00:00.000Z", won: true }),
+    ];
+    const optedOut = new Set(["alex"]);
+
+    const potm = VenueLeaderboardComputer.compute({
+      board: LeaderboardBoard.potm,
+      window: LeaderboardWindow.all(),
+      facts,
+      profiles,
+      optedOutUserIds: optedOut,
+    });
+    expect(potm.entries.map((row) => row.userId)).toEqual(["blake"]);
+    expect(potm.first?.userId).toBe("blake");
+
+    const grinder = VenueLeaderboardComputer.compute({
+      board: LeaderboardBoard.grinder,
+      window: LeaderboardWindow.all(),
+      facts,
+      profiles,
+      optedOutUserIds: optedOut,
+    });
+    expect(grinder.entries.map((row) => row.userId)).toEqual(["blake"]);
+
+    const streak = VenueLeaderboardComputer.compute({
+      board: LeaderboardBoard.streak,
+      window: LeaderboardWindow.all(),
+      facts,
+      profiles,
+      optedOutUserIds: optedOut,
+    });
+    expect(streak.entries.map((row) => row.userId)).toEqual(["blake"]);
+  });
+});

--- a/src/modules/venue-leaderboards/entities/board-computer.ts
+++ b/src/modules/venue-leaderboards/entities/board-computer.ts
@@ -1,0 +1,344 @@
+import { isInJohannesburgMonth } from "./johannesburg-calendar";
+import {
+  PublicBoardEntry,
+  RecordsPayload,
+  SnapshotPayload,
+} from "./board-payload";
+import { LeaderboardBoard } from "./leaderboard-board";
+import { LeaderboardWindow } from "./leaderboard-window";
+import {
+  BoardProfile,
+  toPublicBoardIdentity,
+} from "./public-display-name";
+import { LeaderboardSport, VenueEventFact } from "./venue-event-fact";
+
+export const POTM_LIMIT = 5;
+export const GRINDER_MIN_EVENTS = 3;
+export const HOT_STREAK_MIN = 2;
+export const GOLF_NET_AVG_MIN_ROUNDS = 3;
+
+type Rankable = {
+  userId: string;
+  sort: number[];
+  stats: PublicBoardEntry["stats"];
+};
+
+function compareLockedAt(a: VenueEventFact, b: VenueEventFact): number {
+  const delta = a.lockedAt.getTime() - b.lockedAt.getTime();
+  if (delta !== 0) return delta;
+  return a.eventId.localeCompare(b.eventId);
+}
+
+function excludeOptedOut(
+  facts: VenueEventFact[],
+  optedOut: ReadonlySet<string>,
+): VenueEventFact[] {
+  return facts.filter((fact) => !optedOut.has(fact.userId));
+}
+
+function inWindow(facts: VenueEventFact[], window: LeaderboardWindow): VenueEventFact[] {
+  if (window.value === "all") return facts;
+  return facts.filter((fact) => isInJohannesburgMonth(fact.lockedAt, window.key));
+}
+
+function identity(
+  profiles: ReadonlyMap<string, BoardProfile>,
+  userId: string,
+) {
+  return toPublicBoardIdentity(profiles.get(userId), userId);
+}
+
+function rankEntries(
+  rows: Rankable[],
+  profiles: ReadonlyMap<string, BoardProfile>,
+  limit?: number,
+): PublicBoardEntry[] {
+  const sorted = [...rows].sort((a, b) => {
+    for (let i = 0; i < Math.max(a.sort.length, b.sort.length); i += 1) {
+      const left = a.sort[i] ?? 0;
+      const right = b.sort[i] ?? 0;
+      if (left !== right) return left - right;
+    }
+    return a.userId.localeCompare(b.userId);
+  });
+  const sliced = limit === undefined ? sorted : sorted.slice(0, limit);
+  return sliced.map((row, index) => ({
+    rank: index + 1,
+    ...identity(profiles, row.userId),
+    stats: row.stats,
+  }));
+}
+
+function groupByUser(facts: VenueEventFact[]): Map<string, VenueEventFact[]> {
+  const groups = new Map<string, VenueEventFact[]>();
+  for (const fact of facts) {
+    const list = groups.get(fact.userId) ?? [];
+    list.push(fact);
+    groups.set(fact.userId, list);
+  }
+  for (const list of groups.values()) {
+    list.sort(compareLockedAt);
+  }
+  return groups;
+}
+
+export function currentWinStreak(facts: VenueEventFact[]): number {
+  const newestFirst = [...facts].sort((a, b) => compareLockedAt(b, a));
+  let streak = 0;
+  for (const fact of newestFirst) {
+    if (fact.won === true) {
+      streak += 1;
+      continue;
+    }
+    break;
+  }
+  return streak;
+}
+
+export function bestWinStreak(facts: VenueEventFact[]): number {
+  const oldestFirst = [...facts].sort(compareLockedAt);
+  let current = 0;
+  let best = 0;
+  for (const fact of oldestFirst) {
+    if (fact.won === true) {
+      current += 1;
+      if (current > best) best = current;
+      continue;
+    }
+    current = 0;
+  }
+  return best;
+}
+
+function mostWinsRows(facts: VenueEventFact[]): Rankable[] {
+  const rows: Rankable[] = [];
+  for (const [userId, userFacts] of groupByUser(facts)) {
+    const wins = userFacts.filter((fact) => fact.won === true);
+    if (wins.length === 0) continue;
+    const firstWinAt = wins[0]!.lockedAt.getTime();
+    rows.push({
+      userId,
+      sort: [-wins.length, -userFacts.length, firstWinAt],
+      stats: { wins: wins.length, events: userFacts.length },
+    });
+  }
+  return rows;
+}
+
+function bestStreakRows(facts: VenueEventFact[], minStreak: number): Rankable[] {
+  const rows: Rankable[] = [];
+  for (const [userId, userFacts] of groupByUser(facts)) {
+    const streak = bestWinStreak(userFacts);
+    if (streak < minStreak) continue;
+    rows.push({
+      userId,
+      sort: [-streak, userFacts[0]!.lockedAt.getTime()],
+      stats: { streak },
+    });
+  }
+  return rows;
+}
+
+function currentStreakRows(facts: VenueEventFact[], minStreak: number): Rankable[] {
+  const rows: Rankable[] = [];
+  for (const [userId, userFacts] of groupByUser(facts)) {
+    const streak = currentWinStreak(userFacts);
+    if (streak < minStreak) continue;
+    rows.push({
+      userId,
+      sort: [-streak, userFacts[userFacts.length - 1]!.lockedAt.getTime()],
+      stats: { streak },
+    });
+  }
+  return rows;
+}
+
+function golfTeeRecords(
+  facts: VenueEventFact[],
+  profiles: ReadonlyMap<string, BoardProfile>,
+  kind: "gross" | "net",
+): RecordsPayload["golf"]["bestGrossByTee"] {
+  const byTee = new Map<string, VenueEventFact>();
+  for (const fact of facts) {
+    if (!fact.isEighteenHoleGolf) continue;
+    const score = kind === "gross" ? fact.golfGross : fact.golfNet;
+    if (score === null) continue;
+    const existing = byTee.get(fact.teeKey);
+    if (!existing) {
+      byTee.set(fact.teeKey, fact);
+      continue;
+    }
+    const existingScore =
+      kind === "gross" ? existing.golfGross : existing.golfNet;
+    if (existingScore === null || score < existingScore) {
+      byTee.set(fact.teeKey, fact);
+      continue;
+    }
+    if (
+      existingScore === score &&
+      compareLockedAt(fact, existing) < 0
+    ) {
+      byTee.set(fact.teeKey, fact);
+    }
+  }
+
+  return [...byTee.values()]
+    .sort((a, b) => a.teeKey.localeCompare(b.teeKey))
+    .map((fact) => ({
+      teeId: fact.golfTeeId,
+      teeName: fact.golfTeeName,
+      ...identity(profiles, fact.userId),
+      stats: {
+        score: kind === "gross" ? fact.golfGross : fact.golfNet,
+        eventId: fact.eventId,
+        lockedAt: fact.lockedAt.toISOString(),
+      },
+    }));
+}
+
+function computeRecords(
+  facts: VenueEventFact[],
+  profiles: ReadonlyMap<string, BoardProfile>,
+): RecordsPayload {
+  const padel = facts.filter((fact) => fact.sport === "padel");
+  const darts = facts.filter((fact) => fact.sport === "darts");
+  return {
+    golf: {
+      bestGrossByTee: golfTeeRecords(facts, profiles, "gross"),
+      bestNetByTee: golfTeeRecords(facts, profiles, "net"),
+    },
+    padel: {
+      mostWins: rankEntries(mostWinsRows(padel), profiles, POTM_LIMIT),
+      bestWinStreak: rankEntries(bestStreakRows(padel, HOT_STREAK_MIN), profiles, POTM_LIMIT),
+    },
+    darts: {
+      mostWins: rankEntries(mostWinsRows(darts), profiles, POTM_LIMIT),
+      bestWinStreak: rankEntries(bestStreakRows(darts, HOT_STREAK_MIN), profiles, POTM_LIMIT),
+    },
+  };
+}
+
+export function computePotm(
+  facts: VenueEventFact[],
+  profiles: ReadonlyMap<string, BoardProfile>,
+): PublicBoardEntry[] {
+  const winSports = facts.filter(
+    (fact) => fact.sport === "padel" || fact.sport === "darts",
+  );
+  const golf = facts.filter((fact) => fact.sport === "golf");
+
+  if (winSports.length > 0 && golf.length === 0) {
+    return rankEntries(mostWinsRows(winSports), profiles, POTM_LIMIT);
+  }
+
+  if (golf.length > 0 && winSports.length === 0) {
+    return rankEntries(golfPotmRows(golf), profiles, POTM_LIMIT);
+  }
+
+  // Mixed-sport venue: padel/darts compete on wins; golf uses its own rule.
+  // Combined list is unusual — prefer wins board when any racquet/darts facts
+  // exist, otherwise golf. Product is per-venue sport in practice.
+  if (winSports.length > 0) {
+    return rankEntries(mostWinsRows(winSports), profiles, POTM_LIMIT);
+  }
+  return [];
+}
+
+function golfPotmRows(facts: VenueEventFact[]): Rankable[] {
+  const rows: Rankable[] = [];
+  const byUser = groupByUser(facts);
+  const netQualified: Rankable[] = [];
+
+  for (const [userId, userFacts] of byUser) {
+    const netRounds = userFacts.filter(
+      (fact) => fact.isEighteenHoleGolf && fact.golfNet !== null,
+    );
+    const firstEventAt = userFacts[0]!.lockedAt.getTime();
+    if (netRounds.length >= GOLF_NET_AVG_MIN_ROUNDS) {
+      const netAverage =
+        netRounds.reduce((sum, fact) => sum + (fact.golfNet ?? 0), 0) /
+        netRounds.length;
+      netQualified.push({
+        userId,
+        sort: [netAverage, -userFacts.length, firstEventAt],
+        stats: {
+          netAverage: Number(netAverage.toFixed(2)),
+          events: userFacts.length,
+          netRounds: netRounds.length,
+        },
+      });
+    }
+    rows.push({
+      userId,
+      sort: [-userFacts.length, firstEventAt],
+      stats: { events: userFacts.length },
+    });
+  }
+
+  return netQualified.length > 0 ? netQualified : rows;
+}
+
+export function computeGrinder(
+  facts: VenueEventFact[],
+  profiles: ReadonlyMap<string, BoardProfile>,
+): PublicBoardEntry[] {
+  const rows: Rankable[] = [];
+  for (const [userId, userFacts] of groupByUser(facts)) {
+    if (userFacts.length < GRINDER_MIN_EVENTS) continue;
+    rows.push({
+      userId,
+      sort: [-userFacts.length, userFacts[0]!.lockedAt.getTime()],
+      stats: { events: userFacts.length },
+    });
+  }
+  return rankEntries(rows, profiles);
+}
+
+export function computeHotStreak(
+  facts: VenueEventFact[],
+  profiles: ReadonlyMap<string, BoardProfile>,
+): PublicBoardEntry[] {
+  const eligible = facts.filter(
+    (fact) => fact.sport === "padel" || fact.sport === "darts",
+  );
+  return rankEntries(currentStreakRows(eligible, HOT_STREAK_MIN), profiles);
+}
+
+export class VenueLeaderboardComputer {
+  static compute(input: {
+    board: LeaderboardBoard;
+    window: LeaderboardWindow;
+    facts: VenueEventFact[];
+    profiles: ReadonlyMap<string, BoardProfile>;
+    optedOutUserIds: ReadonlySet<string>;
+  }): SnapshotPayload {
+    const facts = inWindow(
+      excludeOptedOut(input.facts, input.optedOutUserIds),
+      input.window,
+    );
+
+    if (input.board.value === "records") {
+      const records = computeRecords(facts, input.profiles);
+      return { first: null, entries: [], records };
+    }
+
+    const entries =
+      input.board.value === "potm"
+        ? computePotm(facts, input.profiles)
+        : input.board.value === "grinder"
+          ? computeGrinder(facts, input.profiles)
+          : computeHotStreak(facts, input.profiles);
+
+    return {
+      first: entries[0] ?? null,
+      entries,
+    };
+  }
+}
+
+export function sportFacts(
+  facts: VenueEventFact[],
+  sport: LeaderboardSport,
+): VenueEventFact[] {
+  return facts.filter((fact) => fact.sport === sport);
+}

--- a/src/modules/venue-leaderboards/entities/board-payload.ts
+++ b/src/modules/venue-leaderboards/entities/board-payload.ts
@@ -1,0 +1,51 @@
+export type PublicBoardStats = Record<string, number | string | null>;
+
+export type PublicBoardEntry = {
+  rank: number;
+  userId: string;
+  displayName: string;
+  avatarUrl: string | null;
+  stats: PublicBoardStats;
+};
+
+export type GolfTeeRecord = {
+  teeId: string | null;
+  teeName: string | null;
+  userId: string;
+  displayName: string;
+  avatarUrl: string | null;
+  stats: PublicBoardStats;
+};
+
+export type RecordsPayload = {
+  golf: {
+    bestGrossByTee: GolfTeeRecord[];
+    bestNetByTee: GolfTeeRecord[];
+  };
+  padel: {
+    mostWins: PublicBoardEntry[];
+    bestWinStreak: PublicBoardEntry[];
+  };
+  darts: {
+    mostWins: PublicBoardEntry[];
+    bestWinStreak: PublicBoardEntry[];
+  };
+};
+
+export type SnapshotPayload = {
+  first: PublicBoardEntry | null;
+  entries: PublicBoardEntry[];
+  records?: RecordsPayload;
+};
+
+export type VenueLeaderboardResponse = {
+  venue: { id: string; cmsId: string; name: string };
+  board: "records" | "potm" | "grinder" | "streak";
+  window: "month" | "all";
+  windowKey: string;
+  timezone: string;
+  computedAt: string;
+  first: PublicBoardEntry | null;
+  entries: PublicBoardEntry[];
+  records?: RecordsPayload;
+};

--- a/src/modules/venue-leaderboards/entities/johannesburg-calendar.ts
+++ b/src/modules/venue-leaderboards/entities/johannesburg-calendar.ts
@@ -1,0 +1,32 @@
+export const JOHANNESBURG_TIMEZONE = "Africa/Johannesburg";
+
+const YEAR_MONTH = /^(\d{4})-(\d{2})$/;
+
+export function johannesburgYearMonth(date: Date): string {
+  const parts = new Intl.DateTimeFormat("en-ZA", {
+    timeZone: JOHANNESBURG_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+  }).formatToParts(date);
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  if (!year || !month) {
+    throw new Error("Unable to format Johannesburg calendar month");
+  }
+  return `${year}-${month}`;
+}
+
+export function currentJohannesburgYearMonth(now = new Date()): string {
+  return johannesburgYearMonth(now);
+}
+
+export function isJohannesburgYearMonth(value: string): boolean {
+  const match = YEAR_MONTH.exec(value);
+  if (!match) return false;
+  const month = Number(match[2]);
+  return month >= 1 && month <= 12;
+}
+
+export function isInJohannesburgMonth(date: Date, yearMonth: string): boolean {
+  return johannesburgYearMonth(date) === yearMonth;
+}

--- a/src/modules/venue-leaderboards/entities/leaderboard-board.ts
+++ b/src/modules/venue-leaderboards/entities/leaderboard-board.ts
@@ -1,0 +1,34 @@
+import { DomainError } from "../../../lib/domain-error";
+
+export const LEADERBOARD_BOARDS = ["records", "potm", "grinder", "streak"] as const;
+
+export type LeaderboardBoardId = (typeof LEADERBOARD_BOARDS)[number];
+
+export class LeaderboardBoard {
+  static readonly records = new LeaderboardBoard("records");
+  static readonly potm = new LeaderboardBoard("potm");
+  static readonly grinder = new LeaderboardBoard("grinder");
+  static readonly streak = new LeaderboardBoard("streak");
+
+  private constructor(readonly value: LeaderboardBoardId) {}
+
+  static from(raw: unknown): LeaderboardBoard {
+    if (raw === "records") return LeaderboardBoard.records;
+    if (raw === "potm") return LeaderboardBoard.potm;
+    if (raw === "grinder") return LeaderboardBoard.grinder;
+    if (raw === "streak") return LeaderboardBoard.streak;
+    throw new DomainError("board must be records, potm, grinder, or streak");
+  }
+
+  get defaultWindow(): "month" | "all" {
+    return this.value === "potm" || this.value === "grinder" ? "month" : "all";
+  }
+
+  usesWindowQuery(): boolean {
+    return this.value === "grinder";
+  }
+
+  equals(other: LeaderboardBoard): boolean {
+    return this.value === other.value;
+  }
+}

--- a/src/modules/venue-leaderboards/entities/leaderboard-window.ts
+++ b/src/modules/venue-leaderboards/entities/leaderboard-window.ts
@@ -1,0 +1,53 @@
+import { DomainError } from "../../../lib/domain-error";
+import { currentJohannesburgYearMonth, isJohannesburgYearMonth } from "./johannesburg-calendar";
+import { LeaderboardBoard } from "./leaderboard-board";
+
+export const LEADERBOARD_WINDOWS = ["month", "all"] as const;
+
+export type LeaderboardWindowId = (typeof LEADERBOARD_WINDOWS)[number];
+
+export class LeaderboardWindow {
+  private constructor(
+    readonly value: LeaderboardWindowId,
+    readonly key: string,
+  ) {}
+
+  static all(): LeaderboardWindow {
+    return new LeaderboardWindow("all", "all");
+  }
+
+  static month(yearMonth = currentJohannesburgYearMonth()): LeaderboardWindow {
+    if (!isJohannesburgYearMonth(yearMonth)) {
+      throw new DomainError("windowKey must be YYYY-MM");
+    }
+    return new LeaderboardWindow("month", yearMonth);
+  }
+
+  static fromQuery(
+    board: LeaderboardBoard,
+    raw: unknown,
+    now = new Date(),
+  ): LeaderboardWindow {
+    if (raw !== undefined && raw !== "month" && raw !== "all") {
+      throw new DomainError("window must be month or all");
+    }
+
+    if (board.value === "records" || board.value === "streak") {
+      return LeaderboardWindow.all();
+    }
+
+    if (board.value === "potm") {
+      return LeaderboardWindow.month(currentJohannesburgYearMonth(now));
+    }
+
+    if (raw === "all") {
+      return LeaderboardWindow.all();
+    }
+
+    return LeaderboardWindow.month(currentJohannesburgYearMonth(now));
+  }
+
+  equals(other: LeaderboardWindow): boolean {
+    return this.value === other.value && this.key === other.key;
+  }
+}

--- a/src/modules/venue-leaderboards/entities/public-display-name.ts
+++ b/src/modules/venue-leaderboards/entities/public-display-name.ts
@@ -1,0 +1,30 @@
+export function publicBoardDisplayName(
+  firstName: string,
+  lastName: string,
+  fallback = "Player",
+): string {
+  const first = firstName.trim();
+  const last = lastName.trim();
+  if (!first && !last) return fallback;
+  if (!last) return first;
+  const initial = last[0]!.toUpperCase();
+  if (!first) return `${initial}.`;
+  return `${first} ${initial}.`;
+}
+
+export type BoardProfile = {
+  userId: string;
+  firstName: string;
+  lastName: string;
+  avatarUrl: string | null;
+};
+
+export function toPublicBoardIdentity(profile: BoardProfile | undefined, userId: string) {
+  return {
+    userId,
+    displayName: profile
+      ? publicBoardDisplayName(profile.firstName, profile.lastName)
+      : "Player",
+    avatarUrl: profile?.avatarUrl ?? null,
+  };
+}

--- a/src/modules/venue-leaderboards/entities/venue-event-fact.test.ts
+++ b/src/modules/venue-leaderboards/entities/venue-event-fact.test.ts
@@ -1,0 +1,37 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { Match } from "../../match/entities/match";
+import { StartsAt } from "../../match/entities/starts-at";
+import { Ruleset } from "../../match/entities/ruleset";
+import { VenueEventFact } from "./venue-event-fact";
+
+describe("VenueEventFact.fromPadelMatch", () => {
+  test("skips guests and attributes wins to the winning pair", () => {
+    const match = Match.captureFinished({
+      venueCmsId: CmsId.from("sanity-court-1"),
+      startsAt: StartsAt.from("2026-09-12T10:00:00.000Z"),
+      ruleset: Ruleset.from("golden_point"),
+      pairings: {
+        teamA: [
+          { displayName: "Alex", isGuest: false, userId: "user-alex" },
+          { displayName: "Sam", isGuest: true, userId: null },
+        ],
+        teamB: [
+          { displayName: "Jordan", isGuest: false, userId: "user-jordan" },
+          { displayName: "Riley", isGuest: false, userId: "user-riley" },
+        ],
+      },
+      score: { sets: [{ gamesA: 6, gamesB: 4, winner: "A" }] },
+      winner: "A",
+      lockedByUserId: "user-alex",
+    });
+
+    const facts = VenueEventFact.fromPadelMatch(match);
+    expect(facts.map((fact) => fact.userId).sort()).toEqual([
+      "user-alex",
+      "user-jordan",
+      "user-riley",
+    ]);
+    expect(facts.find((fact) => fact.userId === "user-alex")?.won).toBe(true);
+    expect(facts.find((fact) => fact.userId === "user-jordan")?.won).toBe(false);
+  });
+});

--- a/src/modules/venue-leaderboards/entities/venue-event-fact.ts
+++ b/src/modules/venue-leaderboards/entities/venue-event-fact.ts
@@ -1,0 +1,173 @@
+import { randomUUID } from "node:crypto";
+
+import { DartsMatch } from "../../darts/entities/darts-match";
+import { GolfRound } from "../../golf-round/entities/golf-round";
+import { Match } from "../../match/entities/match";
+
+export const LEADERBOARD_SPORTS = ["padel", "golf", "darts"] as const;
+
+export type LeaderboardSport = (typeof LEADERBOARD_SPORTS)[number];
+
+export type VenueEventFactSnapshot = {
+  id: string;
+  venueCmsId: string;
+  sport: LeaderboardSport;
+  eventId: string;
+  userId: string;
+  lockedAt: string;
+  won: boolean | null;
+  golfGross: number | null;
+  golfNet: number | null;
+  golfTeeId: string | null;
+  golfTeeName: string | null;
+  golfHolesPlayed: number | null;
+};
+
+export type VenueEventFactProps = {
+  id?: string;
+  venueCmsId: string;
+  sport: LeaderboardSport;
+  eventId: string;
+  userId: string;
+  lockedAt: Date;
+  won?: boolean | null;
+  golfGross?: number | null;
+  golfNet?: number | null;
+  golfTeeId?: string | null;
+  golfTeeName?: string | null;
+  golfHolesPlayed?: number | null;
+};
+
+export class VenueEventFact {
+  private constructor(
+    readonly id: string,
+    readonly venueCmsId: string,
+    readonly sport: LeaderboardSport,
+    readonly eventId: string,
+    readonly userId: string,
+    readonly lockedAt: Date,
+    readonly won: boolean | null,
+    readonly golfGross: number | null,
+    readonly golfNet: number | null,
+    readonly golfTeeId: string | null,
+    readonly golfTeeName: string | null,
+    readonly golfHolesPlayed: number | null,
+  ) {}
+
+  static create(props: VenueEventFactProps): VenueEventFact {
+    return new VenueEventFact(
+      props.id ?? randomUUID(),
+      props.venueCmsId,
+      props.sport,
+      props.eventId,
+      props.userId,
+      props.lockedAt,
+      props.won ?? null,
+      props.golfGross ?? null,
+      props.golfNet ?? null,
+      props.golfTeeId ?? null,
+      props.golfTeeName ?? null,
+      props.golfHolesPlayed ?? null,
+    );
+  }
+
+  static fromPadelMatch(match: Match): VenueEventFact[] {
+    if (!match.isLocked) return [];
+    const winner = match.winner;
+    const lockedAt = match.lockedAt ?? match.startsAt.value;
+    const facts: VenueEventFact[] = [];
+
+    for (const player of match.pairings.players) {
+      if (!player.userId || player.isGuest) continue;
+      facts.push(
+        VenueEventFact.create({
+          venueCmsId: match.venueCmsId.value,
+          sport: "padel",
+          eventId: match.id,
+          userId: player.userId,
+          lockedAt,
+          won: winner ? player.slot.team.equals(winner) : null,
+        }),
+      );
+    }
+
+    return facts;
+  }
+
+  static fromGolfRound(round: GolfRound): VenueEventFact[] {
+    if (!round.isLocked) return [];
+    const lockedAt = round.lockedAt ?? round.startsAt.value;
+    const facts: VenueEventFact[] = [];
+
+    for (const player of round.players) {
+      if (!player.userId || player.isGuest) continue;
+      const snapshot = player.toSnapshot();
+      facts.push(
+        VenueEventFact.create({
+          venueCmsId: round.venueCmsId.value,
+          sport: "golf",
+          eventId: round.id,
+          userId: player.userId,
+          lockedAt,
+          golfGross: snapshot.grossTotal,
+          golfNet: snapshot.netTotal,
+          golfTeeId: round.teeId,
+          golfTeeName: round.teeName,
+          golfHolesPlayed: round.holesPlayed,
+        }),
+      );
+    }
+
+    return facts;
+  }
+
+  static fromDartsMatch(match: DartsMatch): VenueEventFact[] {
+    if (!match.isLocked || !match.venueCmsId) return [];
+    const snapshot = match.toSnapshot();
+    const lockedAt = match.lockedAt ?? match.startsAt.value;
+    const facts: VenueEventFact[] = [];
+
+    for (const player of match.players) {
+      if (!player.userId || player.isGuest) continue;
+      facts.push(
+        VenueEventFact.create({
+          venueCmsId: match.venueCmsId.value,
+          sport: "darts",
+          eventId: match.id,
+          userId: player.userId,
+          lockedAt,
+          won: snapshot.winnerUserId
+            ? player.userId === snapshot.winnerUserId
+            : player.slot === snapshot.winnerSlot,
+        }),
+      );
+    }
+
+    return facts;
+  }
+
+  get isEighteenHoleGolf(): boolean {
+    return this.sport === "golf" && this.golfHolesPlayed === 18;
+  }
+
+  get teeKey(): string {
+    return this.golfTeeId?.trim() || this.golfTeeName?.trim() || "unknown";
+  }
+
+  toSnapshot(): VenueEventFactSnapshot {
+    return {
+      id: this.id,
+      venueCmsId: this.venueCmsId,
+      sport: this.sport,
+      eventId: this.eventId,
+      userId: this.userId,
+      lockedAt: this.lockedAt.toISOString(),
+      won: this.won,
+      golfGross: this.golfGross,
+      golfNet: this.golfNet,
+      golfTeeId: this.golfTeeId,
+      golfTeeName: this.golfTeeName,
+      golfHolesPlayed: this.golfHolesPlayed,
+    };
+  }
+}

--- a/src/modules/venue-leaderboards/index.ts
+++ b/src/modules/venue-leaderboards/index.ts
@@ -1,0 +1,113 @@
+import {
+  NextFunction,
+  Request,
+  Response,
+  Router,
+} from "express";
+
+import { PrismaClient } from "../../generated/prisma/client";
+import { DartsMatchRepository } from "../darts/repositories/darts-match.repository";
+import { GolfRoundRepository } from "../golf-round/repositories/golf-round.repository";
+import { MatchRepository } from "../match/repositories/match.repository";
+import { OnScorecardLocked } from "../scorecards/on-scorecard-locked";
+import { VenueRepository } from "../venue/repositories/venue.repository";
+import { LeaderboardMemoryCache } from "./cache/leaderboard-cache";
+import { createVenueLeaderboardsController } from "./controllers/venue-leaderboards.controller";
+import { InMemoryVenueLeaderboardRepository } from "./repositories/in-memory-venue-leaderboard.repository";
+import { PrismaVenueLeaderboardRepository } from "./repositories/prisma-venue-leaderboard.repository";
+import { VenueLeaderboardRepository } from "./repositories/venue-leaderboard.repository";
+import { createVenueLeaderboardsRoutes } from "./routes/venue-leaderboards.routes";
+import { GetVenueLeaderboards } from "./services/get-venue-leaderboards.service";
+import { IngestLockedScorecard } from "./services/ingest-locked-scorecard.service";
+import { RecomputeVenueLeaderboards } from "./services/recompute-venue-leaderboards.service";
+import { ReconcileVenueLeaderboards } from "./services/reconcile-venue-leaderboards.service";
+
+export type CreateVenueLeaderboardsModuleParams = {
+  prisma: PrismaClient;
+  venueRepository: VenueRepository;
+  matchRepository: MatchRepository;
+  golfRoundRepository: GolfRoundRepository;
+  dartsMatchRepository: DartsMatchRepository;
+  venueLeaderboardRepository?: VenueLeaderboardRepository;
+  useInMemoryLeaderboards?: boolean;
+  tryGetSessionUserId: (req: Request) => string | null;
+  requireAuth: (req: Request, res: Response, next: NextFunction) => void;
+};
+
+export type VenueLeaderboardsModule = {
+  router: Router;
+  venueLeaderboardRepository: VenueLeaderboardRepository;
+  onScorecardLocked: OnScorecardLocked;
+  reconcile: ReconcileVenueLeaderboards;
+};
+
+export function createVenueLeaderboardsModule({
+  prisma,
+  venueRepository,
+  matchRepository,
+  golfRoundRepository,
+  dartsMatchRepository,
+  venueLeaderboardRepository: venueLeaderboardRepositoryOverride,
+  useInMemoryLeaderboards,
+  tryGetSessionUserId,
+  requireAuth,
+}: CreateVenueLeaderboardsModuleParams): VenueLeaderboardsModule {
+  const venueLeaderboardRepository =
+    venueLeaderboardRepositoryOverride ??
+    (useInMemoryLeaderboards
+      ? new InMemoryVenueLeaderboardRepository()
+      : new PrismaVenueLeaderboardRepository(prisma));
+
+  const cache = new LeaderboardMemoryCache();
+  const recompute = new RecomputeVenueLeaderboards(
+    venueLeaderboardRepository,
+    cache,
+  );
+  const ingest = new IngestLockedScorecard(
+    venueLeaderboardRepository,
+    matchRepository,
+    golfRoundRepository,
+    dartsMatchRepository,
+    recompute,
+  );
+  const reconcile = new ReconcileVenueLeaderboards(
+    venueRepository,
+    matchRepository,
+    golfRoundRepository,
+    dartsMatchRepository,
+    venueLeaderboardRepository,
+    recompute,
+  );
+  const getVenueLeaderboards = new GetVenueLeaderboards(
+    venueRepository,
+    venueLeaderboardRepository,
+    cache,
+  );
+  const controller = createVenueLeaderboardsController({
+    getVenueLeaderboards,
+    tryGetSessionUserId,
+  });
+
+  return {
+    router: createVenueLeaderboardsRoutes(controller, { requireAuth }),
+    venueLeaderboardRepository,
+    onScorecardLocked: async (event) => {
+      try {
+        await ingest.execute(event);
+      } catch (error) {
+        console.error("venue leaderboard ingest failed", error);
+      }
+    },
+    reconcile,
+  };
+}
+
+export { createVenueLeaderboardsController } from "./controllers/venue-leaderboards.controller";
+export { InMemoryVenueLeaderboardRepository } from "./repositories/in-memory-venue-leaderboard.repository";
+export { PrismaVenueLeaderboardRepository } from "./repositories/prisma-venue-leaderboard.repository";
+export { VenueLeaderboardPersistenceError } from "./repositories/venue-leaderboard-persistence-error";
+export type { VenueLeaderboardRepository } from "./repositories/venue-leaderboard.repository";
+export { GetVenueLeaderboards } from "./services/get-venue-leaderboards.service";
+export { IngestLockedScorecard } from "./services/ingest-locked-scorecard.service";
+export { RecomputeVenueLeaderboards } from "./services/recompute-venue-leaderboards.service";
+export { ReconcileVenueLeaderboards } from "./services/reconcile-venue-leaderboards.service";

--- a/src/modules/venue-leaderboards/repositories/in-memory-venue-leaderboard.repository.ts
+++ b/src/modules/venue-leaderboards/repositories/in-memory-venue-leaderboard.repository.ts
@@ -1,0 +1,117 @@
+import { LeaderboardBoard } from "../entities/leaderboard-board";
+import { LeaderboardWindow } from "../entities/leaderboard-window";
+import { BoardProfile } from "../entities/public-display-name";
+import { VenueEventFact } from "../entities/venue-event-fact";
+import {
+  LeaderboardSnapshotRecord,
+  VenueLeaderboardRepository,
+} from "./venue-leaderboard.repository";
+
+function factKey(fact: VenueEventFact): string {
+  return `${fact.venueCmsId}:${fact.sport}:${fact.eventId}:${fact.userId}`;
+}
+
+function snapshotKey(
+  venueCmsId: string,
+  board: LeaderboardBoard,
+  window: LeaderboardWindow,
+): string {
+  return `${venueCmsId}:${board.value}:${window.key}`;
+}
+
+function cloneFact(fact: VenueEventFact): VenueEventFact {
+  return VenueEventFact.create({
+    id: fact.id,
+    venueCmsId: fact.venueCmsId,
+    sport: fact.sport,
+    eventId: fact.eventId,
+    userId: fact.userId,
+    lockedAt: new Date(fact.lockedAt),
+    won: fact.won,
+    golfGross: fact.golfGross,
+    golfNet: fact.golfNet,
+    golfTeeId: fact.golfTeeId,
+    golfTeeName: fact.golfTeeName,
+    golfHolesPlayed: fact.golfHolesPlayed,
+  });
+}
+
+export class InMemoryVenueLeaderboardRepository
+  implements VenueLeaderboardRepository
+{
+  private readonly facts = new Map<string, VenueEventFact>();
+  private readonly snapshots = new Map<string, LeaderboardSnapshotRecord>();
+  private readonly profiles = new Map<string, BoardProfile>();
+  private readonly optedOut = new Set<string>();
+
+  seedProfile(profile: BoardProfile): void {
+    this.profiles.set(profile.userId, { ...profile });
+  }
+
+  setAppearOnBoards(userId: string, appear: boolean): void {
+    if (appear) this.optedOut.delete(userId);
+    else this.optedOut.add(userId);
+  }
+
+  async upsertFacts(facts: VenueEventFact[]): Promise<void> {
+    for (const fact of facts) {
+      this.facts.set(factKey(fact), cloneFact(fact));
+    }
+  }
+
+  async replaceFactsForVenue(
+    venueCmsId: string,
+    facts: VenueEventFact[],
+  ): Promise<void> {
+    for (const [key, fact] of this.facts) {
+      if (fact.venueCmsId === venueCmsId) this.facts.delete(key);
+    }
+    await this.upsertFacts(facts);
+  }
+
+  async listFacts(venueCmsId: string): Promise<VenueEventFact[]> {
+    return [...this.facts.values()]
+      .filter((fact) => fact.venueCmsId === venueCmsId)
+      .map(cloneFact);
+  }
+
+  async listVenueCmsIdsWithFacts(): Promise<string[]> {
+    return [...new Set([...this.facts.values()].map((fact) => fact.venueCmsId))];
+  }
+
+  async saveSnapshot(record: LeaderboardSnapshotRecord): Promise<void> {
+    this.snapshots.set(
+      snapshotKey(record.venueCmsId, record.board, record.window),
+      {
+        ...record,
+        payload: structuredClone(record.payload),
+        computedAt: new Date(record.computedAt),
+      },
+    );
+  }
+
+  async getSnapshot(
+    venueCmsId: string,
+    board: LeaderboardBoard,
+    window: LeaderboardWindow,
+  ): Promise<LeaderboardSnapshotRecord | null> {
+    const stored = this.snapshots.get(snapshotKey(venueCmsId, board, window));
+    if (!stored) return null;
+    return {
+      ...stored,
+      payload: structuredClone(stored.payload),
+      computedAt: new Date(stored.computedAt),
+    };
+  }
+
+  async listProfiles(userIds: string[]): Promise<BoardProfile[]> {
+    return userIds
+      .map((userId) => this.profiles.get(userId))
+      .filter((row): row is BoardProfile => !!row)
+      .map((row) => ({ ...row }));
+  }
+
+  async listOptedOutUserIds(userIds: string[]): Promise<string[]> {
+    return userIds.filter((userId) => this.optedOut.has(userId));
+  }
+}

--- a/src/modules/venue-leaderboards/repositories/prisma-venue-leaderboard.repository.ts
+++ b/src/modules/venue-leaderboards/repositories/prisma-venue-leaderboard.repository.ts
@@ -1,0 +1,258 @@
+import { PrismaClient } from "../../../generated/prisma/client";
+import { LeaderboardBoard } from "../entities/leaderboard-board";
+import { LeaderboardWindow } from "../entities/leaderboard-window";
+import { SnapshotPayload } from "../entities/board-payload";
+import { BoardProfile } from "../entities/public-display-name";
+import {
+  LeaderboardSport,
+  VenueEventFact,
+} from "../entities/venue-event-fact";
+import { VenueLeaderboardPersistenceError } from "./venue-leaderboard-persistence-error";
+import {
+  LeaderboardSnapshotRecord,
+  VenueLeaderboardRepository,
+} from "./venue-leaderboard.repository";
+
+export class PrismaVenueLeaderboardRepository
+  implements VenueLeaderboardRepository
+{
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async upsertFacts(facts: VenueEventFact[]): Promise<void> {
+    if (facts.length === 0) return;
+    try {
+      await this.prisma.$transaction(
+        facts.map((fact) =>
+          this.prisma.venueLeaderboardEventFact.upsert({
+            where: {
+              venueCmsId_sport_eventId_userId: {
+                venueCmsId: fact.venueCmsId,
+                sport: fact.sport,
+                eventId: fact.eventId,
+                userId: fact.userId,
+              },
+            },
+            create: toFactRow(fact),
+            update: {
+              lockedAt: fact.lockedAt,
+              won: fact.won,
+              golfGross: fact.golfGross,
+              golfNet: fact.golfNet,
+              golfTeeId: fact.golfTeeId,
+              golfTeeName: fact.golfTeeName,
+              golfHolesPlayed: fact.golfHolesPlayed,
+            },
+          }),
+        ),
+      );
+    } catch (error) {
+      throw new VenueLeaderboardPersistenceError(
+        "Failed to upsert venue leaderboard facts",
+        { cause: error },
+      );
+    }
+  }
+
+  async replaceFactsForVenue(
+    venueCmsId: string,
+    facts: VenueEventFact[],
+  ): Promise<void> {
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        await tx.venueLeaderboardEventFact.deleteMany({ where: { venueCmsId } });
+        if (facts.length === 0) return;
+        await tx.venueLeaderboardEventFact.createMany({
+          data: facts.map(toFactRow),
+        });
+      });
+    } catch (error) {
+      throw new VenueLeaderboardPersistenceError(
+        "Failed to rebuild venue leaderboard facts",
+        { cause: error },
+      );
+    }
+  }
+
+  async listFacts(venueCmsId: string): Promise<VenueEventFact[]> {
+    try {
+      const rows = await this.prisma.venueLeaderboardEventFact.findMany({
+        where: { venueCmsId },
+        orderBy: { lockedAt: "asc" },
+      });
+      return rows.map(fromFactRow);
+    } catch (error) {
+      throw new VenueLeaderboardPersistenceError(
+        "Failed to load venue leaderboard facts",
+        { cause: error },
+      );
+    }
+  }
+
+  async listVenueCmsIdsWithFacts(): Promise<string[]> {
+    try {
+      const rows = await this.prisma.venueLeaderboardEventFact.findMany({
+        distinct: ["venueCmsId"],
+        select: { venueCmsId: true },
+      });
+      return rows.map((row) => row.venueCmsId);
+    } catch (error) {
+      throw new VenueLeaderboardPersistenceError(
+        "Failed to list venues with leaderboard facts",
+        { cause: error },
+      );
+    }
+  }
+
+  async saveSnapshot(record: LeaderboardSnapshotRecord): Promise<void> {
+    try {
+      await this.prisma.venueLeaderboardSnapshot.upsert({
+        where: {
+          venueCmsId_board_windowKey: {
+            venueCmsId: record.venueCmsId,
+            board: record.board.value,
+            windowKey: record.window.key,
+          },
+        },
+        create: {
+          venueCmsId: record.venueCmsId,
+          board: record.board.value,
+          windowKey: record.window.key,
+          payload: record.payload,
+          computedAt: record.computedAt,
+        },
+        update: {
+          payload: record.payload,
+          computedAt: record.computedAt,
+        },
+      });
+    } catch (error) {
+      throw new VenueLeaderboardPersistenceError(
+        "Failed to save venue leaderboard snapshot",
+        { cause: error },
+      );
+    }
+  }
+
+  async getSnapshot(
+    venueCmsId: string,
+    board: LeaderboardBoard,
+    window: LeaderboardWindow,
+  ): Promise<LeaderboardSnapshotRecord | null> {
+    try {
+      const row = await this.prisma.venueLeaderboardSnapshot.findUnique({
+        where: {
+          venueCmsId_board_windowKey: {
+            venueCmsId,
+            board: board.value,
+            windowKey: window.key,
+          },
+        },
+      });
+      if (!row) return null;
+      return {
+        venueCmsId: row.venueCmsId,
+        board,
+        window,
+        payload: row.payload as SnapshotPayload,
+        computedAt: row.computedAt,
+      };
+    } catch (error) {
+      throw new VenueLeaderboardPersistenceError(
+        "Failed to load venue leaderboard snapshot",
+        { cause: error },
+      );
+    }
+  }
+
+  async listProfiles(userIds: string[]): Promise<BoardProfile[]> {
+    if (userIds.length === 0) return [];
+    try {
+      const rows = await this.prisma.profile.findMany({
+        where: { userId: { in: userIds } },
+        select: {
+          userId: true,
+          firstName: true,
+          lastName: true,
+          avatarUrl: true,
+        },
+      });
+      return rows.map((row) => ({
+        userId: row.userId,
+        firstName: row.firstName,
+        lastName: row.lastName,
+        avatarUrl: row.avatarUrl,
+      }));
+    } catch (error) {
+      throw new VenueLeaderboardPersistenceError(
+        "Failed to load leaderboard profiles",
+        { cause: error },
+      );
+    }
+  }
+
+  async listOptedOutUserIds(userIds: string[]): Promise<string[]> {
+    if (userIds.length === 0) return [];
+    try {
+      const rows = await this.prisma.profile.findMany({
+        where: {
+          userId: { in: userIds },
+          appearOnVenueLeaderboards: false,
+        },
+        select: { userId: true },
+      });
+      return rows.map((row) => row.userId);
+    } catch (error) {
+      throw new VenueLeaderboardPersistenceError(
+        "Failed to load leaderboard opt-outs",
+        { cause: error },
+      );
+    }
+  }
+}
+
+function toFactRow(fact: VenueEventFact) {
+  return {
+    id: fact.id,
+    venueCmsId: fact.venueCmsId,
+    sport: fact.sport,
+    eventId: fact.eventId,
+    userId: fact.userId,
+    lockedAt: fact.lockedAt,
+    won: fact.won,
+    golfGross: fact.golfGross,
+    golfNet: fact.golfNet,
+    golfTeeId: fact.golfTeeId,
+    golfTeeName: fact.golfTeeName,
+    golfHolesPlayed: fact.golfHolesPlayed,
+  };
+}
+
+function fromFactRow(row: {
+  id: string;
+  venueCmsId: string;
+  sport: LeaderboardSport;
+  eventId: string;
+  userId: string;
+  lockedAt: Date;
+  won: boolean | null;
+  golfGross: number | null;
+  golfNet: number | null;
+  golfTeeId: string | null;
+  golfTeeName: string | null;
+  golfHolesPlayed: number | null;
+}): VenueEventFact {
+  return VenueEventFact.create({
+    id: row.id,
+    venueCmsId: row.venueCmsId,
+    sport: row.sport,
+    eventId: row.eventId,
+    userId: row.userId,
+    lockedAt: row.lockedAt,
+    won: row.won,
+    golfGross: row.golfGross,
+    golfNet: row.golfNet,
+    golfTeeId: row.golfTeeId,
+    golfTeeName: row.golfTeeName,
+    golfHolesPlayed: row.golfHolesPlayed,
+  });
+}

--- a/src/modules/venue-leaderboards/repositories/venue-leaderboard-persistence-error.ts
+++ b/src/modules/venue-leaderboards/repositories/venue-leaderboard-persistence-error.ts
@@ -1,0 +1,9 @@
+export class VenueLeaderboardPersistenceError extends Error {
+  constructor(
+    message = "Unable to save venue leaderboard",
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "VenueLeaderboardPersistenceError";
+  }
+}

--- a/src/modules/venue-leaderboards/repositories/venue-leaderboard.repository.ts
+++ b/src/modules/venue-leaderboards/repositories/venue-leaderboard.repository.ts
@@ -1,0 +1,28 @@
+import { SnapshotPayload } from "../entities/board-payload";
+import { LeaderboardBoard } from "../entities/leaderboard-board";
+import { LeaderboardWindow } from "../entities/leaderboard-window";
+import { BoardProfile } from "../entities/public-display-name";
+import { VenueEventFact } from "../entities/venue-event-fact";
+
+export type LeaderboardSnapshotRecord = {
+  venueCmsId: string;
+  board: LeaderboardBoard;
+  window: LeaderboardWindow;
+  payload: SnapshotPayload;
+  computedAt: Date;
+};
+
+export interface VenueLeaderboardRepository {
+  upsertFacts(facts: VenueEventFact[]): Promise<void>;
+  replaceFactsForVenue(venueCmsId: string, facts: VenueEventFact[]): Promise<void>;
+  listFacts(venueCmsId: string): Promise<VenueEventFact[]>;
+  listVenueCmsIdsWithFacts(): Promise<string[]>;
+  saveSnapshot(record: LeaderboardSnapshotRecord): Promise<void>;
+  getSnapshot(
+    venueCmsId: string,
+    board: LeaderboardBoard,
+    window: LeaderboardWindow,
+  ): Promise<LeaderboardSnapshotRecord | null>;
+  listProfiles(userIds: string[]): Promise<BoardProfile[]>;
+  listOptedOutUserIds(userIds: string[]): Promise<string[]>;
+}

--- a/src/modules/venue-leaderboards/routes/venue-leaderboards.routes.ts
+++ b/src/modules/venue-leaderboards/routes/venue-leaderboards.routes.ts
@@ -1,0 +1,26 @@
+import { Router } from "express";
+
+import { createVenueLeaderboardsController } from "../controllers/venue-leaderboards.controller";
+
+export function createVenueLeaderboardsRoutes(
+  controller: ReturnType<typeof createVenueLeaderboardsController>,
+  options: {
+    requireAuth: (
+      req: import("express").Request,
+      res: import("express").Response,
+      next: import("express").NextFunction,
+    ) => void;
+  },
+): Router {
+  const router = Router();
+
+  router.get(
+    "/api/venues/:idOrCmsId/leaderboards",
+    options.requireAuth,
+    (req, res) => {
+      void controller.get(req, res);
+    },
+  );
+
+  return router;
+}

--- a/src/modules/venue-leaderboards/services/get-venue-leaderboards.service.ts
+++ b/src/modules/venue-leaderboards/services/get-venue-leaderboards.service.ts
@@ -1,0 +1,111 @@
+import { DomainError } from "../../../lib/domain-error";
+import { Venue } from "../../venue/entities/venue";
+import { CmsId } from "../../venue/entities/cms-id";
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { JOHANNESBURG_TIMEZONE } from "../entities/johannesburg-calendar";
+import { VenueLeaderboardComputer } from "../entities/board-computer";
+import { VenueLeaderboardResponse } from "../entities/board-payload";
+import { LeaderboardBoard } from "../entities/leaderboard-board";
+import { LeaderboardWindow } from "../entities/leaderboard-window";
+import { BoardProfile } from "../entities/public-display-name";
+import { LeaderboardMemoryCache } from "../cache/leaderboard-cache";
+import { VenueLeaderboardRepository } from "../repositories/venue-leaderboard.repository";
+
+export class VenueLeaderboardNotFoundError extends DomainError {
+  constructor() {
+    super("Venue not found");
+    this.name = "VenueLeaderboardNotFoundError";
+  }
+}
+
+export class GetVenueLeaderboards {
+  constructor(
+    private readonly venues: VenueRepository,
+    private readonly leaderboards: VenueLeaderboardRepository,
+    private readonly cache: LeaderboardMemoryCache,
+  ) {}
+
+  async execute(input: {
+    idOrCmsId: unknown;
+    board: unknown;
+    window?: unknown;
+    now?: Date;
+  }): Promise<VenueLeaderboardResponse> {
+    const venue = await this.resolveVenue(input.idOrCmsId);
+    if (!venue) {
+      throw new VenueLeaderboardNotFoundError();
+    }
+
+    const board = LeaderboardBoard.from(input.board);
+    const window = LeaderboardWindow.fromQuery(board, input.window, input.now);
+    const cacheKey = this.cache.key(venue.cmsId.value, board.value, window.key);
+    const cached = this.cache.get(cacheKey);
+    if (cached) return cached;
+
+    const stored = await this.leaderboards.getSnapshot(
+      venue.cmsId.value,
+      board,
+      window,
+    );
+    const payload =
+      stored?.payload ??
+      (await this.computeLive(venue.cmsId.value, board, window));
+    const computedAt = stored?.computedAt ?? new Date();
+
+    const response: VenueLeaderboardResponse = {
+      venue: {
+        id: venue.id,
+        cmsId: venue.cmsId.value,
+        name: venue.name.value,
+      },
+      board: board.value,
+      window: window.value,
+      windowKey: window.key,
+      timezone: JOHANNESBURG_TIMEZONE,
+      computedAt: computedAt.toISOString(),
+      first: payload.first,
+      entries: payload.entries,
+      ...(payload.records ? { records: payload.records } : {}),
+    };
+
+    this.cache.set(cacheKey, response);
+    return response;
+  }
+
+  private async computeLive(
+    venueCmsId: string,
+    board: LeaderboardBoard,
+    window: LeaderboardWindow,
+  ) {
+    const facts = await this.leaderboards.listFacts(venueCmsId);
+    const userIds = [...new Set(facts.map((fact) => fact.userId))];
+    const [profiles, optedOut] = await Promise.all([
+      this.leaderboards.listProfiles(userIds),
+      this.leaderboards.listOptedOutUserIds(userIds),
+    ]);
+    return VenueLeaderboardComputer.compute({
+      board,
+      window,
+      facts,
+      profiles: new Map<string, BoardProfile>(
+        profiles.map((profile) => [profile.userId, profile]),
+      ),
+      optedOutUserIds: new Set(optedOut),
+    });
+  }
+
+  private async resolveVenue(idOrCmsId: unknown): Promise<Venue | null> {
+    if (typeof idOrCmsId !== "string" || idOrCmsId.trim().length === 0) {
+      throw new DomainError("idOrCmsId is required");
+    }
+    const raw = idOrCmsId.trim();
+    const byId = await this.venues.findById(raw);
+    if (byId) return byId;
+    try {
+      return await this.venues.findByCmsId(CmsId.from(raw));
+    } catch (error) {
+      if (error instanceof DomainError) return null;
+      throw error;
+    }
+  }
+}

--- a/src/modules/venue-leaderboards/services/ingest-locked-scorecard.service.ts
+++ b/src/modules/venue-leaderboards/services/ingest-locked-scorecard.service.ts
@@ -1,0 +1,39 @@
+import { DartsMatchRepository } from "../../darts/repositories/darts-match.repository";
+import { GolfRoundRepository } from "../../golf-round/repositories/golf-round.repository";
+import { MatchRepository } from "../../match/repositories/match.repository";
+import { ScorecardLockedEvent } from "../../scorecards/on-scorecard-locked";
+import { VenueEventFact } from "../entities/venue-event-fact";
+import { VenueLeaderboardRepository } from "../repositories/venue-leaderboard.repository";
+import { RecomputeVenueLeaderboards } from "./recompute-venue-leaderboards.service";
+
+export class IngestLockedScorecard {
+  constructor(
+    private readonly leaderboards: VenueLeaderboardRepository,
+    private readonly matches: MatchRepository,
+    private readonly golfRounds: GolfRoundRepository,
+    private readonly dartsMatches: DartsMatchRepository,
+    private readonly recompute: RecomputeVenueLeaderboards,
+  ) {}
+
+  async execute(event: ScorecardLockedEvent): Promise<void> {
+    const facts = await this.factsForEvent(event);
+    if (facts.length === 0) return;
+    await this.leaderboards.upsertFacts(facts);
+    await this.recompute.execute(facts[0]!.venueCmsId);
+  }
+
+  private async factsForEvent(
+    event: ScorecardLockedEvent,
+  ): Promise<VenueEventFact[]> {
+    if (event.sport === "padel") {
+      const match = await this.matches.findById(event.scorecardId);
+      return match ? VenueEventFact.fromPadelMatch(match) : [];
+    }
+    if (event.sport === "golf") {
+      const round = await this.golfRounds.findById(event.scorecardId);
+      return round ? VenueEventFact.fromGolfRound(round) : [];
+    }
+    const match = await this.dartsMatches.findById(event.scorecardId);
+    return match ? VenueEventFact.fromDartsMatch(match) : [];
+  }
+}

--- a/src/modules/venue-leaderboards/services/recompute-venue-leaderboards.service.ts
+++ b/src/modules/venue-leaderboards/services/recompute-venue-leaderboards.service.ts
@@ -1,0 +1,57 @@
+import { currentJohannesburgYearMonth } from "../entities/johannesburg-calendar";
+import { VenueLeaderboardComputer } from "../entities/board-computer";
+import { LeaderboardBoard } from "../entities/leaderboard-board";
+import { LeaderboardWindow } from "../entities/leaderboard-window";
+import { BoardProfile } from "../entities/public-display-name";
+import { LeaderboardMemoryCache } from "../cache/leaderboard-cache";
+import { VenueLeaderboardRepository } from "../repositories/venue-leaderboard.repository";
+
+export class RecomputeVenueLeaderboards {
+  constructor(
+    private readonly leaderboards: VenueLeaderboardRepository,
+    private readonly cache: LeaderboardMemoryCache,
+  ) {}
+
+  async execute(venueCmsId: string, now = new Date()): Promise<void> {
+    const facts = await this.leaderboards.listFacts(venueCmsId);
+    const userIds = [...new Set(facts.map((fact) => fact.userId))];
+    const [profiles, optedOut] = await Promise.all([
+      this.leaderboards.listProfiles(userIds),
+      this.leaderboards.listOptedOutUserIds(userIds),
+    ]);
+    const profileMap = new Map<string, BoardProfile>(
+      profiles.map((profile) => [profile.userId, profile]),
+    );
+    const optedOutUserIds = new Set(optedOut);
+    const month = LeaderboardWindow.month(currentJohannesburgYearMonth(now));
+    const all = LeaderboardWindow.all();
+    const computedAt = now;
+
+    const jobs: Array<{ board: LeaderboardBoard; window: LeaderboardWindow }> = [
+      { board: LeaderboardBoard.records, window: all },
+      { board: LeaderboardBoard.potm, window: month },
+      { board: LeaderboardBoard.grinder, window: all },
+      { board: LeaderboardBoard.grinder, window: month },
+      { board: LeaderboardBoard.streak, window: all },
+    ];
+
+    for (const job of jobs) {
+      const payload = VenueLeaderboardComputer.compute({
+        board: job.board,
+        window: job.window,
+        facts,
+        profiles: profileMap,
+        optedOutUserIds,
+      });
+      await this.leaderboards.saveSnapshot({
+        venueCmsId,
+        board: job.board,
+        window: job.window,
+        payload,
+        computedAt,
+      });
+    }
+
+    this.cache.invalidateVenue(venueCmsId);
+  }
+}

--- a/src/modules/venue-leaderboards/services/reconcile-venue-leaderboards.service.ts
+++ b/src/modules/venue-leaderboards/services/reconcile-venue-leaderboards.service.ts
@@ -1,0 +1,53 @@
+import { CmsId } from "../../venue/entities/cms-id";
+import { DartsMatchRepository } from "../../darts/repositories/darts-match.repository";
+import { GolfRoundRepository } from "../../golf-round/repositories/golf-round.repository";
+import { MatchRepository } from "../../match/repositories/match.repository";
+import { VenueRepository } from "../../venue/repositories/venue.repository";
+import { VenueEventFact } from "../entities/venue-event-fact";
+import { VenueLeaderboardRepository } from "../repositories/venue-leaderboard.repository";
+import { RecomputeVenueLeaderboards } from "./recompute-venue-leaderboards.service";
+
+export class ReconcileVenueLeaderboards {
+  constructor(
+    private readonly venues: VenueRepository,
+    private readonly matches: MatchRepository,
+    private readonly golfRounds: GolfRoundRepository,
+    private readonly dartsMatches: DartsMatchRepository,
+    private readonly leaderboards: VenueLeaderboardRepository,
+    private readonly recompute: RecomputeVenueLeaderboards,
+  ) {}
+
+  async execute(venueCmsId: string): Promise<void> {
+    const facts = await this.collectFacts(venueCmsId);
+    await this.leaderboards.replaceFactsForVenue(venueCmsId, facts);
+    await this.recompute.execute(venueCmsId);
+  }
+
+  async executeAll(venueCmsIds?: string[]): Promise<{ venues: number }> {
+    const cmsIds = new Set(
+      venueCmsIds ?? (await this.leaderboards.listVenueCmsIdsWithFacts()),
+    );
+    for (const cmsId of cmsIds) {
+      await this.execute(cmsId);
+    }
+    return { venues: cmsIds.size };
+  }
+
+  private async collectFacts(venueCmsId: string): Promise<VenueEventFact[]> {
+    const cmsId = CmsId.from(venueCmsId);
+    const venue = await this.venues.findByCmsId(cmsId);
+    if (!venue) return [];
+
+    const [padel, golf, darts] = await Promise.all([
+      this.matches.listLockedByVenueCmsId(cmsId),
+      this.golfRounds.listLockedByVenueCmsId(cmsId),
+      this.dartsMatches.listLockedByVenueCmsId(cmsId),
+    ]);
+
+    return [
+      ...padel.flatMap((match) => VenueEventFact.fromPadelMatch(match)),
+      ...golf.flatMap((round) => VenueEventFact.fromGolfRound(round)),
+      ...darts.flatMap((match) => VenueEventFact.fromDartsMatch(match)),
+    ];
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Venue leaderboards v1 for signed-in users. Empty boards return **200** with empty lists (Frontend hides tabs).

Closes #61.

### Boards
- **Records** (all-time): golf best locked 18-hole gross/net per tee; padel/darts most wins + best win-streak (≥2)
- **POTM**: calendar month in `Africa/Johannesburg`; padel/darts most wins; golf net average if ≥3 locked 18-hole nets, else most rounds. Top 5 + `#1`. Tie-break: more events, then earlier first win/event
- **The Grinder**: most locked events; `window=month|all`; appear only with ≥3
- **Hot streak**: current consecutive wins at venue; padel/darts only; appear only if ≥2

### Gates
- Signed-in session required
- `Profile.appearOnVenueLeaderboards` default **true**; toggle via `PUT /api/me/preferences`
- Public payload: `userId`, `displayName` (first + last initial), `avatarUrl?`, `stats` — no email, no HI

### Migrate
`20260912120000_venue_leaderboard`

### API
`GET /api/venues/:idOrCmsId/leaderboards?board=records|potm|grinder|streak&window=month|all`

Resolve venue by internal UUID or Sanity/cms id. Auth required. Cache: in-memory 30s TTL + `VenueLeaderboardSnapshot`. Zod errors `{ "error": string }`.

### Lock hooks + nightly
`onScorecardLocked` (padel/golf/darts lock **and** capture-finished) upserts `VenueLeaderboardEventFact` when a venue is present, then recomputes snapshots. Ingest errors do not fail the lock.

```bash
yarn leaderboards:reconcile
yarn leaderboards:reconcile <venueCmsId>
```

See `src/modules/venue-leaderboards/README.md`.

## Out of scope
Frontend, TV, inventing scores, ClubMaster, most improved.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-461c35c9-df2c-4d90-a26b-606046e2178a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-461c35c9-df2c-4d90-a26b-606046e2178a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

